### PR TITLE
refactor(editor)!: make lifecycle ownership explicit

### DIFF
--- a/docs/ai-workflow/async-editor-context-migration.md
+++ b/docs/ai-workflow/async-editor-context-migration.md
@@ -56,6 +56,18 @@ retained close capability:
 EditorContextCloseRequest request = editorContext.CloseService.RequestClose(editorContext);
 ```
 
+`IEditorContext.CloseService` is the canonical close-capability access path. The
+`IServiceProvider` surface remains available for other editor-scoped services,
+but contexts must not expose a second `IEditorContextCloseService` lookup through
+`GetService`.
+
+A successful `TryCreateContext` transfers a new, non-null context to the host. The
+host disposes that context exactly once even when a subsequent attachment or
+publication step fails. A failed creation returns `false` with `context == null`
+and the extension is responsible for cleaning up partial state. Direct
+replacement APIs separately reject foreign or already-owned contexts without
+consuming them; those values remain caller-owned.
+
 The request distinguishes `Accepted`, `AlreadyClosing`, and `NotOwned`.
 `Completion` is the stable terminal task for physical tab removal and context
 teardown, including failures.

--- a/docs/ai-workflow/async-editor-context-migration.md
+++ b/docs/ai-workflow/async-editor-context-migration.md
@@ -37,6 +37,30 @@ to their asynchronous counterparts. Disposal and context replacement are
 idempotent host operations: callers should await them rather than adding a
 synchronous wrapper or blocking with `GetAwaiter().GetResult()`.
 
+Host publication and dispatcher callbacks must not synchronously wait for
+`DisposeAsync` or `EditorService.CloseTabItem`, because both retain terminal
+completion semantics. Resolve `IEditorContextCloseService` from the supplied
+`IEditorContextServices` and request closure instead:
+
+```csharp
+services.TryGetService<IEditorContextCloseService>(out var closeService);
+EditorContextCloseRequest request = closeService!.RequestClose(this);
+// Return from the callback. Observe request.Completion afterward if needed.
+```
+
+`ToolTabExtension` callbacks receive only `IEditorContext`; resolve the same
+service through its inherited `IServiceProvider` surface:
+
+```csharp
+var closeService = (IEditorContextCloseService?)editorContext.GetService(
+    typeof(IEditorContextCloseService));
+EditorContextCloseRequest request = closeService!.RequestClose(editorContext);
+```
+
+The request distinguishes `Accepted`, `AlreadyClosing`, and `NotOwned`.
+`Completion` is the stable terminal task for physical tab removal and context
+teardown, including failures.
+
 Dock layout application and reset are asynchronous for the same reason. Await
 the operation so outgoing tools finish teardown before replacement tools begin
 using the editor.
@@ -49,7 +73,9 @@ The host-owned editor collections are now read-only to consumers:
 
 Use `EditorTabItem.ReplaceContextAsync` to replace a context. It serializes
 replacement with tab close, awaits the outgoing context, and consumes the new
-context if close wins. If outgoing teardown fails, the tab is terminally removed
-and the replacement task faults after cleanup. Add and remove tabs through
+context if close wins. A context identity already owned by the same or another
+tab is rejected before outgoing teardown and remains caller-owned. If outgoing
+teardown fails, the tab is terminally removed and the replacement task faults
+after cleanup. Add and remove tabs through
 `EditorService`; do not cast
 the read-only collections back to their concrete mutable implementations.

--- a/docs/ai-workflow/async-editor-context-migration.md
+++ b/docs/ai-workflow/async-editor-context-migration.md
@@ -64,9 +64,9 @@ but contexts must not expose a second `IEditorContextCloseService` lookup throug
 A successful `TryCreateContext` transfers a new, non-null context to the host. The
 host disposes that context exactly once even when a subsequent attachment or
 publication step fails. A failed creation returns `false` with `context == null`
-and the extension is responsible for cleaning up partial state. Direct
-replacement APIs separately reject foreign or already-owned contexts without
-consuming them; those values remain caller-owned.
+and the extension is responsible for cleaning up partial state. A successful
+factory result must be a newly created, unowned context; returning a context that
+is already active in a tab violates the ownership contract.
 
 The request distinguishes `Accepted`, `AlreadyClosing`, and `NotOwned`.
 `Completion` is the stable terminal task for physical tab removal and context
@@ -77,6 +77,16 @@ Every `IEditorContextCloseService` also exposes a required, opaque
 close capability (or a wrapper that forwards both `RequestClose` and the exact `HostToken`).
 `EditorService` rejects initial attachment and replacement when the token belongs to another host;
 do not construct a fresh token in a context wrapper.
+
+Independent editor-host implementations must call
+`EditorContextHostToken.TryAcquireContext(context, out lease)` before publishing a context and
+retain the lease until that context has been unpublished and asynchronously disposed. This atomic
+claim lets every host distinguish a new factory result from a context that is already live, even
+when the close capability is wrapped. The built-in `EditorService` manages these leases itself.
+
+The built-in `EditViewModel` is now created only by its owning `EditorService` through
+`SceneEditorExtension`. Extensions should implement `IEditorContext` and retain the supplied
+`IEditorContextServices`; they must not instantiate the built-in view model directly.
 
 ## Project shutdown
 
@@ -109,11 +119,12 @@ The host-owned editor collections are now read-only to consumers:
   replacement or terminal disposal is in progress, so callers must use a null-safe fallback.
 - `EditorService.TabItems` is `ICoreReadOnlyList<EditorTabItem>`.
 
-Use `EditorTabItem.ReplaceContextAsync` to replace a context. It serializes
-replacement with tab close, awaits the outgoing context, and consumes the new
-context if close wins. A context identity already owned by the same or another
-tab is rejected before outgoing teardown and remains caller-owned. If outgoing
-teardown fails, the tab is terminally removed and the replacement task faults
-after cleanup. Add and remove tabs through
-`EditorService`; do not cast
-the read-only collections back to their concrete mutable implementations.
+Use `EditorService.ReplaceContextAsync(tab, extension)` to replace an editor
+context. The host creates the context with its own services, validates the tab
+owner and current context, serializes replacement with tab close, and owns every
+successful factory result. The operation returns `EditorContextReplacementStatus`;
+callers never dispose a context returned by this host-mediated overload. A tab
+that is unowned, still being attached, or belongs to another host returns
+`NotOwned` without changing either tab or registry. `EditorTabItem`'s raw
+context overload is host-internal. Add and remove tabs through `EditorService`;
+do not cast the read-only collections back to their concrete mutable implementations.

--- a/docs/ai-workflow/async-editor-context-migration.md
+++ b/docs/ai-workflow/async-editor-context-migration.md
@@ -43,10 +43,13 @@ using the editor.
 
 The host-owned editor collections are now read-only to consumers:
 
-- `EditorTabItem.Context` is `IReadOnlyReactiveProperty<IEditorContext>`;
+- `EditorTabItem.Context` is `IReadOnlyReactiveProperty<IEditorContext?>`; it is `null` while
+  replacement or terminal disposal is in progress, so callers must use a null-safe fallback.
 - `EditorService.TabItems` is `ICoreReadOnlyList<EditorTabItem>`.
 
 Use `EditorTabItem.ReplaceContextAsync` to replace a context. It serializes
 replacement with tab close, awaits the outgoing context, and consumes the new
-context if close wins. Add and remove tabs through `EditorService`; do not cast
+context if close wins. If outgoing teardown fails, the tab is terminally removed
+and the replacement task faults after cleanup. Add and remove tabs through
+`EditorService`; do not cast
 the read-only collections back to their concrete mutable implementations.

--- a/docs/ai-workflow/async-editor-context-migration.md
+++ b/docs/ai-workflow/async-editor-context-migration.md
@@ -60,12 +60,23 @@ The request distinguishes `Accepted`, `AlreadyClosing`, and `NotOwned`.
 `Completion` is the stable terminal task for physical tab removal and context
 teardown, including failures.
 
+Every `IEditorContextCloseService` also exposes a required, opaque
+`EditorContextHostToken`. The host creates one stable token and contexts must retain the supplied
+close capability (or a wrapper that forwards both `RequestClose` and the exact `HostToken`).
+`EditorService` rejects initial attachment and replacement when the token belongs to another host;
+do not construct a fresh token in a context wrapper.
+
 ## Project shutdown
 
 `ProjectService.CloseProject()` has been replaced by `CloseProjectAsync()`.
 Await it before unloading packages, replacing the editor host, or releasing any
 resource that an editor context can still reach. Repeated calls join the queued
 project transition, including a close that has already cleared `CurrentProject`.
+
+When an editor host starts unregistering, transitions accepted before the fence
+finish through that host. New `OpenProject`, `CreateProject`, and `CloseProjectAsync`
+operations fail without changing `CurrentProject` until a replacement host has
+finished replaying the current project. Callers may retry after host initialization.
 
 `ProjectObservable` is now a post-commit notification stream. Notifications are
 ordered and run only after the editor reaches a stable state, but project methods

--- a/docs/ai-workflow/async-editor-context-migration.md
+++ b/docs/ai-workflow/async-editor-context-migration.md
@@ -1,0 +1,52 @@
+# Async editor and tool context migration
+
+The editor host now waits for context teardown before it replaces an editor,
+applies a dock layout, or releases scene resources. This intentionally changes
+the public extension contract in `Beutl.Extensibility`.
+
+## Tool contexts
+
+`IToolContext` implements `IAsyncDisposable` instead of `IDisposable`. Replace
+`Dispose()` with `ValueTask DisposeAsync()` and put every subscription, native
+resource, and in-flight operation behind that one completion boundary. A host
+call to `OpenToolTabAsync` consumes the supplied context even when it returns
+`false`; an extension must not dispose or reuse it afterward.
+
+`CloseToolTabAsync` normally completes after the target tool is disposed. When
+it is called from inside an `IToolContext.DisposeAsync` callback, the host only
+schedules the sibling close and returns to avoid mutual-disposal cycles. The
+enclosing layout/editor teardown still joins all scheduled tool disposals before
+it releases editor resources.
+
+```csharp
+public ValueTask DisposeAsync()
+{
+    _disposables.Dispose();
+    return ValueTask.CompletedTask;
+}
+
+await editorContext.OpenToolTabAsync(context);
+await editorContext.CloseToolTabAsync(context);
+```
+
+## Editor contexts
+
+`IEditorContext` no longer implements `IDisposable`. Implement
+`IAsyncDisposable.DisposeAsync`, and update `OpenToolTab` / `CloseToolTab` calls
+to their asynchronous counterparts. Disposal and context replacement are
+idempotent host operations: callers should await them rather than adding a
+synchronous wrapper or blocking with `GetAwaiter().GetResult()`.
+
+Dock layout application and reset are asynchronous for the same reason. Await
+the operation so outgoing tools finish teardown before replacement tools begin
+using the editor.
+
+The host-owned editor collections are now read-only to consumers:
+
+- `EditorTabItem.Context` is `IReadOnlyReactiveProperty<IEditorContext>`;
+- `EditorService.TabItems` is `ICoreReadOnlyList<EditorTabItem>`.
+
+Use `EditorTabItem.ReplaceContextAsync` to replace a context. It serializes
+replacement with tab close, awaits the outgoing context, and consumes the new
+context if close wins. Add and remove tabs through `EditorService`; do not cast
+the read-only collections back to their concrete mutable implementations.

--- a/docs/ai-workflow/async-editor-context-migration.md
+++ b/docs/ai-workflow/async-editor-context-migration.md
@@ -49,6 +49,13 @@ EditorContextCloseRequest request = CloseService.RequestClose(this);
 // Return from the callback. Observe request.Completion afterward if needed.
 ```
 
+`TryCreateContext`, publication observers, and disposal callbacks must not synchronously start and
+wait for a project or editor lifecycle operation on the same or another thread. Queue the operation
+so it begins only after the callback returns. The host rejects detected causal reentry, but this is
+diagnostic protection rather than the contract: manually suppressing execution context or blocking
+through a dispatcher can hide causality and must not be used to bypass the rule. Independent
+shutdown and reconciliation remain valid and drain in-flight admitted work.
+
 `ToolTabExtension` callbacks receive only `IEditorContext`; use its required
 retained close capability:
 

--- a/docs/ai-workflow/async-editor-context-migration.md
+++ b/docs/ai-workflow/async-editor-context-migration.md
@@ -39,27 +39,42 @@ synchronous wrapper or blocking with `GetAwaiter().GetResult()`.
 
 Host publication and dispatcher callbacks must not synchronously wait for
 `DisposeAsync` or `EditorService.CloseTabItem`, because both retain terminal
-completion semantics. Resolve `IEditorContextCloseService` from the supplied
-`IEditorContextServices` and request closure instead:
+completion semantics. `TryCreateContext` must retain the close capability supplied
+by `IEditorContextServices` and expose it through the required
+`IEditorContext.CloseService` property, either directly or through a
+context-specific wrapper. Request closure instead:
 
 ```csharp
-services.TryGetService<IEditorContextCloseService>(out var closeService);
-EditorContextCloseRequest request = closeService!.RequestClose(this);
+EditorContextCloseRequest request = CloseService.RequestClose(this);
 // Return from the callback. Observe request.Completion afterward if needed.
 ```
 
-`ToolTabExtension` callbacks receive only `IEditorContext`; resolve the same
-service through its inherited `IServiceProvider` surface:
+`ToolTabExtension` callbacks receive only `IEditorContext`; use its required
+retained close capability:
 
 ```csharp
-var closeService = (IEditorContextCloseService?)editorContext.GetService(
-    typeof(IEditorContextCloseService));
-EditorContextCloseRequest request = closeService!.RequestClose(editorContext);
+EditorContextCloseRequest request = editorContext.CloseService.RequestClose(editorContext);
 ```
 
 The request distinguishes `Accepted`, `AlreadyClosing`, and `NotOwned`.
 `Completion` is the stable terminal task for physical tab removal and context
 teardown, including failures.
+
+## Project shutdown
+
+`ProjectService.CloseProject()` has been replaced by `CloseProjectAsync()`.
+Await it before unloading packages, replacing the editor host, or releasing any
+resource that an editor context can still reach. Repeated calls join the queued
+project transition, including a close that has already cleared `CurrentProject`.
+
+`ProjectObservable` is now a post-commit notification stream. Notifications are
+ordered and run only after the editor reaches a stable state, but project methods
+do not wait for observers to finish. Observers must not synchronously block on a
+new project operation; enqueue or await the operation after returning from the
+callback. The event payload identifies the historical transition; a later
+transition may already be visible through `CurrentProject`. Use
+`WaitForPendingProjectChangesAsync()` when code that mutates
+`Project.Items` needs an explicit editor-state barrier.
 
 Dock layout application and reset are asynchronous for the same reason. Await
 the operation so outgoing tools finish teardown before replacement tools begin

--- a/docs/ai-workflow/async-editor-context-migration.md
+++ b/docs/ai-workflow/async-editor-context-migration.md
@@ -9,14 +9,23 @@ the public extension contract in `Beutl.Extensibility`.
 `IToolContext` implements `IAsyncDisposable` instead of `IDisposable`. Replace
 `Dispose()` with `ValueTask DisposeAsync()` and put every subscription, native
 resource, and in-flight operation behind that one completion boundary. A host
-call to `OpenToolTabAsync` consumes the supplied context even when it returns
-`false`; an extension must not dispose or reuse it afterward.
+call to `OpenToolTabAsync` consumes a fresh supplied context even when it returns
+`false`; a context already claimed by another host remains with its owner. In either case, the
+caller must not dispose or reuse it afterward.
 
 `CloseToolTabAsync` normally completes after the target tool is disposed. When
 it is called from inside an `IToolContext.DisposeAsync` callback, the host only
 schedules the sibling close and returns to avoid mutual-disposal cycles. The
 enclosing layout/editor teardown still joins all scheduled tool disposals before
 it releases editor resources.
+
+Independent tool hosts must own a stable `ToolContextHostToken`. Call
+`TryAcquireContext` before publishing a tool and retain the returned
+`ToolContextOwnershipLease` until the tool has been unpublished and its asynchronous teardown has
+completed. Claims are process-wide: an open request for a tool already owned by another editor
+returns `false` without disposing the owner's live instance, and a foreign close request is a
+no-op. A rejected fresh context is still consumed and fully disposed before `OpenToolTabAsync`
+returns.
 
 ```csharp
 public ValueTask DisposeAsync()
@@ -39,7 +48,7 @@ synchronous wrapper or blocking with `GetAwaiter().GetResult()`.
 
 Host publication and dispatcher callbacks must not synchronously wait for
 `DisposeAsync` or `EditorService.CloseTabItem`, because both retain terminal
-completion semantics. `TryCreateContext` must retain the close capability supplied
+completion semantics. `EditorExtension.CreateContextAsync` must retain the close capability supplied
 by `IEditorContextServices` and expose it through the required
 `IEditorContext.CloseService` property, either directly or through a
 context-specific wrapper. Request closure instead:
@@ -49,7 +58,12 @@ EditorContextCloseRequest request = CloseService.RequestClose(this);
 // Return from the callback. Observe request.Completion afterward if needed.
 ```
 
-`TryCreateContext`, publication observers, and disposal callbacks must not synchronously start and
+`EditorExtension.TryCreateContext` has been replaced by
+`ValueTask<IEditorContext?> CreateContextAsync(...)`. Return a newly created context to transfer
+ownership, or await cleanup of every partial resource before returning `null`. Opening a core
+object is correspondingly awaitable through `EditorService.ActivateTabItemAsync(CoreObject)`.
+
+`CreateContextAsync`, publication observers, and disposal callbacks must not synchronously start and
 wait for a project or editor lifecycle operation on the same or another thread. Queue the operation
 so it begins only after the callback returns. The host rejects detected causal reentry, but this is
 diagnostic protection rather than the contract: manually suppressing execution context or blocking
@@ -68,10 +82,10 @@ EditorContextCloseRequest request = editorContext.CloseService.RequestClose(edit
 but contexts must not expose a second `IEditorContextCloseService` lookup through
 `GetService`.
 
-A successful `TryCreateContext` transfers a new, non-null context to the host. The
+A non-null `CreateContextAsync` result transfers a new context to the host. The
 host disposes that context exactly once even when a subsequent attachment or
-publication step fails. A failed creation returns `false` with `context == null`
-and the extension is responsible for cleaning up partial state. A successful
+publication step fails. A failed creation returns `null` only after the extension has finished
+asynchronous cleanup of partial state. A successful
 factory result must be a newly created, unowned context; returning a context that
 is already active in a tab violates the ownership contract.
 
@@ -120,11 +134,21 @@ Dock layout application and reset are asynchronous for the same reason. Await
 the operation so outgoing tools finish teardown before replacement tools begin
 using the editor.
 
+`MainViewModel` now implements `IAsyncDisposable`; hosts that own the application composition root
+should await `DisposeAsync`. The inherited synchronous `Dispose` starts the same idempotent terminal
+task for UI lifetime callbacks, but does not provide a completion boundary by itself.
+
 The host-owned editor collections are now read-only to consumers:
 
 - `EditorTabItem.Context` is `IReadOnlyReactiveProperty<IEditorContext?>`; it is `null` while
-  replacement or terminal disposal is in progress, so callers must use a null-safe fallback.
-- `EditorService.TabItems` is `ICoreReadOnlyList<EditorTabItem>`.
+  replacement or terminal disposal is in progress, so callers must use a null-safe fallback. The
+  returned object is a read-only projection and cannot be cast back to `IReactiveProperty`.
+- `EditorTabItem.IsSelected` and `EditorService.SelectedTabItem` are read-only reactive
+  projections. Request selection through `EditorService.ActivateTabItem(EditorTabItem)`, which
+  rejects tabs that are not currently owned and published by that host. The projections cannot be
+  cast back to `IReactiveProperty`.
+- `EditorService.TabItems` is an `ICoreReadOnlyList<EditorTabItem>` facade that forwards collection
+  notifications without exposing the mutable `ICoreList` implementation.
 
 Use `EditorService.ReplaceContextAsync(tab, extension)` to replace an editor
 context. The host creates the context with its own services, validates the tab
@@ -134,4 +158,6 @@ callers never dispose a context returned by this host-mediated overload. A tab
 that is unowned, still being attached, or belongs to another host returns
 `NotOwned` without changing either tab or registry. `EditorTabItem`'s raw
 context overload is host-internal. Add and remove tabs through `EditorService`;
-do not cast the read-only collections back to their concrete mutable implementations.
+the returned collection has no mutable implementation to cast back to.
+`EditorTabItem` construction is also host-internal; external editor hosts should define their
+own tab model and claim each context with `EditorContextHostToken` before publishing it.

--- a/samples/PackageSample/ChoicesProviderSample/AddWellKnownSizeScreenViewModel.cs
+++ b/samples/PackageSample/ChoicesProviderSample/AddWellKnownSizeScreenViewModel.cs
@@ -5,8 +5,10 @@ using Reactive.Bindings;
 
 namespace PackageSample;
 
-public sealed class AddWellKnownSizeScreenViewModel
+public sealed class AddWellKnownSizeScreenViewModel : IDisposable
 {
+    private int _disposed;
+
     public AddWellKnownSizeScreenViewModel()
     {
         Name.SetValidateAttribute(() => Name);
@@ -38,5 +40,16 @@ public sealed class AddWellKnownSizeScreenViewModel
         Name.Value = string.Empty;
         Width.Value = 0;
         Height.Value = 0;
+    }
+
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            return;
+
+        Add.Dispose();
+        Name.Dispose();
+        Width.Dispose();
+        Height.Dispose();
     }
 }

--- a/samples/PackageSample/ChoicesProviderSample/EditWellKnownSizeTabViewModel.cs
+++ b/samples/PackageSample/ChoicesProviderSample/EditWellKnownSizeTabViewModel.cs
@@ -16,8 +16,9 @@ public sealed class EditWellKnownSizeTabViewModel(ToolTabExtension extension) : 
 
     public RemoveWellKnownSizeScreenViewModel RemoveScreen { get; } = new RemoveWellKnownSizeScreenViewModel();
 
-    public void Dispose()
+    public ValueTask DisposeAsync()
     {
+        return ValueTask.CompletedTask;
     }
 
     public object? GetService(Type serviceType)

--- a/samples/PackageSample/ChoicesProviderSample/EditWellKnownSizeTabViewModel.cs
+++ b/samples/PackageSample/ChoicesProviderSample/EditWellKnownSizeTabViewModel.cs
@@ -6,6 +6,8 @@ namespace PackageSample;
 
 public sealed class EditWellKnownSizeTabViewModel(ToolTabExtension extension) : IToolContext
 {
+    private int _disposed;
+
     public ToolTabExtension Extension { get; } = extension;
 
     public IReactiveProperty<bool> IsSelected { get; } = new ReactivePropertySlim<bool>();
@@ -18,6 +20,13 @@ public sealed class EditWellKnownSizeTabViewModel(ToolTabExtension extension) : 
 
     public ValueTask DisposeAsync()
     {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            return ValueTask.CompletedTask;
+
+        AddScreen.Dispose();
+        RemoveScreen.Dispose();
+        IsSelected.Dispose();
+        (Header as IDisposable)?.Dispose();
         return ValueTask.CompletedTask;
     }
 

--- a/samples/PackageSample/ChoicesProviderSample/RemoveWellKnownSizeScreenViewModel.cs
+++ b/samples/PackageSample/ChoicesProviderSample/RemoveWellKnownSizeScreenViewModel.cs
@@ -6,8 +6,10 @@ using Reactive.Bindings;
 
 namespace PackageSample;
 
-public sealed class RemoveWellKnownSizeScreenViewModel
+public sealed class RemoveWellKnownSizeScreenViewModel : IDisposable
 {
+    private int _disposed;
+
     public RemoveWellKnownSizeScreenViewModel()
     {
         Items = WellKnownSizesProvider.GetTypedChoices();
@@ -27,5 +29,14 @@ public sealed class RemoveWellKnownSizeScreenViewModel
     {
         WellKnownSizesProvider.RemoveChoice(SelectedItem.Value!);
         SelectedItem.Value = null;
+    }
+
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            return;
+
+        Remove.Dispose();
+        SelectedItem.Dispose();
     }
 }

--- a/samples/PackageSample/SampleEditorExtension.cs
+++ b/samples/PackageSample/SampleEditorExtension.cs
@@ -66,9 +66,6 @@ public sealed class TextEditorContext : IEditorContext
 
     public object? GetService(Type serviceType)
     {
-        if (serviceType == typeof(IEditorContextCloseService))
-            return CloseService;
-
         return null;
     }
 

--- a/samples/PackageSample/SampleEditorExtension.cs
+++ b/samples/PackageSample/SampleEditorExtension.cs
@@ -98,6 +98,8 @@ public sealed class TextEditorContext : IEditorContext
         TextEditorContext owner,
         IEditorContextCloseService closeService) : IEditorContextCloseService
     {
+        public EditorContextHostToken HostToken => closeService.HostToken;
+
         public EditorContextCloseRequest RequestClose(IEditorContext context)
         {
             return ReferenceEquals(context, owner)

--- a/samples/PackageSample/SampleEditorExtension.cs
+++ b/samples/PackageSample/SampleEditorExtension.cs
@@ -15,13 +15,19 @@ namespace PackageSample;
 public sealed class TextEditorContext : IEditorContext
 {
     private int _disposed;
-    public TextEditorContext(CoreObject obj, SampleEditorExtension extension)
+    public TextEditorContext(
+        CoreObject obj,
+        SampleEditorExtension extension,
+        IEditorContextCloseService closeService)
     {
         Extension = extension;
         Object = obj;
+        CloseService = new BoundCloseService(this, closeService);
         Text.Value = File.ReadAllText(obj.Uri!.LocalPath);
         Commands = new CommandsImpl(this);
     }
+
+    public IEditorContextCloseService CloseService { get; }
 
     public EditorExtension Extension { get; }
 
@@ -60,6 +66,9 @@ public sealed class TextEditorContext : IEditorContext
 
     public object? GetService(Type serviceType)
     {
+        if (serviceType == typeof(IEditorContextCloseService))
+            return CloseService;
+
         return null;
     }
 
@@ -82,6 +91,20 @@ public sealed class TextEditorContext : IEditorContext
             {
                 return false;
             }
+        }
+    }
+
+    private sealed class BoundCloseService(
+        TextEditorContext owner,
+        IEditorContextCloseService closeService) : IEditorContextCloseService
+    {
+        public EditorContextCloseRequest RequestClose(IEditorContext context)
+        {
+            return ReferenceEquals(context, owner)
+                ? closeService.RequestClose(owner)
+                : new EditorContextCloseRequest(
+                    EditorContextCloseRequestStatus.NotOwned,
+                    Task.CompletedTask);
         }
     }
 }
@@ -129,7 +152,7 @@ public sealed class SampleEditorExtension : EditorExtension
         context = null;
         if (obj is Scene)
         {
-            context = new TextEditorContext(obj, this);
+            context = new TextEditorContext(obj, this, services.CloseService);
             return true;
         }
         else

--- a/samples/PackageSample/SampleEditorExtension.cs
+++ b/samples/PackageSample/SampleEditorExtension.cs
@@ -14,6 +14,7 @@ namespace PackageSample;
 
 public sealed class TextEditorContext : IEditorContext
 {
+    private int _disposed;
     public TextEditorContext(CoreObject obj, SampleEditorExtension extension)
     {
         Extension = extension;
@@ -32,12 +33,19 @@ public sealed class TextEditorContext : IEditorContext
 
     public IReactiveProperty<bool> IsEnabled { get; } = new ReactiveProperty<bool>(true);
 
-    public void CloseToolTab(IToolContext item)
+    public ValueTask CloseToolTabAsync(IToolContext item)
     {
+        return ValueTask.CompletedTask;
     }
 
-    public void Dispose()
+    public ValueTask DisposeAsync()
     {
+        if (Interlocked.Exchange(ref _disposed, 1) == 0)
+        {
+            Text.Dispose();
+            IsEnabled.Dispose();
+        }
+        return ValueTask.CompletedTask;
     }
 
     public T? FindToolTab<T>(Func<T, bool> condition) where T : IToolContext
@@ -55,8 +63,9 @@ public sealed class TextEditorContext : IEditorContext
         return null;
     }
 
-    public bool OpenToolTab(IToolContext item)
+    public async ValueTask<bool> OpenToolTabAsync(IToolContext item)
     {
+        await item.DisposeAsync();
         return false;
     }
 

--- a/samples/PackageSample/SampleEditorExtension.cs
+++ b/samples/PackageSample/SampleEditorExtension.cs
@@ -146,18 +146,15 @@ public sealed class SampleEditorExtension : EditorExtension
         return ext is ".txt" or ".scene";
     }
 
-    public override bool TryCreateContext(CoreObject obj, IEditorContextServices services, [NotNullWhen(true)] out IEditorContext? context)
+    public override ValueTask<IEditorContext?> CreateContextAsync(CoreObject obj, IEditorContextServices services)
     {
-        context = null;
         if (obj is Scene)
         {
-            context = new TextEditorContext(obj, this, services.CloseService);
-            return true;
+            return ValueTask.FromResult<IEditorContext?>(
+                new TextEditorContext(obj, this, services.CloseService));
         }
-        else
-        {
-            return false;
-        }
+
+        return ValueTask.FromResult<IEditorContext?>(null);
     }
 
     public override bool TryCreateEditor(CoreObject obj, [NotNullWhen(true)] out Control? editor)

--- a/samples/PackageSample/SampleEditorExtension.cs
+++ b/samples/PackageSample/SampleEditorExtension.cs
@@ -71,9 +71,14 @@ public sealed class TextEditorContext : IEditorContext
 
     public async ValueTask<bool> OpenToolTabAsync(IToolContext item)
     {
-        await item.DisposeAsync();
+        if (!_toolHost.TryAcquireContext(item, out ToolContextOwnershipLease? lease))
+            return false;
+        try { await item.DisposeAsync(); }
+        finally { lease.Dispose(); }
         return false;
     }
+
+    private readonly ToolContextHostToken _toolHost = new();
 
     private sealed class CommandsImpl(TextEditorContext context) : IKnownEditorCommands
     {

--- a/samples/PackageSample/SampleToolTabExtension.cs
+++ b/samples/PackageSample/SampleToolTabExtension.cs
@@ -50,8 +50,9 @@ public sealed class SampleToolTabExtension : ToolTabExtension
         public IReadOnlyReactiveProperty<string> Header { get; } =
             new ReactivePropertySlim<string>($"Sample tab {Interlocked.Increment(ref s_lastInstanceNumber)}");
 
-        public void Dispose()
+        public ValueTask DisposeAsync()
         {
+            return ValueTask.CompletedTask;
         }
 
         public object? GetService(Type serviceType)

--- a/samples/PackageSample/SampleToolTabExtension.cs
+++ b/samples/PackageSample/SampleToolTabExtension.cs
@@ -42,6 +42,7 @@ public sealed class SampleToolTabExtension : ToolTabExtension
     {
         // Number each instance because CanMultiple is enabled.
         private static int s_lastInstanceNumber;
+        private int _disposed;
 
         public ToolTabExtension Extension { get; } = extension;
 
@@ -52,6 +53,11 @@ public sealed class SampleToolTabExtension : ToolTabExtension
 
         public ValueTask DisposeAsync()
         {
+            if (Interlocked.Exchange(ref _disposed, 1) != 0)
+                return ValueTask.CompletedTask;
+
+            IsSelected.Dispose();
+            (Header as IDisposable)?.Dispose();
             return ValueTask.CompletedTask;
         }
 

--- a/src/Beutl.Core/Collections/CoreList.cs
+++ b/src/Beutl.Core/Collections/CoreList.cs
@@ -1,5 +1,4 @@
-﻿using System.Buffers;
-using System.Collections;
+﻿using System.Collections;
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
@@ -613,18 +612,9 @@ public class CoreList<T> : ICoreList<T>
         PropertyChanged?.Invoke(this, s_indexerPropertyChanged);
         if (CollectionChanged != null)
         {
-            T[] array = ArrayPool<T>.Shared.Rent(t.Length);
-            t.CopyTo(array.AsSpan());
-
-            var e = new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, array, index);
-            try
-            {
-                CollectionChanged(this, e);
-            }
-            finally
-            {
-                ArrayPool<T>.Shared.Return(array);
-            }
+            T[] items = t.ToArray();
+            var e = new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, items, index);
+            CollectionChanged(this, e);
         }
 
         NotifyCountChanged();

--- a/src/Beutl.Core/Collections/CoreList.cs
+++ b/src/Beutl.Core/Collections/CoreList.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System.Buffers;
+using System.Collections;
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
@@ -329,16 +330,17 @@ public class CoreList<T> : ICoreList<T>
     {
         if (items.Length > 0)
         {
-            T[] snapshot = items.ToArray();
-            EnsureCapacity(Inner.Count + snapshot.Length);
+            EnsureCapacity(Inner.Count + items.Length);
 
+            ReadOnlySpan<T>.Enumerator en = items.GetEnumerator();
             int insertIndex = index;
-            foreach (T item in snapshot)
+
+            while (en.MoveNext())
             {
-                Inner.Insert(insertIndex++, item);
+                Inner.Insert(insertIndex++, en.Current);
             }
 
-            NotifyAdd((IList)snapshot, index);
+            NotifyAdd(items, index);
         }
     }
 
@@ -596,6 +598,33 @@ public class CoreList<T> : ICoreList<T>
         {
             var e = new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, t, index);
             CollectionChanged(this, e);
+        }
+
+        NotifyCountChanged();
+    }
+
+    private void NotifyAdd(ReadOnlySpan<T> t, int index)
+    {
+        for (int i = 0; i < t.Length; i++)
+        {
+            Attached?.Invoke(t[i]);
+        }
+
+        PropertyChanged?.Invoke(this, s_indexerPropertyChanged);
+        if (CollectionChanged != null)
+        {
+            T[] array = ArrayPool<T>.Shared.Rent(t.Length);
+            t.CopyTo(array.AsSpan());
+
+            var e = new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, array, index);
+            try
+            {
+                CollectionChanged(this, e);
+            }
+            finally
+            {
+                ArrayPool<T>.Shared.Return(array);
+            }
         }
 
         NotifyCountChanged();

--- a/src/Beutl.Core/Collections/CoreList.cs
+++ b/src/Beutl.Core/Collections/CoreList.cs
@@ -329,17 +329,16 @@ public class CoreList<T> : ICoreList<T>
     {
         if (items.Length > 0)
         {
-            EnsureCapacity(Inner.Count + items.Length);
+            T[] snapshot = items.ToArray();
+            EnsureCapacity(Inner.Count + snapshot.Length);
 
-            ReadOnlySpan<T>.Enumerator en = items.GetEnumerator();
             int insertIndex = index;
-
-            while (en.MoveNext())
+            foreach (T item in snapshot)
             {
-                Inner.Insert(insertIndex++, en.Current);
+                Inner.Insert(insertIndex++, item);
             }
 
-            NotifyAdd(items, index);
+            NotifyAdd((IList)snapshot, index);
         }
     }
 
@@ -596,24 +595,6 @@ public class CoreList<T> : ICoreList<T>
         if (CollectionChanged != null)
         {
             var e = new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, t, index);
-            CollectionChanged(this, e);
-        }
-
-        NotifyCountChanged();
-    }
-
-    private void NotifyAdd(ReadOnlySpan<T> t, int index)
-    {
-        for (int i = 0; i < t.Length; i++)
-        {
-            Attached?.Invoke(t[i]);
-        }
-
-        PropertyChanged?.Invoke(this, s_indexerPropertyChanged);
-        if (CollectionChanged != null)
-        {
-            T[] items = t.ToArray();
-            var e = new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, items, index);
             CollectionChanged(this, e);
         }
 

--- a/src/Beutl.Core/Services/Tutorials/TutorialDefinition.cs
+++ b/src/Beutl.Core/Services/Tutorials/TutorialDefinition.cs
@@ -10,7 +10,7 @@ public sealed class TutorialDefinition
 
     public required IReadOnlyList<TutorialStep> Steps { get; init; }
 
-    public Func<bool>? CanStart { get; init; }
+    public Func<Task<bool>>? CanStart { get; init; }
 
     public Func<Task<bool>>? FulfillPrerequisites { get; init; }
 

--- a/src/Beutl.Editor.Components/AudioVisualizerTab/ViewModels/AudioVisualizerTabViewModel.cs
+++ b/src/Beutl.Editor.Components/AudioVisualizerTab/ViewModels/AudioVisualizerTabViewModel.cs
@@ -170,11 +170,13 @@ public sealed class AudioVisualizerTabViewModel : IToolContext
         }
     }
 
-    public void Dispose()
+    public ValueTask DisposeAsync()
     {
         _disposables.Dispose();
         RingBuffer.Clear();
+        return ValueTask.CompletedTask;
     }
+
 
     internal static string LocalizeMode(AudioVisualizerMode mode) => mode switch
     {

--- a/src/Beutl.Editor.Components/AudioVisualizerTab/ViewModels/AudioVisualizerTabViewModel.cs
+++ b/src/Beutl.Editor.Components/AudioVisualizerTab/ViewModels/AudioVisualizerTabViewModel.cs
@@ -22,6 +22,10 @@ public sealed class AudioVisualizerTabViewModel : IToolContext
     private readonly IEditorClock _clock;
     private readonly AudioVisualizerTabExtension _extension;
     private int _composeInFlight;
+    private readonly object _lifetimeGate = new();
+    private readonly CancellationTokenSource _composeCancellation = new();
+    private Task _composeTask = Task.CompletedTask;
+    private bool _disposed;
 
     public AudioVisualizerTabViewModel(IEditorContext editorContext, AudioVisualizerTabExtension extension)
     {
@@ -51,7 +55,7 @@ public sealed class AudioVisualizerTabViewModel : IToolContext
                 (time, playing, selected, mode) => (time, playing, selected, mode))
             .Where(t => t.selected)
             .Throttle(TimeSpan.FromMilliseconds(40))
-            .Subscribe(t => _ = ComposeSnapshotOnIdleAsync())
+            .Subscribe(t => _ = ToolTabCallback.RunAsync(ComposeSnapshotOnIdleAsync))
             .DisposeWith(_disposables);
 
         // Use Strings.Audio: the localized full name plus mode is too wide for the tab.
@@ -101,12 +105,17 @@ public sealed class AudioVisualizerTabViewModel : IToolContext
 
     private void OnAudioFrameReceived(AudioFrameSnapshot snapshot)
     {
-        RingBuffer.WriteInterleaved(
-            snapshot.Interleaved,
-            snapshot.ChannelCount,
-            snapshot.SampleRate,
-            snapshot.StartTime);
-        SnapshotUpdated?.Invoke(this, EventArgs.Empty);
+        lock (_lifetimeGate)
+        {
+            if (_disposed)
+                return;
+            RingBuffer.WriteInterleaved(
+                snapshot.Interleaved,
+                snapshot.ChannelCount,
+                snapshot.SampleRate,
+                snapshot.StartTime);
+            SnapshotUpdated?.Invoke(this, EventArgs.Empty);
+        }
     }
 
     // Per-mode compose length. Spectrogram needs the full WindowSeconds (default 4s)
@@ -124,8 +133,16 @@ public sealed class AudioVisualizerTabViewModel : IToolContext
 
     private async Task ComposeSnapshotOnIdleAsync()
     {
-        if (_player.IsPlaying.Value) return;
-        if (Interlocked.Exchange(ref _composeInFlight, 1) != 0) return;
+        TaskCompletionSource completion;
+        lock (_lifetimeGate)
+        {
+            if (_disposed)
+                return;
+            if (_player.IsPlaying.Value) return;
+            if (Interlocked.Exchange(ref _composeInFlight, 1) != 0) return;
+            completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            _composeTask = completion.Task;
+        }
         try
         {
             // Bounded retry loop: a long compose (e.g. 4s for Spectrogram) can
@@ -136,6 +153,7 @@ public sealed class AudioVisualizerTabViewModel : IToolContext
             // once the user actually pauses for 40ms.
             for (int attempt = 0; attempt < 3; attempt++)
             {
+                _composeCancellation.Token.ThrowIfCancellationRequested();
                 if (_player.IsPlaying.Value) break;
 
                 TimeSpan targetTime = _clock.CurrentTime.Value;
@@ -149,7 +167,7 @@ public sealed class AudioVisualizerTabViewModel : IToolContext
                 if (duration <= TimeSpan.Zero) duration = window;
 
                 AudioFrameSnapshot? snapshot = await _player
-                    .ComposeAudioAsync(windowStart, duration)
+                    .ComposeAudioAsync(windowStart, duration, _composeCancellation.Token)
                     .ConfigureAwait(false);
                 if (snapshot != null)
                 {
@@ -167,14 +185,36 @@ public sealed class AudioVisualizerTabViewModel : IToolContext
         finally
         {
             Interlocked.Exchange(ref _composeInFlight, 0);
+            completion.TrySetResult();
         }
     }
 
-    public ValueTask DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
-        _disposables.Dispose();
-        RingBuffer.Clear();
-        return ValueTask.CompletedTask;
+        Task pending;
+        bool first;
+        lock (_lifetimeGate)
+        {
+            first = !_disposed;
+            _disposed = true;
+            pending = _composeTask;
+        }
+        try
+        {
+            if (first)
+            {
+                _composeCancellation.Cancel();
+                _disposables.Dispose();
+            }
+        }
+        finally
+        {
+            await pending;
+            lock (_lifetimeGate)
+                RingBuffer.Clear();
+            if (first)
+                _composeCancellation.Dispose();
+        }
     }
 
 

--- a/src/Beutl.Editor.Components/ColorGradingProperties/Views/ColorGradingPropertiesEditor.axaml.cs
+++ b/src/Beutl.Editor.Components/ColorGradingProperties/Views/ColorGradingPropertiesEditor.axaml.cs
@@ -39,7 +39,7 @@ public sealed partial class ColorGradingPropertiesEditor : UserControl
             });
     }
 
-    private void OpenTabClick(object? sender, RoutedEventArgs e)
+    private async void OpenTabClick(object? sender, RoutedEventArgs e)
     {
         if (DataContext is ColorGradingPropertiesViewModel context &&
             context.GetService<IEditorContext>() is { } editorContext &&
@@ -54,7 +54,7 @@ public sealed partial class ColorGradingPropertiesEditor : UserControl
 
             toolTab.Effect.Value = colorGrading;
 
-            editorContext.OpenToolTab(toolTab);
+            await editorContext.OpenToolTabAsync(toolTab);
         }
     }
 

--- a/src/Beutl.Editor.Components/ColorGradingTab/ViewModels/ColorGradingTabViewModel.cs
+++ b/src/Beutl.Editor.Components/ColorGradingTab/ViewModels/ColorGradingTabViewModel.cs
@@ -136,11 +136,13 @@ public sealed class ColorGradingTabViewModel : IToolContext, IPropertyEditorCont
         return _editorContext.GetService(serviceType);
     }
 
-    public void Dispose()
+    public ValueTask DisposeAsync()
     {
         ClearEditors();
         _disposables.Dispose();
+        return ValueTask.CompletedTask;
     }
+
 
     public void ReadFromJson(JsonObject json)
     {
@@ -225,9 +227,9 @@ public sealed class ColorGradingTabViewModel : IToolContext, IPropertyEditorCont
         return ctx;
     }
 
-    private void OnEffectDetached(object? sender, HierarchyAttachmentEventArgs e)
+    private async void OnEffectDetached(object? sender, HierarchyAttachmentEventArgs e)
     {
-        _editorContext.CloseToolTab(this);
+        await _editorContext.CloseToolTabAsync(this);
     }
 
     private void ClearEditors()

--- a/src/Beutl.Editor.Components/ColorGradingTab/ViewModels/ColorGradingTabViewModel.cs
+++ b/src/Beutl.Editor.Components/ColorGradingTab/ViewModels/ColorGradingTabViewModel.cs
@@ -229,7 +229,7 @@ public sealed class ColorGradingTabViewModel : IToolContext, IPropertyEditorCont
 
     private async void OnEffectDetached(object? sender, HierarchyAttachmentEventArgs e)
     {
-        await _editorContext.CloseToolTabAsync(this);
+        await Beutl.Editor.Components.Helpers.ToolTabCallback.CloseAsync(_editorContext, this);
     }
 
     private void ClearEditors()

--- a/src/Beutl.Editor.Components/ColorScopesTab/ViewModels/ColorScopesTabViewModel.cs
+++ b/src/Beutl.Editor.Components/ColorScopesTab/ViewModels/ColorScopesTabViewModel.cs
@@ -77,10 +77,12 @@ public sealed class ColorScopesTabViewModel : IToolContext
 
     public IReactiveProperty<bool> IsSelected { get; } = new ReactiveProperty<bool>();
 
-    public void Dispose()
+    public ValueTask DisposeAsync()
     {
         _disposables.Dispose();
+        return ValueTask.CompletedTask;
     }
+
 
     internal static string LocalizeScopeType(ColorScopeType type) => type switch
     {

--- a/src/Beutl.Editor.Components/CurvesTab/ViewModels/CurvesTabViewModel.cs
+++ b/src/Beutl.Editor.Components/CurvesTab/ViewModels/CurvesTabViewModel.cs
@@ -235,11 +235,13 @@ public sealed class CurvesTabViewModel : IToolContext
 
     public ReactivePropertySlim<Curves?> Effect { get; } = new();
 
-    public void Dispose()
+    public ValueTask DisposeAsync()
     {
         ClearEditors();
         _disposables.Dispose();
+        return ValueTask.CompletedTask;
     }
+
 
     public void ReadFromJson(JsonObject json)
     {
@@ -352,9 +354,9 @@ public sealed class CurvesTabViewModel : IToolContext
         _effectDisposables.Add(Disposable.Create(() => effect.DetachedFromHierarchy -= OnEffectDetached));
     }
 
-    private void OnEffectDetached(object? sender, HierarchyAttachmentEventArgs e)
+    private async void OnEffectDetached(object? sender, HierarchyAttachmentEventArgs e)
     {
-        _editorContext.CloseToolTab(this);
+        await _editorContext.CloseToolTabAsync(this);
     }
 
     private CurvePresenterViewModel CreateCurve(IProperty<CurveMap> property, HistoryManager history)

--- a/src/Beutl.Editor.Components/CurvesTab/ViewModels/CurvesTabViewModel.cs
+++ b/src/Beutl.Editor.Components/CurvesTab/ViewModels/CurvesTabViewModel.cs
@@ -356,7 +356,7 @@ public sealed class CurvesTabViewModel : IToolContext
 
     private async void OnEffectDetached(object? sender, HierarchyAttachmentEventArgs e)
     {
-        await _editorContext.CloseToolTabAsync(this);
+        await Beutl.Editor.Components.Helpers.ToolTabCallback.CloseAsync(_editorContext, this);
     }
 
     private CurvePresenterViewModel CreateCurve(IProperty<CurveMap> property, HistoryManager history)

--- a/src/Beutl.Editor.Components/ElementPropertyTab/ViewModels/ElementPropertyTabViewModel.cs
+++ b/src/Beutl.Editor.Components/ElementPropertyTab/ViewModels/ElementPropertyTabViewModel.cs
@@ -121,7 +121,7 @@ public sealed class ElementPropertyTabViewModel : IToolContext
         RequestScroll?.Invoke(obj);
     }
 
-    public void Dispose()
+    public ValueTask DisposeAsync()
     {
         if (Element.Value != null)
         {
@@ -134,7 +134,9 @@ public sealed class ElementPropertyTabViewModel : IToolContext
         Element.Dispose();
         _editorContext = null!;
         RequestScroll = null;
+        return ValueTask.CompletedTask;
     }
+
 
     private static string ViewStateDirectory(Element element)
     {

--- a/src/Beutl.Editor.Components/FileBrowserTab/ViewModels/FileBrowserTabViewModel.cs
+++ b/src/Beutl.Editor.Components/FileBrowserTab/ViewModels/FileBrowserTabViewModel.cs
@@ -675,7 +675,7 @@ public sealed class FileBrowserTabViewModel : IToolContext
         return null;
     }
 
-    public void Dispose()
+    public ValueTask DisposeAsync()
     {
         _disposed = true;
         DecoderRegistry.DecodersChanged -= OnDecodersChanged;
@@ -688,7 +688,9 @@ public sealed class FileBrowserTabViewModel : IToolContext
         DisposeAndClear(ProjectDirectoryItems);
 
         _disposables.Dispose();
+        return ValueTask.CompletedTask;
     }
+
 }
 
 public static class FileBrowserViewModeConverters

--- a/src/Beutl.Editor.Components/GraphEditorTab/ViewModels/GraphEditorTabViewModel.cs
+++ b/src/Beutl.Editor.Components/GraphEditorTab/ViewModels/GraphEditorTabViewModel.cs
@@ -77,14 +77,16 @@ public sealed class GraphEditorTabViewModel : IToolContext
 
     public IReactiveProperty<bool> IsSelected { get; } = new ReactiveProperty<bool>();
 
-    public void Dispose()
+    public ValueTask DisposeAsync()
     {
         _disposed = true;
         if (Element.Value is IHierarchical h)
             h.DetachedFromHierarchy -= OnElementDetached;
         _animationDisposables.Dispose();
         _disposables.Dispose();
+        return ValueTask.CompletedTask;
     }
+
 
     public object? GetService(Type serviceType)
     {
@@ -143,17 +145,17 @@ public sealed class GraphEditorTabViewModel : IToolContext
     private void OnElementDetached(object? sender, HierarchyAttachmentEventArgs e)
     {
         if (_disposed) return;
-        Dispatcher.UIThread.Post(() =>
+        Dispatcher.UIThread.Post(async void () =>
         {
             if (!_disposed)
-                _editorContext.CloseToolTab(this);
+                await _editorContext.CloseToolTabAsync(this);
         });
     }
 
     private void OnAnimationDetached(object? sender, HierarchyAttachmentEventArgs e)
     {
         if (_disposed) return;
-        Dispatcher.UIThread.Post(() =>
+        Dispatcher.UIThread.Post(async void () =>
         {
             if (_disposed) return;
             if (sender is KeyFrameAnimation animation)
@@ -173,7 +175,7 @@ public sealed class GraphEditorTabViewModel : IToolContext
 
             if (Items.Count == 0)
             {
-                _editorContext.CloseToolTab(this);
+                await _editorContext.CloseToolTabAsync(this);
             }
         });
     }

--- a/src/Beutl.Editor.Components/GraphEditorTab/ViewModels/GraphEditorTabViewModel.cs
+++ b/src/Beutl.Editor.Components/GraphEditorTab/ViewModels/GraphEditorTabViewModel.cs
@@ -148,7 +148,7 @@ public sealed class GraphEditorTabViewModel : IToolContext
         Dispatcher.UIThread.Post(async void () =>
         {
             if (!_disposed)
-                await _editorContext.CloseToolTabAsync(this);
+                await Beutl.Editor.Components.Helpers.ToolTabCallback.CloseAsync(_editorContext, this);
         });
     }
 
@@ -175,7 +175,7 @@ public sealed class GraphEditorTabViewModel : IToolContext
 
             if (Items.Count == 0)
             {
-                await _editorContext.CloseToolTabAsync(this);
+                await Beutl.Editor.Components.Helpers.ToolTabCallback.CloseAsync(_editorContext, this);
             }
         });
     }

--- a/src/Beutl.Editor.Components/Helpers/ToolTabCallback.cs
+++ b/src/Beutl.Editor.Components/Helpers/ToolTabCallback.cs
@@ -1,0 +1,53 @@
+﻿using Beutl.Logging;
+using Beutl.Services;
+using Microsoft.Extensions.Logging;
+
+namespace Beutl.Editor.Components.Helpers;
+
+internal static class ToolTabCallback
+{
+    private static readonly ILogger s_logger = Log.CreateLogger(typeof(ToolTabCallback));
+    private static readonly ToolContextHostToken s_unpublishedTools = new();
+
+    public static async Task RunAsync(Func<Task> operation)
+    {
+        try
+        {
+            await operation();
+        }
+        catch (Exception ex)
+        {
+            s_logger.LogError(ex, "A tool-tab UI operation failed.");
+            NotificationService.ShowError(Strings.Error, MessageStrings.OperationFailed);
+        }
+    }
+
+    public static Task OpenAsync(IEditorContext editor, IToolContext tool)
+        => RunAsync(async () => await editor.OpenToolTabAsync(tool));
+
+    public static Task CloseAsync(IEditorContext editor, IToolContext tool)
+        => RunAsync(async () => await editor.CloseToolTabAsync(tool));
+
+    public static Task OpenFromExtensionAsync(IEditorContext editor, ToolTabExtension extension)
+        => RunAsync(async () =>
+        {
+            IToolContext? tool = null;
+            bool handedOff = false;
+            try
+            {
+                if (extension.TryCreateContext(editor, out tool) && tool is not null)
+                {
+                    handedOff = true;
+                    await editor.OpenToolTabAsync(tool);
+                }
+            }
+            finally
+            {
+                if (!handedOff && tool is not null && s_unpublishedTools.TryAcquireContext(tool, out var lease))
+                {
+                    try { await tool.DisposeAsync(); }
+                    finally { lease.Dispose(); }
+                }
+            }
+        });
+}

--- a/src/Beutl.Editor.Components/LibraryTab/ViewModels/LibraryTabViewModel.cs
+++ b/src/Beutl.Editor.Components/LibraryTab/ViewModels/LibraryTabViewModel.cs
@@ -15,7 +15,7 @@ using Reactive.Bindings;
 
 namespace Beutl.Editor.Components.LibraryTab.ViewModels;
 
-public sealed class LibraryTabViewModel : IDisposable, IToolContext
+public sealed class LibraryTabViewModel : IToolContext
 {
     private readonly CompositeDisposable _disposables = [];
     private readonly SemaphoreSlim _asyncLock = new(1, 1);
@@ -129,7 +129,7 @@ public sealed class LibraryTabViewModel : IDisposable, IToolContext
         }
     }
 
-    public void Dispose()
+    public ValueTask DisposeAsync()
     {
         _disposables.Dispose();
         Easings.Clear();
@@ -137,7 +137,9 @@ public sealed class LibraryTabViewModel : IDisposable, IToolContext
         Nodes.Clear();
         AllItems.Clear();
         SearchResult.Clear();
+        return ValueTask.CompletedTask;
     }
+
 
     public void WriteToJson(JsonObject json)
     {

--- a/src/Beutl.Editor.Components/LibraryTab/ViewModels/LibraryTabViewModel.cs
+++ b/src/Beutl.Editor.Components/LibraryTab/ViewModels/LibraryTabViewModel.cs
@@ -19,6 +19,7 @@ public sealed class LibraryTabViewModel : IToolContext
 {
     private readonly CompositeDisposable _disposables = [];
     private readonly SemaphoreSlim _asyncLock = new(1, 1);
+    private int _disposed;
 
     public LibraryTabViewModel(IEditorContext editorContext)
     {
@@ -102,9 +103,11 @@ public sealed class LibraryTabViewModel : IToolContext
         await _asyncLock.WaitAsync(cancellationToken);
         try
         {
-            SearchResult.ClearOnScheduler();
-            await Task.Run(() =>
+            if (Volatile.Read(ref _disposed) != 0)
+                return;
+            var results = await Task.Run(() =>
             {
+                var matches = new List<KeyValuePair<int, LibraryItemViewModel>>();
                 Regex[] regices = RegexHelper.CreateRegexes(str);
                 for (int i = 0; i < AllItems.Count; i++)
                 {
@@ -112,16 +115,25 @@ public sealed class LibraryTabViewModel : IToolContext
                     int score = item.Value.Match(regices);
                     if (score > 0)
                     {
-                        SearchResult.OrderedAddDescendingOnScheduler(new(score, item.Value), x => x.Key);
+                        matches.Add(new(score, item.Value));
                     }
 
                     cancellationToken.ThrowIfCancellationRequested();
                 }
+                return matches.OrderByDescending(static item => item.Key).ToArray();
             }, cancellationToken);
+            await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                if (Volatile.Read(ref _disposed) != 0)
+                    return;
+                SearchResult.Clear();
+                foreach (var result in results)
+                    SearchResult.Add(result);
+            });
         }
         catch (OperationCanceledException)
         {
-            SearchResult.ClearOnScheduler();
+            await Dispatcher.UIThread.InvokeAsync(SearchResult.Clear);
         }
         finally
         {
@@ -129,15 +141,23 @@ public sealed class LibraryTabViewModel : IToolContext
         }
     }
 
-    public ValueTask DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
-        _disposables.Dispose();
-        Easings.Clear();
-        LibraryItems.Clear();
-        Nodes.Clear();
-        AllItems.Clear();
-        SearchResult.Clear();
-        return ValueTask.CompletedTask;
+        Interlocked.Exchange(ref _disposed, 1);
+        await _asyncLock.WaitAsync();
+        try
+        {
+            _disposables.Dispose();
+            Easings.Clear();
+            LibraryItems.Clear();
+            Nodes.Clear();
+            AllItems.Clear();
+            SearchResult.Clear();
+        }
+        finally
+        {
+            _asyncLock.Release();
+        }
     }
 
 

--- a/src/Beutl.Editor.Components/NodeGraphTab/ViewModels/NodeGraphTabViewModel.cs
+++ b/src/Beutl.Editor.Components/NodeGraphTab/ViewModels/NodeGraphTabViewModel.cs
@@ -45,6 +45,7 @@ public sealed class NodeGraphNavigationItem : IDisposable, IJsonSerializable
         NodeGraph = null!;
     }
 
+
     public void WriteToJson(JsonObject json)
     {
         ViewModel.WriteToJson(json);
@@ -121,7 +122,7 @@ public sealed class NodeGraphTabViewModel : IToolContext
 
     public CoreList<NodeGraphNavigationItem> Items { get; } = [];
 
-    public void Dispose()
+    public ValueTask DisposeAsync()
     {
         Model.Value = null;
 
@@ -136,6 +137,7 @@ public sealed class NodeGraphTabViewModel : IToolContext
         NodeGraph.Value?.Dispose();
         NodeGraph.Value = null;
         _editorContext = null!;
+        return ValueTask.CompletedTask;
     }
 
     public void NavigateTo(int index)

--- a/src/Beutl.Editor.Components/ObjectPropertyTab/ViewModels/ObjectPropertyTabViewModel.cs
+++ b/src/Beutl.Editor.Components/ObjectPropertyTab/ViewModels/ObjectPropertyTabViewModel.cs
@@ -127,10 +127,12 @@ public sealed class ObjectPropertyTabViewModel : IToolContext
         _canBack.Value = _backStack.Count > 0;
     }
 
-    public void Dispose()
+    public ValueTask DisposeAsync()
     {
         _disposables.Dispose();
+        return ValueTask.CompletedTask;
     }
+
 
     public void ReadFromJson(JsonObject json)
     {

--- a/src/Beutl.Editor.Components/PathEditorTab/ViewModels/PathEditorTabViewModel.cs
+++ b/src/Beutl.Editor.Components/PathEditorTab/ViewModels/PathEditorTabViewModel.cs
@@ -10,7 +10,7 @@ using Reactive.Bindings;
 
 namespace Beutl.Editor.Components.PathEditorTab.ViewModels;
 
-public sealed class PathEditorTabViewModel : IDisposable, IPathEditorContext, IToolContext
+public sealed class PathEditorTabViewModel : IPathEditorContext, IToolContext
 {
     private readonly CompositeDisposable _disposables = [];
     private readonly IEditorClock _clock;
@@ -123,12 +123,13 @@ public sealed class PathEditorTabViewModel : IDisposable, IPathEditorContext, IT
         }
     }
 
-    public void Dispose()
+    public ValueTask DisposeAsync()
     {
         if (PathFigure.Value is IHierarchical h)
             h.DetachedFromHierarchy -= OnPathFigureDetached;
         _disposables.Dispose();
         FigureContext.Dispose();
+        return ValueTask.CompletedTask;
     }
 
     private void OnPathFigureDetached(object? sender, HierarchyAttachmentEventArgs e)

--- a/src/Beutl.Editor.Components/PreviewSettingsTab/ViewModels/PreviewSettingsTabViewModel.cs
+++ b/src/Beutl.Editor.Components/PreviewSettingsTab/ViewModels/PreviewSettingsTabViewModel.cs
@@ -120,7 +120,7 @@ public sealed class PreviewSettingsTabViewModel : IToolContext, IPropertyEditorC
     {
     }
 
-    public void Dispose()
+    public ValueTask DisposeAsync()
     {
         foreach (IPropertyEditorContext? context in OnionSkinProperties
                      .Concat(FrameCacheProperties)
@@ -135,7 +135,9 @@ public sealed class PreviewSettingsTabViewModel : IToolContext, IPropertyEditorC
         _disposables.Dispose();
         _history.Dispose();
         _editorContext = null!;
+        return ValueTask.CompletedTask;
     }
+
 
     public void WriteToJson(JsonObject json)
     {

--- a/src/Beutl.Editor.Components/ProxiesTab/ViewModels/ProxiesTabViewModel.cs
+++ b/src/Beutl.Editor.Components/ProxiesTab/ViewModels/ProxiesTabViewModel.cs
@@ -24,7 +24,7 @@ using Reactive.Bindings.Extensions;
 
 namespace Beutl.Editor.Components.ProxiesTab.ViewModels;
 
-public sealed class ProxiesTabViewModel : IDisposable, IToolContext
+public sealed class ProxiesTabViewModel : IToolContext
 {
     private static readonly ProxyPreset[] s_presetOrder =
     [
@@ -386,15 +386,17 @@ public sealed class ProxiesTabViewModel : IDisposable, IToolContext
         }
     }
 
-    public void Dispose()
+    public ValueTask DisposeAsync()
     {
         if (_isDisposed)
-            return;
+            return ValueTask.CompletedTask;
 
         _isDisposed = true;
         ClearClips();
         _disposables.Dispose();
+        return ValueTask.CompletedTask;
     }
+
 
     public void WriteToJson(System.Text.Json.Nodes.JsonObject json)
     {

--- a/src/Beutl.Editor.Components/SceneSettingsTab/ViewModels/SceneSettingsTabViewModel.cs
+++ b/src/Beutl.Editor.Components/SceneSettingsTab/ViewModels/SceneSettingsTabViewModel.cs
@@ -192,13 +192,15 @@ public sealed class SceneSettingsTabViewModel : IToolContext
             && hasDuration && duration > TimeSpan.Zero;
     }
 
-    public void Dispose()
+    public ValueTask DisposeAsync()
     {
         _disposable.Dispose();
         _editorContext = null!;
         _scene = null!;
         _optionsProvider = null!;
+        return ValueTask.CompletedTask;
     }
+
 
     public void WriteToJson(JsonObject json)
     {

--- a/src/Beutl.Editor.Components/SceneSettingsTab/ViewModels/SceneSettingsTabViewModel.cs
+++ b/src/Beutl.Editor.Components/SceneSettingsTab/ViewModels/SceneSettingsTabViewModel.cs
@@ -18,6 +18,10 @@ public sealed class SceneSettingsTabViewModel : IToolContext
     private IEditorContext _editorContext;
     private Scene _scene;
     private ITimelineOptionsProvider _optionsProvider;
+    private readonly object _lifetimeGate = new();
+    private Task _activeApply = Task.CompletedTask;
+    private bool _disposed;
+    private bool _cleaned;
 
     public SceneSettingsTabViewModel(IEditorContext editorContext)
     {
@@ -69,37 +73,52 @@ public sealed class SceneSettingsTabViewModel : IToolContext
         Apply = new AsyncReactiveCommand(CanApply)
             .WithSubscribe(async () =>
             {
-                if (TryReadSceneSettings(out Media.PixelSize frameSize, out TimeSpan start, out TimeSpan duration))
+                TaskCompletionSource completion;
+                lock (_lifetimeGate)
                 {
-                    // Pause playback before rebuilding the renderer to avoid UI freeze.
-                    if ((frameSize != _scene.FrameSize
-                            || start != _scene.Start
-                            || duration != _scene.Duration)
-                        && _editorContext.GetService<IPreviewPlayer>() is { IsPlaying.Value: true } player)
+                    if (_disposed)
+                        return;
+                    completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                    _activeApply = completion.Task;
+                }
+                try
+                {
+                    if (TryReadSceneSettings(out Media.PixelSize frameSize, out TimeSpan start, out TimeSpan duration))
                     {
-                        await player.Pause();
-
-                        if (!TryReadSceneSettings(out frameSize, out start, out duration))
+                        // Pause playback before rebuilding the renderer to avoid UI freeze.
+                        if ((frameSize != _scene.FrameSize
+                                || start != _scene.Start
+                                || duration != _scene.Duration)
+                            && _editorContext.GetService<IPreviewPlayer>() is { IsPlaying.Value: true } player)
                         {
-                            // Pausing yielded to the UI thread, so the user may have invalidated an
-                            // input meanwhile. Warn instead of returning silently.
-                            NotificationService.ShowWarning(
-                                Strings.SceneSettings,
-                                MessageStrings.SceneSettings_ApplyCanceledInputsInvalid);
-                            return;
+                            await player.Pause();
+
+                            if (!TryReadSceneSettings(out frameSize, out start, out duration))
+                            {
+                                // Pausing yielded to the UI thread, so the user may have invalidated an
+                                // input meanwhile. Warn instead of returning silently.
+                                NotificationService.ShowWarning(
+                                    Strings.SceneSettings,
+                                    MessageStrings.SceneSettings_ApplyCanceledInputsInvalid);
+                                return;
+                            }
                         }
+
+                        _editorContext.GetRequiredService<ISceneSettingsService>().Apply(
+                            _scene,
+                            frameSize,
+                            start,
+                            duration);
+
+                        _optionsProvider.Options.Value = _optionsProvider.Options.Value with
+                        {
+                            MaxLayerCount = LayerCount.Value
+                        };
                     }
-
-                    _editorContext.GetRequiredService<ISceneSettingsService>().Apply(
-                        _scene,
-                        frameSize,
-                        start,
-                        duration);
-
-                    _optionsProvider.Options.Value = _optionsProvider.Options.Value with
-                    {
-                        MaxLayerCount = LayerCount.Value
-                    };
+                }
+                finally
+                {
+                    completion.TrySetResult();
                 }
             })
             .DisposeWith(_disposable);
@@ -192,13 +211,25 @@ public sealed class SceneSettingsTabViewModel : IToolContext
             && hasDuration && duration > TimeSpan.Zero;
     }
 
-    public ValueTask DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
+        Task pending;
+        lock (_lifetimeGate)
+        {
+            _disposed = true;
+            pending = _activeApply;
+        }
+        await pending;
+        lock (_lifetimeGate)
+        {
+            if (_cleaned)
+                return;
+            _cleaned = true;
+        }
         _disposable.Dispose();
         _editorContext = null!;
         _scene = null!;
         _optionsProvider = null!;
-        return ValueTask.CompletedTask;
     }
 
 

--- a/src/Beutl.Editor.Components/TerminalTab/ViewModels/TerminalTabViewModel.cs
+++ b/src/Beutl.Editor.Components/TerminalTab/ViewModels/TerminalTabViewModel.cs
@@ -123,7 +123,7 @@ public sealed class TerminalTabViewModel : IToolContext
         return null;
     }
 
-    public void Dispose()
+    public ValueTask DisposeAsync()
     {
         Disposed?.Invoke(this, EventArgs.Empty);
         Disposed = null;
@@ -132,7 +132,9 @@ public sealed class TerminalTabViewModel : IToolContext
         ExitCode.Dispose();
         _header.Dispose();
         TerminalTitle.Dispose();
+        return ValueTask.CompletedTask;
     }
+
 
     private string BuildHeader(string? reportedTitle)
     {

--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/TimelineTabViewModel.cs
@@ -436,7 +436,7 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
 
     public IReadOnlyReactiveProperty<string> Header { get; } = new ReactivePropertySlim<string>(Strings.Timeline);
 
-    public void Dispose()
+    public ValueTask DisposeAsync()
     {
         _logger.LogInformation("Disposing TimelineViewModel.");
         // Dispose は throw しない契約。HistoryManager が先に Dispose されている等で
@@ -484,7 +484,9 @@ public sealed class TimelineTabViewModel : IToolContext, IContextCommandHandler,
         LayerHeaders.Clear();
         Elements.Clear();
         _logger.LogInformation("TimelineViewModel disposed successfully.");
+        return ValueTask.CompletedTask;
     }
+
 
     private void DuplicateSelectedElements()
     {

--- a/src/Beutl.Editor.Components/TimelineTab/Views/InlineAnimationLayerHeader.axaml.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/InlineAnimationLayerHeader.axaml.cs
@@ -22,7 +22,7 @@ public partial class InlineAnimationLayerHeader : UserControl
         });
     }
 
-    private void OpenTab_Click(object? sender, RoutedEventArgs e)
+    private async void OpenTab_Click(object? sender, RoutedEventArgs e)
     {
         if (DataContext is InlineAnimationLayerViewModel viewModel
             && viewModel.Property is IAnimatablePropertyAdapter { Animation: KeyFrameAnimation kfAnimation })
@@ -34,7 +34,7 @@ public partial class InlineAnimationLayerHeader : UserControl
                 ?? new GraphEditorTabViewModel(editorContext);
             anmTimelineViewModel.Element.Value = viewModel.Element.Model;
             anmTimelineViewModel.Select(kfAnimation);
-            editorContext.OpenToolTab(anmTimelineViewModel);
+            await editorContext.OpenToolTabAsync(anmTimelineViewModel);
         }
     }
 

--- a/src/Beutl.Editor.Components/TimelineTab/Views/InlineAnimationLayerHeader.axaml.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/InlineAnimationLayerHeader.axaml.cs
@@ -34,7 +34,7 @@ public partial class InlineAnimationLayerHeader : UserControl
                 ?? new GraphEditorTabViewModel(editorContext);
             anmTimelineViewModel.Element.Value = viewModel.Element.Model;
             anmTimelineViewModel.Select(kfAnimation);
-            await editorContext.OpenToolTabAsync(anmTimelineViewModel);
+            await Beutl.Editor.Components.Helpers.ToolTabCallback.OpenAsync(editorContext, anmTimelineViewModel);
         }
     }
 

--- a/src/Beutl.Editor.Components/TimelineTab/Views/TimelineTabView.axaml.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/TimelineTabView.axaml.cs
@@ -692,7 +692,7 @@ public sealed partial class TimelineTabView : UserControl
             ViewModel.CalculateClickedLayer()));
     }
 
-    private void ShowSceneSettings(object? sender, RoutedEventArgs e)
+    private async void ShowSceneSettings(object? sender, RoutedEventArgs e)
     {
         if (ViewModel == null) return;
         IEditorContext editorContext = ViewModel.EditorContext;
@@ -703,7 +703,7 @@ public sealed partial class TimelineTabView : UserControl
         }
         else
         {
-            editorContext.OpenToolTab(new SceneSettingsTabViewModel(editorContext));
+            await editorContext.OpenToolTabAsync(new SceneSettingsTabViewModel(editorContext));
         }
     }
 

--- a/src/Beutl.Editor.Components/VersionControlTab/ViewModels/VersionControlTabViewModel.cs
+++ b/src/Beutl.Editor.Components/VersionControlTab/ViewModels/VersionControlTabViewModel.cs
@@ -805,11 +805,11 @@ internal sealed class VersionControlTabViewModel : IToolContext
     {
     }
 
-    public void Dispose()
+    public ValueTask DisposeAsync()
     {
         if (_disposed)
         {
-            return;
+            return ValueTask.CompletedTask;
         }
 
         _disposed = true;
@@ -845,6 +845,7 @@ internal sealed class VersionControlTabViewModel : IToolContext
         DiffLines.Clear();
         IsSelected.Dispose();
         _disposables.Dispose();
+        return ValueTask.CompletedTask;
     }
 
     internal Task<bool> RestoreAsync(CommitInfo commit)

--- a/src/Beutl.Extensibility/EditorContextHostToken.cs
+++ b/src/Beutl.Extensibility/EditorContextHostToken.cs
@@ -1,0 +1,12 @@
+﻿namespace Beutl.Extensibility;
+
+/// <summary>Opaque identity carried by a host-bound editor-context close capability.</summary>
+/// <remarks>
+/// Host tokens are compared by reference. A host creates one token and retains it for its
+/// lifetime; contexts created by that host must expose the same instance through their close
+/// capability. The public constructor allows independent host implementations to establish their
+/// own identity without exposing any meaningful token value.
+/// </remarks>
+public sealed class EditorContextHostToken
+{
+}

--- a/src/Beutl.Extensibility/EditorContextHostToken.cs
+++ b/src/Beutl.Extensibility/EditorContextHostToken.cs
@@ -1,12 +1,89 @@
-﻿namespace Beutl.Extensibility;
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace Beutl.Extensibility;
 
 /// <summary>Opaque identity carried by a host-bound editor-context close capability.</summary>
 /// <remarks>
 /// Host tokens are compared by reference. A host creates one token and retains it for its
 /// lifetime; contexts created by that host must expose the same instance through their close
-/// capability. The public constructor allows independent host implementations to establish their
-/// own identity without exposing any meaningful token value.
+/// capability. Independent host implementations use <see cref="TryAcquireContext"/> to claim each
+/// context before publication and hold the returned lease through asynchronous teardown.
 /// </remarks>
 public sealed class EditorContextHostToken
 {
+    private readonly object _ownershipGate = new();
+    private readonly Dictionary<IEditorContext, EditorContextOwnershipLease> _ownedContexts =
+        new(ReferenceEqualityComparer.Instance);
+
+    /// <summary>Attempts to acquire exclusive ownership of an editor context.</summary>
+    /// <remarks>
+    /// An editor host must acquire this lease before publishing a context and retain it until the
+    /// context has been unpublished and disposed. The operation is atomic across all hosts that use
+    /// this token, including contexts whose close capability is exposed through a wrapper.
+    /// </remarks>
+    /// <param name="context">The context the host is preparing to publish.</param>
+    /// <param name="lease">The exclusive ownership lease when the claim succeeds.</param>
+    /// <returns><see langword="true"/> when ownership was acquired; otherwise <see langword="false"/>.</returns>
+    public bool TryAcquireContext(
+        IEditorContext context,
+        [NotNullWhen(true)] out EditorContextOwnershipLease? lease)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        if (!ReferenceEquals(context.CloseService.HostToken, this))
+        {
+            lease = null;
+            return false;
+        }
+
+        lock (_ownershipGate)
+        {
+            if (_ownedContexts.ContainsKey(context))
+            {
+                lease = null;
+                return false;
+            }
+
+            lease = new EditorContextOwnershipLease(this, context);
+            _ownedContexts.Add(context, lease);
+            return true;
+        }
+    }
+
+    internal void Release(IEditorContext context, EditorContextOwnershipLease lease)
+    {
+        lock (_ownershipGate)
+        {
+            if (_ownedContexts.TryGetValue(context, out EditorContextOwnershipLease? current)
+                && ReferenceEquals(current, lease))
+            {
+                _ownedContexts.Remove(context);
+            }
+        }
+    }
+}
+
+/// <summary>Represents a host's exclusive ownership of one editor context.</summary>
+/// <remarks>
+/// Dispose the lease only after the context is no longer published and its asynchronous disposal
+/// has completed. Disposal is idempotent.
+/// </remarks>
+public sealed class EditorContextOwnershipLease : IDisposable
+{
+    private readonly IEditorContext _context;
+    private EditorContextHostToken? _hostToken;
+
+    internal EditorContextOwnershipLease(
+        EditorContextHostToken hostToken,
+        IEditorContext context)
+    {
+        _hostToken = hostToken;
+        _context = context;
+    }
+
+    /// <summary>Releases the ownership claim.</summary>
+    public void Dispose()
+    {
+        EditorContextHostToken? current = Interlocked.Exchange(ref _hostToken, null);
+        current?.Release(_context, this);
+    }
 }

--- a/src/Beutl.Extensibility/EditorExtension.cs
+++ b/src/Beutl.Extensibility/EditorExtension.cs
@@ -24,8 +24,10 @@ public abstract class EditorExtension : ViewExtension
     /// Host services owned by the composition root and passed in explicitly. A successful
     /// implementation must retain <see cref="IEditorContextServices.CloseService"/> and expose it,
     /// directly or through a context-specific wrapper, through
-    /// <see cref="IEditorContext.CloseService"/>. The extension provider is available for querying
-    /// other extensions.
+    /// <see cref="IEditorContext.CloseService"/>. The wrapper must forward the same stable,
+    /// non-null <see cref="IEditorContextCloseService.HostToken"/> so the context cannot be
+    /// attached to another editor host. The extension provider is available for querying other
+    /// extensions.
     /// </param>
     /// <param name="context">The created editor context, set when this returns <see langword="true"/>.</param>
     /// <returns><see langword="true"/> if a context was created for <paramref name="obj"/>.</returns>

--- a/src/Beutl.Extensibility/EditorExtension.cs
+++ b/src/Beutl.Extensibility/EditorExtension.cs
@@ -42,6 +42,8 @@ public abstract class EditorExtension : ViewExtension
     /// publication step fails. The returned context must be newly created and unowned; returning a
     /// context that is already active in a tab violates the ownership contract. On failure, the
     /// extension must dispose any partially initialized state and must not return a context.
+    /// Implementations must not synchronously start and wait for a project or editor lifecycle
+    /// operation, on this thread or another; enqueue that work to begin after this callback returns.
     /// </remarks>
     public abstract bool TryCreateContext(
         CoreObject obj,

--- a/src/Beutl.Extensibility/EditorExtension.cs
+++ b/src/Beutl.Extensibility/EditorExtension.cs
@@ -39,9 +39,9 @@ public abstract class EditorExtension : ViewExtension
     /// When a ProjectItem is needed here, obtain it from the ProjectItemContainer. Returning a
     /// context without the supplied close capability violates the host ownership contract. After a
     /// successful return, the host owns disposal exactly once, including when a later attachment or
-    /// publication step fails. On failure, the extension must dispose any partially initialized
-    /// state and must not return a context. A context rejected because it is foreign or already
-    /// owned by another tab is a caller-owned value in direct replacement APIs and is not consumed.
+    /// publication step fails. The returned context must be newly created and unowned; returning a
+    /// context that is already active in a tab violates the ownership contract. On failure, the
+    /// extension must dispose any partially initialized state and must not return a context.
     /// </remarks>
     public abstract bool TryCreateContext(
         CoreObject obj,

--- a/src/Beutl.Extensibility/EditorExtension.cs
+++ b/src/Beutl.Extensibility/EditorExtension.cs
@@ -21,14 +21,17 @@ public abstract class EditorExtension : ViewExtension
     /// </summary>
     /// <param name="obj">The object to open in the editor.</param>
     /// <param name="services">
-    /// Host services the created context may need — e.g. <see cref="IEditorContextServices.ExtensionProvider"/>
-    /// for querying other extensions. Owned by the composition root and passed in explicitly. An
-    /// extension that needs nothing from the host may ignore it.
+    /// Host services owned by the composition root and passed in explicitly. A successful
+    /// implementation must retain <see cref="IEditorContextServices.CloseService"/> and expose it,
+    /// directly or through a context-specific wrapper, through
+    /// <see cref="IEditorContext.CloseService"/>. The extension provider is available for querying
+    /// other extensions.
     /// </param>
     /// <param name="context">The created editor context, set when this returns <see langword="true"/>.</param>
     /// <returns><see langword="true"/> if a context was created for <paramref name="obj"/>.</returns>
     /// <remarks>
-    /// When a ProjectItem is needed here, obtain it from the ProjectItemContainer.
+    /// When a ProjectItem is needed here, obtain it from the ProjectItemContainer. Returning a
+    /// context without the supplied close capability violates the host ownership contract.
     /// </remarks>
     public abstract bool TryCreateContext(
         CoreObject obj,

--- a/src/Beutl.Extensibility/EditorExtension.cs
+++ b/src/Beutl.Extensibility/EditorExtension.cs
@@ -30,10 +30,18 @@ public abstract class EditorExtension : ViewExtension
     /// extensions.
     /// </param>
     /// <param name="context">The created editor context, set when this returns <see langword="true"/>.</param>
-    /// <returns><see langword="true"/> if a context was created for <paramref name="obj"/>.</returns>
+    /// <returns>
+    /// <see langword="true"/> when a new, non-null context was created and ownership is transferred
+    /// to the host; otherwise <see langword="false"/> with <paramref name="context"/> set to
+    /// <see langword="null"/>.
+    /// </returns>
     /// <remarks>
     /// When a ProjectItem is needed here, obtain it from the ProjectItemContainer. Returning a
-    /// context without the supplied close capability violates the host ownership contract.
+    /// context without the supplied close capability violates the host ownership contract. After a
+    /// successful return, the host owns disposal exactly once, including when a later attachment or
+    /// publication step fails. On failure, the extension must dispose any partially initialized
+    /// state and must not return a context. A context rejected because it is foreign or already
+    /// owned by another tab is a caller-owned value in direct replacement APIs and is not consumed.
     /// </remarks>
     public abstract bool TryCreateContext(
         CoreObject obj,

--- a/src/Beutl.Extensibility/EditorExtension.cs
+++ b/src/Beutl.Extensibility/EditorExtension.cs
@@ -17,7 +17,7 @@ public abstract class EditorExtension : ViewExtension
         [NotNullWhen(true)] out Control? editor);
 
     /// <summary>
-    /// Creates the editor context for <paramref name="obj"/>.
+    /// Asynchronously creates the editor context for <paramref name="obj"/>.
     /// </summary>
     /// <param name="obj">The object to open in the editor.</param>
     /// <param name="services">
@@ -29,26 +29,23 @@ public abstract class EditorExtension : ViewExtension
     /// attached to another editor host. The extension provider is available for querying other
     /// extensions.
     /// </param>
-    /// <param name="context">The created editor context, set when this returns <see langword="true"/>.</param>
     /// <returns>
-    /// <see langword="true"/> when a new, non-null context was created and ownership is transferred
-    /// to the host; otherwise <see langword="false"/> with <paramref name="context"/> set to
-    /// <see langword="null"/>.
+    /// A new context whose ownership is transferred to the host, or <see langword="null"/> after
+    /// all partial initialization state has been asynchronously cleaned up.
     /// </returns>
     /// <remarks>
     /// When a ProjectItem is needed here, obtain it from the ProjectItemContainer. Returning a
-    /// context without the supplied close capability violates the host ownership contract. After a
-    /// successful return, the host owns disposal exactly once, including when a later attachment or
+    /// context without the supplied close capability violates the host ownership contract. A
+    /// non-null return transfers disposal to the host exactly once, including when a later attachment or
     /// publication step fails. The returned context must be newly created and unowned; returning a
-    /// context that is already active in a tab violates the ownership contract. On failure, the
-    /// extension must dispose any partially initialized state and must not return a context.
+    /// context that is already active in a tab violates the ownership contract. Before returning
+    /// <see langword="null"/>, the extension must await disposal of any partially initialized state.
     /// Implementations must not synchronously start and wait for a project or editor lifecycle
     /// operation, on this thread or another; enqueue that work to begin after this callback returns.
     /// </remarks>
-    public abstract bool TryCreateContext(
+    public abstract ValueTask<IEditorContext?> CreateContextAsync(
         CoreObject obj,
-        IEditorContextServices services,
-        [NotNullWhen(true)] out IEditorContext? context);
+        IEditorContextServices services);
 
     public virtual bool IsSupported(string? file)
     {

--- a/src/Beutl.Extensibility/IEditorContext.cs
+++ b/src/Beutl.Extensibility/IEditorContext.cs
@@ -5,6 +5,11 @@ namespace Beutl.Extensibility;
 public interface IEditorContext : IAsyncDisposable, IServiceProvider
 {
     /// <summary>Asynchronously releases the editor context and completes after all owned resources are closed.</summary>
+    /// <remarks>
+    /// Do not synchronously wait for disposal from a host publication or dispatcher callback. Resolve
+    /// <see cref="IEditorContextCloseService"/> from <see cref="IEditorContextServices"/> and request
+    /// host closure instead; its completion can be observed after the callback returns.
+    /// </remarks>
     new ValueTask DisposeAsync();
 
     CoreObject Object { get; }

--- a/src/Beutl.Extensibility/IEditorContext.cs
+++ b/src/Beutl.Extensibility/IEditorContext.cs
@@ -4,11 +4,20 @@ namespace Beutl.Extensibility;
 
 public interface IEditorContext : IAsyncDisposable, IServiceProvider
 {
+    /// <summary>Gets the host close capability retained by this editor context.</summary>
+    /// <remarks>
+    /// Every context returned from <see cref="EditorExtension.TryCreateContext"/> must expose
+    /// the capability supplied by <see cref="IEditorContextServices"/>, directly or through a
+    /// context-specific wrapper. Tool-tab extensions call it with this context and must not fall
+    /// back to synchronous disposal.
+    /// </remarks>
+    IEditorContextCloseService CloseService { get; }
+
     /// <summary>Asynchronously releases the editor context and completes after all owned resources are closed.</summary>
     /// <remarks>
-    /// Do not synchronously wait for disposal from a host publication or dispatcher callback. Resolve
-    /// <see cref="IEditorContextCloseService"/> from <see cref="IEditorContextServices"/> and request
-    /// host closure instead; its completion can be observed after the callback returns.
+    /// Do not synchronously wait for disposal from a host publication or dispatcher callback. Call
+    /// <see cref="CloseService"/>.<see cref="IEditorContextCloseService.RequestClose"/> instead; its
+    /// completion can be observed after the callback returns.
     /// </remarks>
     new ValueTask DisposeAsync();
 

--- a/src/Beutl.Extensibility/IEditorContext.cs
+++ b/src/Beutl.Extensibility/IEditorContext.cs
@@ -8,8 +8,9 @@ public interface IEditorContext : IAsyncDisposable, IServiceProvider
     /// <remarks>
     /// Every context returned from <see cref="EditorExtension.TryCreateContext"/> must expose
     /// the capability supplied by <see cref="IEditorContextServices"/>, directly or through a
-    /// context-specific wrapper. Tool-tab extensions call it with this context and must not fall
-    /// back to synchronous disposal.
+    /// context-specific wrapper. This property is the canonical close-capability access path;
+    /// implementations must not duplicate it through <see cref="IServiceProvider.GetService"/>.
+    /// Tool-tab extensions call it with this context and must not fall back to synchronous disposal.
     /// </remarks>
     IEditorContextCloseService CloseService { get; }
 

--- a/src/Beutl.Extensibility/IEditorContext.cs
+++ b/src/Beutl.Extensibility/IEditorContext.cs
@@ -2,8 +2,11 @@
 
 namespace Beutl.Extensibility;
 
-public interface IEditorContext : IDisposable, IAsyncDisposable, IServiceProvider
+public interface IEditorContext : IAsyncDisposable, IServiceProvider
 {
+    /// <summary>Asynchronously releases the editor context and completes after all owned resources are closed.</summary>
+    new ValueTask DisposeAsync();
+
     CoreObject Object { get; }
 
     EditorExtension Extension { get; }
@@ -18,17 +21,19 @@ public interface IEditorContext : IDisposable, IAsyncDisposable, IServiceProvide
     T? FindToolTab<T>()
         where T : IToolContext;
 
-    bool OpenToolTab(IToolContext item);
+    /// <summary>Transfers ownership of a tool context to the editor host.</summary>
+    /// <returns>
+    /// <see langword="true"/> when the tab was opened or activated; otherwise
+    /// <see langword="false"/> after the supplied context has been disposed.
+    /// </returns>
+    /// <remarks>The supplied context is consumed for both return values and must not be reused.</remarks>
+    ValueTask<bool> OpenToolTabAsync(IToolContext item);
 
-    void CloseToolTab(IToolContext item);
-
-    void IDisposable.Dispose()
-    {
-    }
-
-    ValueTask IAsyncDisposable.DisposeAsync()
-    {
-        Dispose();
-        return ValueTask.CompletedTask;
-    }
+    /// <summary>Closes a host-owned tool tab and completes after its asynchronous teardown has finished.</summary>
+    /// <remarks>
+    /// A close reentered from an <see cref="IToolContext.DisposeAsync"/> callback is scheduled and
+    /// returns without awaiting a sibling callback, so mutually closing tools cannot deadlock. The
+    /// enclosing host layout or editor teardown joins every scheduled close before it completes.
+    /// </remarks>
+    ValueTask CloseToolTabAsync(IToolContext item);
 }

--- a/src/Beutl.Extensibility/IEditorContext.cs
+++ b/src/Beutl.Extensibility/IEditorContext.cs
@@ -18,7 +18,9 @@ public interface IEditorContext : IAsyncDisposable, IServiceProvider
     /// <remarks>
     /// Do not synchronously wait for disposal from a host publication or dispatcher callback. Call
     /// <see cref="CloseService"/>.<see cref="IEditorContextCloseService.RequestClose"/> instead; its
-    /// completion can be observed after the callback returns.
+    /// completion can be observed after the callback returns. Disposal callbacks must not
+    /// synchronously start and wait for another project or editor lifecycle operation on any thread;
+    /// enqueue that work to begin after the callback returns.
     /// </remarks>
     new ValueTask DisposeAsync();
 

--- a/src/Beutl.Extensibility/IEditorContext.cs
+++ b/src/Beutl.Extensibility/IEditorContext.cs
@@ -6,7 +6,7 @@ public interface IEditorContext : IAsyncDisposable, IServiceProvider
 {
     /// <summary>Gets the host close capability retained by this editor context.</summary>
     /// <remarks>
-    /// Every context returned from <see cref="EditorExtension.TryCreateContext"/> must expose
+    /// Every context returned from <see cref="EditorExtension.CreateContextAsync"/> must expose
     /// the capability supplied by <see cref="IEditorContextServices"/>, directly or through a
     /// context-specific wrapper. This property is the canonical close-capability access path;
     /// implementations must not duplicate it through <see cref="IServiceProvider.GetService"/>.
@@ -41,9 +41,13 @@ public interface IEditorContext : IAsyncDisposable, IServiceProvider
     /// <summary>Transfers ownership of a tool context to the editor host.</summary>
     /// <returns>
     /// <see langword="true"/> when the tab was opened or activated; otherwise
-    /// <see langword="false"/> after the supplied context has been disposed.
+    /// <see langword="false"/> after a fresh rejected context has been disposed. A context already
+    /// owned by another tool host remains live under that owner and is not consumed.
     /// </returns>
-    /// <remarks>The supplied context is consumed for both return values and must not be reused.</remarks>
+    /// <remarks>
+    /// The caller must not reuse or dispose the supplied context after either return value. On a
+    /// foreign-ownership rejection, the original host retains its existing ownership.
+    /// </remarks>
     ValueTask<bool> OpenToolTabAsync(IToolContext item);
 
     /// <summary>Closes a host-owned tool tab and completes after its asynchronous teardown has finished.</summary>

--- a/src/Beutl.Extensibility/IEditorContextCloseService.cs
+++ b/src/Beutl.Extensibility/IEditorContextCloseService.cs
@@ -3,6 +3,17 @@
 /// <summary>Requests host-owned editor-context closure without synchronously joining teardown.</summary>
 public interface IEditorContextCloseService
 {
+    /// <summary>
+    /// Gets the opaque host identity for this close capability.
+    /// </summary>
+    /// <remarks>
+    /// A context must retain the capability supplied by its creating host, including this token.
+    /// Hosts compare the token by reference when attaching or replacing a context so a context
+    /// cannot route close requests to a different host. Implementations must return a stable,
+    /// non-null token for the lifetime of the capability.
+    /// </remarks>
+    EditorContextHostToken HostToken { get; }
+
     /// <summary>Requests closure of the tab that owns <paramref name="context"/>.</summary>
     /// <remarks>
     /// Observer and dispatcher callbacks should retain or ignore the returned completion instead of

--- a/src/Beutl.Extensibility/IEditorContextCloseService.cs
+++ b/src/Beutl.Extensibility/IEditorContextCloseService.cs
@@ -1,0 +1,52 @@
+﻿namespace Beutl.Extensibility;
+
+/// <summary>Requests host-owned editor-context closure without synchronously joining teardown.</summary>
+public interface IEditorContextCloseService
+{
+    /// <summary>Requests closure of the tab that owns <paramref name="context"/>.</summary>
+    /// <remarks>
+    /// Observer and dispatcher callbacks should retain or ignore the returned completion instead of
+    /// synchronously waiting for it. Normal disposal remains available through
+    /// <see cref="IEditorContext.DisposeAsync"/>.
+    /// </remarks>
+    EditorContextCloseRequest RequestClose(IEditorContext context);
+}
+
+/// <summary>The result of requesting host-owned editor-context closure.</summary>
+/// <remarks>
+/// For <see cref="EditorContextCloseRequestStatus.Accepted"/> and
+/// <see cref="EditorContextCloseRequestStatus.AlreadyClosing"/>, <see cref="Completion"/> covers
+/// physical tab removal and context teardown and propagates their failures. A
+/// <see cref="EditorContextCloseRequestStatus.NotOwned"/> request is a completed no-op. The default
+/// value is also a valid <c>NotOwned</c> result.
+/// </remarks>
+public readonly struct EditorContextCloseRequest
+{
+    private readonly Task? _completion;
+
+    public EditorContextCloseRequest(
+        EditorContextCloseRequestStatus status,
+        Task completion)
+    {
+        ArgumentNullException.ThrowIfNull(completion);
+        Status = status;
+        _completion = completion;
+    }
+
+    public EditorContextCloseRequestStatus Status { get; }
+
+    public Task Completion => _completion ?? Task.CompletedTask;
+}
+
+/// <summary>Describes whether an editor-context close request was accepted by its host.</summary>
+public enum EditorContextCloseRequestStatus
+{
+    /// <summary>The context is not owned by this host.</summary>
+    NotOwned,
+
+    /// <summary>A new terminal close was accepted.</summary>
+    Accepted,
+
+    /// <summary>The context was already closing; <see cref="EditorContextCloseRequest.Completion"/> joins it.</summary>
+    AlreadyClosing
+}

--- a/src/Beutl.Extensibility/IEditorContextCloseService.cs
+++ b/src/Beutl.Extensibility/IEditorContextCloseService.cs
@@ -10,7 +10,8 @@ public interface IEditorContextCloseService
     /// A context must retain the capability supplied by its creating host, including this token.
     /// Hosts compare the token by reference when attaching or replacing a context so a context
     /// cannot route close requests to a different host. Implementations must return a stable,
-    /// non-null token for the lifetime of the capability.
+    /// non-null token for the lifetime of the capability and acquire an ownership lease before
+    /// publishing each context.
     /// </remarks>
     EditorContextHostToken HostToken { get; }
 

--- a/src/Beutl.Extensibility/IEditorContextServices.cs
+++ b/src/Beutl.Extensibility/IEditorContextServices.cs
@@ -5,7 +5,9 @@ namespace Beutl.Extensibility;
 /// <summary>
 /// Host services supplied to <see cref="EditorExtension.TryCreateContext"/> so a created
 /// <see cref="IEditorContext"/> can reach host capabilities. The host owns the instance and
-/// passes it in explicitly; an extension that needs nothing from the host may ignore it.
+/// passes it in explicitly. Every successful context creation must retain
+/// <see cref="CloseService"/> and expose it, directly or through a context-specific wrapper,
+/// through <see cref="IEditorContext.CloseService"/>.
 /// </summary>
 public interface IEditorContextServices
 {
@@ -14,6 +16,9 @@ public interface IEditorContextServices
     /// Executable extension instances must not be retained beyond their lease.
     /// </summary>
     IExtensionProvider ExtensionProvider { get; }
+
+    /// <summary>Gets the required host close capability to retain on the created context.</summary>
+    IEditorContextCloseService CloseService { get; }
 
     /// <summary>
     /// Resolves a host-provided service of type <typeparamref name="T"/> by type. This is the

--- a/src/Beutl.Extensibility/IEditorContextServices.cs
+++ b/src/Beutl.Extensibility/IEditorContextServices.cs
@@ -3,7 +3,7 @@
 namespace Beutl.Extensibility;
 
 /// <summary>
-/// Host services supplied to <see cref="EditorExtension.TryCreateContext"/> so a created
+/// Host services supplied to <see cref="EditorExtension.CreateContextAsync"/> so a created
 /// <see cref="IEditorContext"/> can reach host capabilities. The host owns the instance and
 /// passes it in explicitly. Every successful context creation must retain
 /// <see cref="CloseService"/> and expose it, directly or through a context-specific wrapper,

--- a/src/Beutl.Extensibility/IEditorContextServices.cs
+++ b/src/Beutl.Extensibility/IEditorContextServices.cs
@@ -7,7 +7,8 @@ namespace Beutl.Extensibility;
 /// <see cref="IEditorContext"/> can reach host capabilities. The host owns the instance and
 /// passes it in explicitly. Every successful context creation must retain
 /// <see cref="CloseService"/> and expose it, directly or through a context-specific wrapper,
-/// through <see cref="IEditorContext.CloseService"/>.
+/// through <see cref="IEditorContext.CloseService"/>. The retained capability must preserve its
+/// stable, non-null <see cref="IEditorContextCloseService.HostToken"/>.
 /// </summary>
 public interface IEditorContextServices
 {
@@ -18,6 +19,10 @@ public interface IEditorContextServices
     IExtensionProvider ExtensionProvider { get; }
 
     /// <summary>Gets the required host close capability to retain on the created context.</summary>
+    /// <remarks>
+    /// The capability's <see cref="IEditorContextCloseService.HostToken"/> identifies this host;
+    /// wrappers must forward close requests to this capability and expose the same token instance.
+    /// </remarks>
     IEditorContextCloseService CloseService { get; }
 
     /// <summary>

--- a/src/Beutl.Extensibility/SceneEditorTabExtension.cs
+++ b/src/Beutl.Extensibility/SceneEditorTabExtension.cs
@@ -5,8 +5,11 @@ using Reactive.Bindings;
 
 namespace Beutl.Extensibility;
 
-public interface IToolContext : IDisposable, IJsonSerializable, IServiceProvider
+public interface IToolContext : IAsyncDisposable, IJsonSerializable, IServiceProvider
 {
+    /// <summary>Asynchronously releases this tool context; completion means ownership has ended.</summary>
+    new ValueTask DisposeAsync();
+
     ToolTabExtension Extension { get; }
 
     IReactiveProperty<bool> IsSelected { get; }

--- a/src/Beutl.Extensibility/ToolContextHostToken.cs
+++ b/src/Beutl.Extensibility/ToolContextHostToken.cs
@@ -1,0 +1,67 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+
+namespace Beutl.Extensibility;
+
+/// <summary>Coordinates exclusive ownership of tool contexts across editor hosts.</summary>
+/// <remarks>
+/// Each editor context creates one token for its tool host. Claim a tool context before publishing
+/// it and retain the returned lease until asynchronous teardown completes. Claims are process-wide,
+/// so the same tool instance cannot be published by two independent editor contexts.
+/// </remarks>
+public sealed class ToolContextHostToken
+{
+    private static readonly object s_ownershipGate = new();
+    private static readonly ConditionalWeakTable<IToolContext, ToolContextOwnershipLease> s_owners = new();
+
+    /// <summary>Attempts to acquire exclusive ownership of a tool context.</summary>
+    public bool TryAcquireContext(
+        IToolContext context,
+        [NotNullWhen(true)] out ToolContextOwnershipLease? lease)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        lock (s_ownershipGate)
+        {
+            if (s_owners.TryGetValue(context, out _))
+            {
+                lease = null;
+                return false;
+            }
+
+            lease = new ToolContextOwnershipLease(context);
+            s_owners.Add(context, lease);
+            return true;
+        }
+    }
+
+    internal static void Release(IToolContext context, ToolContextOwnershipLease lease)
+    {
+        lock (s_ownershipGate)
+        {
+            if (s_owners.TryGetValue(context, out ToolContextOwnershipLease? current)
+                && ReferenceEquals(current, lease))
+            {
+                s_owners.Remove(context);
+            }
+        }
+    }
+}
+
+/// <summary>Represents one editor tool host's exclusive claim on a tool context.</summary>
+public sealed class ToolContextOwnershipLease : IDisposable
+{
+    private IToolContext? _context;
+
+    internal ToolContextOwnershipLease(IToolContext context)
+    {
+        _context = context;
+    }
+
+    /// <summary>Releases the ownership claim. Disposal is idempotent.</summary>
+    public void Dispose()
+    {
+        IToolContext? context = Interlocked.Exchange(ref _context, null);
+        if (context is not null)
+            ToolContextHostToken.Release(context, this);
+    }
+}

--- a/src/Beutl.PackageTools.UI/Services/AsyncOperationLifetime.cs
+++ b/src/Beutl.PackageTools.UI/Services/AsyncOperationLifetime.cs
@@ -137,6 +137,10 @@ internal sealed class AsyncOperationLifetime : IAsyncDisposable
         Exception? cancellationFailure = null;
         try
         {
+            // Cancel the transport before signaling operation cancellation. The
+            // latter invokes user callbacks synchronously; doing it first lets
+            // an operation observe cancellation and resume before the transport
+            // cancellation hook has run, making shutdown ordering nondeterministic.
             _cancelPendingRequests();
         }
         catch (Exception ex)

--- a/src/Beutl/AgentHost/EditorProjectSessionGateway.cs
+++ b/src/Beutl/AgentHost/EditorProjectSessionGateway.cs
@@ -23,7 +23,7 @@ public sealed class EditorProjectSessionGateway(
             if (projectService.CurrentProject.Value is { } current)
             {
                 RequireSameProject(current, fullPath);
-                return AttachToOpenProject(current);
+                return await AttachToOpenProjectAsync(current);
             }
 
             await projectService.OpenProject(fullPath);
@@ -36,7 +36,7 @@ public sealed class EditorProjectSessionGateway(
                     "Check the editor notification for the failure reason (unreadable file, version mismatch, ...)."));
             }
 
-            return AttachToOpenProject(opened);
+            return await AttachToOpenProjectAsync(opened);
         });
     }
 
@@ -71,7 +71,7 @@ public sealed class EditorProjectSessionGateway(
 
     public async ValueTask<ProjectSceneResult> AddSceneAsync(IEditingSession activeSession, SceneCreateOptions options, CancellationToken cancellationToken = default)
     {
-        return await Dispatcher.UIThread.InvokeAsync(() =>
+        return await Dispatcher.UIThread.InvokeAsync(async () =>
         {
             if (activeSession is LiveEditingSession liveSession && !liveSession.ProbeIsAlive())
             {
@@ -114,7 +114,7 @@ public sealed class EditorProjectSessionGateway(
             }
             // add_scene activates the new scene's tab, so rebind the live session to it; otherwise
             // read_document/apply_edit would keep operating on the previously attached EditViewModel.
-            LiveEditingSession session = AttachScene(scene);
+            LiveEditingSession session = await AttachSceneAsync(scene);
             return new ProjectSceneResult(scene, project, session);
         });
     }
@@ -132,7 +132,7 @@ public sealed class EditorProjectSessionGateway(
         }
     }
 
-    private ProjectSessionResult AttachToOpenProject(Project project)
+    private async Task<ProjectSessionResult> AttachToOpenProjectAsync(Project project)
     {
         Scene scene = project.Items.OfType<Scene>().FirstOrDefault()
                       ?? throw new ReconcileException(new ToolError(
@@ -140,12 +140,12 @@ public sealed class EditorProjectSessionGateway(
                           "The project does not contain a scene.",
                           project.Uri?.LocalPath));
 
-        return new ProjectSessionResult(AttachScene(scene), project);
+        return new ProjectSessionResult(await AttachSceneAsync(scene), project);
     }
 
-    private LiveEditingSession AttachScene(Scene scene)
+    private async Task<LiveEditingSession> AttachSceneAsync(Scene scene)
     {
-        editorService.ActivateTabItem(scene);
+        await editorService.ActivateTabItemAsync(scene);
         if (editorService.SelectedTabItem.Value?.Context.Value is not EditViewModel editViewModel)
         {
             throw new ReconcileException(new ToolError(

--- a/src/Beutl/Services/EditorContextReplacementResult.cs
+++ b/src/Beutl/Services/EditorContextReplacementResult.cs
@@ -1,0 +1,43 @@
+﻿namespace Beutl.Services;
+
+/// <summary>Describes the result of replacing an editor tab's context.</summary>
+internal readonly struct EditorContextReplacementResult
+{
+    internal EditorContextReplacementResult(
+        EditorContextReplacementStatus status,
+        bool inputConsumed)
+    {
+        Status = status;
+        InputConsumed = inputConsumed;
+    }
+
+    /// <summary>Gets the replacement outcome.</summary>
+    internal EditorContextReplacementStatus Status { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the replacement operation consumed the supplied context.
+    /// </summary>
+    internal bool InputConsumed { get; }
+
+    /// <summary>Gets a value indicating whether the context was accepted by the tab.</summary>
+    internal bool Succeeded => Status == EditorContextReplacementStatus.Succeeded;
+}
+
+/// <summary>Describes why an editor-context replacement completed.</summary>
+public enum EditorContextReplacementStatus
+{
+    /// <summary>The extension did not create a context.</summary>
+    CreationFailed,
+
+    /// <summary>The context was published and ownership transferred to the tab.</summary>
+    Succeeded,
+
+    /// <summary>The tab is not owned by this host, or the factory result already belongs to another owner.</summary>
+    NotOwned,
+
+    /// <summary>The factory returned the context that is already active in this tab.</summary>
+    AlreadyActive,
+
+    /// <summary>The tab changed, is closing, or has another replacement in progress.</summary>
+    Busy
+}

--- a/src/Beutl/Services/EditorContextServices.cs
+++ b/src/Beutl/Services/EditorContextServices.cs
@@ -12,6 +12,8 @@ internal sealed class EditorContextServices(EditorService editorService, Extensi
 {
     IExtensionProvider IEditorContextServices.ExtensionProvider => extensionProvider;
 
+    IEditorContextCloseService IEditorContextServices.CloseService => editorService;
+
     public bool TryGetService<T>([NotNullWhen(true)] out T? service)
         where T : class
     {

--- a/src/Beutl/Services/EditorService.cs
+++ b/src/Beutl/Services/EditorService.cs
@@ -989,7 +989,10 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
     private long _contextRegistrationGeneration;
     private readonly object _lifecycleTeardownGate = new();
     private readonly HashSet<DeferredLifecycleTeardown> _activeLifecycleTeardowns = [];
-    private readonly Queue<Exception> _deferredLifecycleFailures = new();
+    private readonly Dictionary<Task, DeferredLifecycleTeardown> _lifecycleTeardownsByTask = [];
+    private readonly Dictionary<TabAdmissionOperation, DeferredLifecycleTeardown> _lifecycleTeardownsByOperation = [];
+    private readonly HashSet<DeferredLifecycleTeardown> _deferredLifecycleFailures = [];
+    private LifecycleTeardownDrain? _lifecycleTeardownDrain;
 
     internal Action? BeforeInitialOwnerAttach { get; set; }
 
@@ -1283,23 +1286,52 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
 
     private sealed class DeferredLifecycleTeardown
     {
-        public DeferredLifecycleTeardown(Task task)
+        public DeferredLifecycleTeardown(Task task, TabAdmissionOperation operation)
         {
             Task = task;
+            Operation = operation;
         }
 
-        public DeferredLifecycleTeardown()
+        public DeferredLifecycleTeardown(TabAdmissionOperation operation)
         {
             Completion = new TaskCompletionSource(
                 TaskCreationOptions.RunContinuationsAsynchronously);
             Task = Completion.Task;
+            Operation = operation;
         }
 
         public Task Task { get; }
 
         public TaskCompletionSource? Completion { get; }
 
+        public TabAdmissionOperation Operation { get; }
+
+        public HashSet<DeferredLifecycleTeardown> Dependencies { get; } = [];
+
         public bool Taken { get; set; }
+    }
+
+    private sealed class LifecycleTeardownDrain
+    {
+        public HashSet<DeferredLifecycleTeardown> Pending { get; } = [];
+
+        public HashSet<TabAdmissionOperation> Roots { get; } = [];
+
+        public bool Closed { get; set; }
+
+        public bool Includes(DeferredLifecycleTeardown teardown)
+            => IncludesOperation(teardown.Operation);
+
+        public bool IncludesOperation(TabAdmissionOperation? operation)
+        {
+            for (; operation is not null; operation = operation.Parent)
+            {
+                if (Roots.Contains(operation))
+                    return true;
+            }
+
+            return false;
+        }
     }
 
     internal static bool IsTabLifecycleOperationActive
@@ -1839,6 +1871,8 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
                 TrackHostClose,
                 out completion,
                 out completionSource);
+            if (status == EditorContextCloseRequestStatus.AlreadyClosing)
+                AdoptLifecycleTeardown(completion);
         }
 
         return StartHostClose(
@@ -1850,11 +1884,20 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
 
     private EditorContextCloseRequest RequestClose(EditorTabItem item)
     {
-        EditorContextCloseRequestStatus status = item.TryBeginHostClose(
-            _hostToken,
-            TrackHostClose,
-            out Task completion,
-            out TaskCompletionSource<object?>? completionSource);
+        EditorContextCloseRequestStatus status;
+        Task completion;
+        TaskCompletionSource<object?>? completionSource;
+        lock (_contextRegistryGate)
+        {
+            status = item.TryBeginHostClose(
+                _hostToken,
+                TrackHostClose,
+                out completion,
+                out completionSource);
+            if (status == EditorContextCloseRequestStatus.AlreadyClosing)
+                AdoptLifecycleTeardown(completion);
+        }
+
         return StartHostClose(item, status, completion, completionSource);
     }
 
@@ -1883,7 +1926,6 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
                 startupFailure);
             ObserveDeferredTaskFailure(completion);
         }
-
         return new EditorContextCloseRequest(
             status,
             completion);
@@ -1901,7 +1943,8 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
         try
         {
             previousOperation = s_tabAdmissionOperation.Value;
-            operation = BeginTabAdmissionOperation();
+            operation = GetLifecycleTeardownOperation(hostCloseTask)
+                ?? BeginTabAdmissionOperation();
             s_tabAdmissionOperation.Value = operation;
 
             try { await RemoveTabItemAsync(item).ConfigureAwait(false); }
@@ -1925,10 +1968,35 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
         CompleteTrackedHostClose(completion, hostCloseTask, failures);
     }
 
-    private void TrackHostClose(Task completion)
+    private TabAdmissionOperation? GetLifecycleTeardownOperation(Task teardownTask)
     {
         lock (_lifecycleTeardownGate)
-            _activeLifecycleTeardowns.Add(new DeferredLifecycleTeardown(completion));
+        {
+            return _lifecycleTeardownsByTask.TryGetValue(teardownTask, out DeferredLifecycleTeardown? teardown)
+                ? teardown.Operation
+                : null;
+        }
+    }
+
+    private void TrackHostClose(Task completion)
+    {
+        var teardown = new DeferredLifecycleTeardown(
+            completion,
+            new TabAdmissionOperation(this, s_tabAdmissionOperation.Value));
+        lock (_lifecycleTeardownGate)
+        {
+            _lifecycleTeardownsByTask[completion] = teardown;
+            _lifecycleTeardownsByOperation[teardown.Operation] = teardown;
+            if (_lifecycleTeardownDrain is { Closed: false } drain && drain.Includes(teardown))
+            {
+                teardown.Taken = true;
+                drain.Pending.Add(teardown);
+            }
+            else
+            {
+                _activeLifecycleTeardowns.Add(teardown);
+            }
+        }
     }
 
     private void CompleteTrackedHostClose(
@@ -1949,52 +2017,158 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
             else
                 completion.TrySetException(terminalFailure);
 
-            DeferredLifecycleTeardown? entry = null;
-            foreach (DeferredLifecycleTeardown candidate in _activeLifecycleTeardowns)
-            {
-                if (ReferenceEquals(candidate.Task, hostCloseTask))
-                {
-                    entry = candidate;
-                    break;
-                }
-            }
-            if (entry is not null && !entry.Taken)
+            if (_lifecycleTeardownsByTask.TryGetValue(hostCloseTask, out DeferredLifecycleTeardown? entry)
+                && !entry.Taken)
             {
                 _activeLifecycleTeardowns.Remove(entry);
                 if (terminalFailure is not null)
-                    _deferredLifecycleFailures.Enqueue(terminalFailure);
+                    _deferredLifecycleFailures.Add(entry);
+                else
+                    _lifecycleTeardownsByTask.Remove(hostCloseTask);
             }
+
+            if (entry?.Taken == true)
+                _lifecycleTeardownsByTask.Remove(hostCloseTask);
+            if (entry is not null)
+                _lifecycleTeardownsByOperation.Remove(entry.Operation);
         }
     }
 
     private async Task<List<Exception>> DrainActiveLifecycleTeardownsAsync()
     {
         List<Exception>? failures = null;
-        DeferredLifecycleTeardown[] active;
+        var drain = new LifecycleTeardownDrain();
         lock (_lifecycleTeardownGate)
         {
-            while (_deferredLifecycleFailures.TryDequeue(out Exception? failure))
-                (failures ??= []).Add(failure);
-
-            active = _activeLifecycleTeardowns.ToArray();
-            _activeLifecycleTeardowns.Clear();
-            foreach (DeferredLifecycleTeardown teardown in active)
-                teardown.Taken = true;
+            _lifecycleTeardownDrain = drain;
+            ClaimLifecycleTeardowns(drain);
         }
 
-        foreach (DeferredLifecycleTeardown teardown in active)
+        try
         {
-            try
+            while (true)
             {
-                await teardown.Task.ConfigureAwait(false);
+                DeferredLifecycleTeardown[] batch;
+                lock (_lifecycleTeardownGate)
+                {
+                    batch = drain.Pending.ToArray();
+                    drain.Pending.Clear();
+                    foreach (DeferredLifecycleTeardown teardown in batch)
+                    {
+                        if (teardown.Task.IsCompleted)
+                            _lifecycleTeardownsByTask.Remove(teardown.Task);
+                    }
+                    if (batch.Length == 0)
+                    {
+                        drain.Closed = true;
+                        if (ReferenceEquals(_lifecycleTeardownDrain, drain))
+                            _lifecycleTeardownDrain = null;
+                        return failures ?? [];
+                    }
+                }
+
+                foreach (DeferredLifecycleTeardown teardown in batch)
+                {
+                    try
+                    {
+                        await teardown.Task.ConfigureAwait(false);
+                    }
+                    catch (Exception ex)
+                    {
+                        (failures ??= []).Add(ex);
+                    }
+                }
             }
-            catch (Exception ex)
+        }
+        finally
+        {
+            lock (_lifecycleTeardownGate)
             {
-                (failures ??= []).Add(ex);
+                drain.Closed = true;
+                if (ReferenceEquals(_lifecycleTeardownDrain, drain))
+                    _lifecycleTeardownDrain = null;
+            }
+        }
+    }
+
+    private void ClaimLifecycleTeardowns(LifecycleTeardownDrain drain)
+    {
+        foreach (DeferredLifecycleTeardown teardown in _activeLifecycleTeardowns.ToArray())
+            ClaimLifecycleTeardown(drain, teardown);
+        foreach (DeferredLifecycleTeardown teardown in _deferredLifecycleFailures.ToArray())
+            ClaimLifecycleTeardown(drain, teardown);
+    }
+
+    private void ClaimMatchingLifecycleTeardowns(LifecycleTeardownDrain drain)
+    {
+        foreach (DeferredLifecycleTeardown teardown in _activeLifecycleTeardowns
+            .Where(drain.Includes)
+            .ToArray())
+        {
+            ClaimLifecycleTeardown(drain, teardown);
+        }
+        foreach (DeferredLifecycleTeardown teardown in _deferredLifecycleFailures
+            .Where(drain.Includes)
+            .ToArray())
+        {
+            ClaimLifecycleTeardown(drain, teardown);
+        }
+    }
+
+    private void ClaimLifecycleTeardown(
+        LifecycleTeardownDrain drain,
+        DeferredLifecycleTeardown teardown)
+    {
+        if (teardown.Taken)
+            return;
+
+        _activeLifecycleTeardowns.Remove(teardown);
+        _deferredLifecycleFailures.Remove(teardown);
+        teardown.Taken = true;
+        drain.Pending.Add(teardown);
+        drain.Roots.Add(teardown.Operation);
+        foreach (DeferredLifecycleTeardown dependency in teardown.Dependencies)
+            ClaimLifecycleTeardown(drain, dependency);
+    }
+
+    private void AdoptLifecycleTeardown(Task completion)
+    {
+        lock (_lifecycleTeardownGate)
+        {
+            TabAdmissionOperation? operation = s_tabAdmissionOperation.Value;
+            DeferredLifecycleTeardown? caller = GetCurrentLifecycleTeardown();
+            if (!_lifecycleTeardownsByTask.TryGetValue(
+                    completion,
+                    out DeferredLifecycleTeardown? teardown))
+            {
+                return;
+            }
+
+            caller?.Dependencies.Add(teardown);
+            if (_lifecycleTeardownDrain is not { Closed: false } drain
+                || !drain.IncludesOperation(operation))
+                return;
+
+            ClaimLifecycleTeardown(drain, teardown);
+            ClaimMatchingLifecycleTeardowns(drain);
+        }
+    }
+
+    private DeferredLifecycleTeardown? GetCurrentLifecycleTeardown()
+    {
+        for (TabAdmissionOperation? operation = s_tabAdmissionOperation.Value;
+             operation is not null;
+             operation = operation.Parent)
+        {
+            if (_lifecycleTeardownsByOperation.TryGetValue(
+                    operation,
+                    out DeferredLifecycleTeardown? teardown))
+            {
+                return teardown;
             }
         }
 
-        return failures ?? [];
+        return null;
     }
 
     public IReactiveProperty<EditorTabItem?> SelectedTabItem { get; } = new ReactivePropertySlim<EditorTabItem?>();
@@ -2575,9 +2749,21 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
         ArgumentNullException.ThrowIfNull(teardownFactory);
         TabAdmissionOperation? parent = s_tabAdmissionOperation.Value;
         TabAdmissionOperation child = new(this, parent);
-        var entry = new DeferredLifecycleTeardown();
+        var entry = new DeferredLifecycleTeardown(child);
         lock (_lifecycleTeardownGate)
-            _activeLifecycleTeardowns.Add(entry);
+        {
+            _lifecycleTeardownsByTask[entry.Task] = entry;
+            _lifecycleTeardownsByOperation[entry.Operation] = entry;
+            if (_lifecycleTeardownDrain is { Closed: false } drain && drain.Includes(entry))
+            {
+                entry.Taken = true;
+                drain.Pending.Add(entry);
+            }
+            else
+            {
+                _activeLifecycleTeardowns.Add(entry);
+            }
+        }
         _ = CompleteDeferredLifecycleTeardownAsync(entry, teardownFactory, child);
         ObserveDeferredTabDisposal(entry.Task);
     }
@@ -2625,8 +2811,14 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
             {
                 _activeLifecycleTeardowns.Remove(entry);
                 if (failure is not null)
-                    _deferredLifecycleFailures.Enqueue(failure);
+                    _deferredLifecycleFailures.Add(entry);
+                else
+                    _lifecycleTeardownsByTask.Remove(entry.Task);
             }
+
+            if (entry.Taken)
+                _lifecycleTeardownsByTask.Remove(entry.Task);
+            _lifecycleTeardownsByOperation.Remove(entry.Operation);
 
             if (cancellation is not null)
                 entry.Completion!.TrySetCanceled(cancellation.CancellationToken);

--- a/src/Beutl/Services/EditorService.cs
+++ b/src/Beutl/Services/EditorService.cs
@@ -209,17 +209,25 @@ public sealed class EditorTabItem : IAsyncDisposable
         drain?.TrySetResult();
     }
 
-    internal bool TryBeginHostClose(
+    internal EditorContextCloseRequestStatus TryBeginHostClose(
+        EditorContextHostToken expectedHostToken,
         out Task completion,
         out TaskCompletionSource<object?>? completionSource)
     {
         lock (_lifetimeGate)
         {
+            if (!ReferenceEquals(_ownerHostToken, expectedHostToken))
+            {
+                completion = Task.CompletedTask;
+                completionSource = null;
+                return EditorContextCloseRequestStatus.NotOwned;
+            }
+
             if (_hostCloseTask is not null)
             {
                 completion = _hostCloseTask;
                 completionSource = null;
-                return false;
+                return EditorContextCloseRequestStatus.AlreadyClosing;
             }
 
             completionSource = new TaskCompletionSource<object?>(
@@ -227,7 +235,7 @@ public sealed class EditorTabItem : IAsyncDisposable
             completion = completionSource.Task;
             _hostCloseTask = completion;
             _closing = true;
-            return true;
+            return EditorContextCloseRequestStatus.Accepted;
         }
     }
 
@@ -815,6 +823,8 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
 
     internal Action? BeforePhysicalAdd { get; set; }
 
+    internal Action<IEditorContext>? BeforeActivationTabConstruction { get; set; }
+
     public EditorService(ExtensionProvider extensionProvider)
         : this(
             extensionProvider,
@@ -1353,7 +1363,7 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
         IEditorContext context,
         (EditorTabItem Item, long Generation) registration)
     {
-        bool accepted;
+        EditorContextCloseRequestStatus status;
         Task completion;
         TaskCompletionSource<object?>? completionSource;
         lock (_contextRegistryGate)
@@ -1367,33 +1377,35 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
                     Task.CompletedTask);
             }
 
-            accepted = registration.Item.TryBeginHostClose(
+            status = registration.Item.TryBeginHostClose(
+                _hostToken,
                 out completion,
                 out completionSource);
         }
 
         return StartHostClose(
             registration.Item,
-            accepted,
+            status,
             completion,
             completionSource);
     }
 
     private EditorContextCloseRequest RequestClose(EditorTabItem item)
     {
-        bool accepted = item.TryBeginHostClose(
+        EditorContextCloseRequestStatus status = item.TryBeginHostClose(
+            _hostToken,
             out Task completion,
             out TaskCompletionSource<object?>? completionSource);
-        return StartHostClose(item, accepted, completion, completionSource);
+        return StartHostClose(item, status, completion, completionSource);
     }
 
     private EditorContextCloseRequest StartHostClose(
         EditorTabItem item,
-        bool accepted,
+        EditorContextCloseRequestStatus status,
         Task completion,
         TaskCompletionSource<object?>? completionSource)
     {
-        if (accepted)
+        if (status == EditorContextCloseRequestStatus.Accepted)
         {
             BeforeHostCloseStart?.Invoke();
             _ = CompleteHostCloseAsync(item, completionSource!);
@@ -1401,9 +1413,7 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
         }
 
         return new EditorContextCloseRequest(
-            accepted
-                ? EditorContextCloseRequestStatus.Accepted
-                : EditorContextCloseRequestStatus.AlreadyClosing,
+            status,
             completion);
     }
 
@@ -1830,14 +1840,29 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
 
             if (ext?.TryCreateContext(obj, new EditorContextServices(this, _extensionProvider), out IEditorContext? context) == true)
             {
-                var tabItem2 = new EditorTabItem(context) { IsSelected = { Value = true } };
-                if (!TryAddTabItemCore(
+                EditorTabItem? tabItem2 = null;
+                bool added = false;
+                try
+                {
+                    BeforeActivationTabConstruction?.Invoke(context);
+                    tabItem2 = new EditorTabItem(context);
+                    tabItem2.IsSelected.Value = true;
+                    added = TryAddTabItemCore(
                         tabItem2,
                         select: true,
                         beforeAdd: null,
-                        beforeSelection: null)
-                    && tabItem2.IsHostOwned)
-                    ObserveDeferredTabDisposal(tabItem2.DisposeAsync().AsTask());
+                        beforeSelection: null);
+                }
+                finally
+                {
+                    if (!added)
+                    {
+                        if (tabItem2 is not null)
+                            ObserveDeferredTabDisposal(tabItem2.DisposeAsync().AsTask());
+                        else
+                            ObserveDeferredContextDisposal(context);
+                    }
+                }
             }
         }
     }
@@ -1932,6 +1957,21 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
             CancellationToken.None,
             TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
             TaskScheduler.Default);
+    }
+
+    private static void ObserveDeferredContextDisposal(IEditorContext context)
+    {
+        Task disposal;
+        try
+        {
+            disposal = context.DisposeAsync().AsTask();
+        }
+        catch (Exception ex)
+        {
+            disposal = Task.FromException(ex);
+        }
+
+        ObserveDeferredTabDisposal(disposal);
     }
 
     private static void ObserveDeferredTaskFailure(Task task)

--- a/src/Beutl/Services/EditorService.cs
+++ b/src/Beutl/Services/EditorService.cs
@@ -13,11 +13,16 @@ namespace Beutl.Services;
 
 public sealed class EditorTabItem : IAsyncDisposable
 {
+    private readonly object _lifetimeGate = new();
+    private static readonly AsyncLocal<IReadOnlySet<EditorTabItem>?> s_ownedDisposals = new();
+    private Task? _disposeTask;
+    private Task? _transitionTask;
+    private bool _closing;
     private string? _hash;
 
     public EditorTabItem(IEditorContext context)
     {
-        Context = new ReactiveProperty<IEditorContext>(context);
+        MutableContext = new ReactiveProperty<IEditorContext>(context);
         FilePath = Context.Select(ctxt => ctxt?.Object.Uri?.LocalPath)
             .ToReadOnlyReactivePropertySlim()!;
         FileName = FilePath.Select(Path.GetFileName)
@@ -29,7 +34,9 @@ public sealed class EditorTabItem : IAsyncDisposable
             .ToReadOnlyReactivePropertySlim();
     }
 
-    public IReactiveProperty<IEditorContext> Context { get; }
+    private IReactiveProperty<IEditorContext> MutableContext { get; }
+
+    public IReadOnlyReactiveProperty<IEditorContext> Context => MutableContext;
 
     public IReadOnlyReactiveProperty<string> FilePath { get; }
 
@@ -57,17 +64,156 @@ public sealed class EditorTabItem : IAsyncDisposable
         return _hash;
     }
 
-    public async ValueTask DisposeAsync()
+    /// <summary>
+    /// Replaces the owned editor context after the previous context has fully torn down.
+    /// The supplied context is consumed even when replacement is rejected.
+    /// </summary>
+    public ValueTask<bool> ReplaceContextAsync(IEditorContext context)
     {
-        await Context.Value.DisposeAsync();
-        Context.Value = null!;
+        ArgumentNullException.ThrowIfNull(context);
+        IEditorContext? oldContext = null;
+        TaskCompletionSource<bool>? completion = null;
+        bool rejected;
+        lock (_lifetimeGate)
+        {
+            rejected = _closing || _transitionTask is not null;
+            if (!rejected)
+            {
+                oldContext = MutableContext.Value;
+                MutableContext.Value = null!;
+                completion = new TaskCompletionSource<bool>(
+                    TaskCreationOptions.RunContinuationsAsynchronously);
+                _transitionTask = completion.Task;
+            }
+        }
 
-        Context.Dispose();
-        FilePath.Dispose();
-        FileName.Dispose();
-        Extension.Dispose();
-        Commands.Dispose();
-        IsSelected.Dispose();
+        if (rejected)
+            return new ValueTask<bool>(DisposeRejectedAndReturnFalseAsync(context));
+
+        _ = CompleteReplacementAsync(oldContext!, context, completion!);
+        return new ValueTask<bool>(completion!.Task);
+    }
+
+    private async Task CompleteReplacementAsync(
+        IEditorContext oldContext,
+        IEditorContext replacement,
+        TaskCompletionSource<bool> completion)
+    {
+        bool published = false;
+        try
+        {
+            await DisposeOwnedContextAsync(oldContext).ConfigureAwait(true);
+            lock (_lifetimeGate)
+            {
+                if (!_closing)
+                {
+                    MutableContext.Value = replacement;
+                    published = true;
+                }
+                _transitionTask = null;
+            }
+            if (!published)
+                await DisposeRejectedContextAsync(replacement).ConfigureAwait(true);
+            completion.TrySetResult(published);
+        }
+        catch (Exception ex)
+        {
+            lock (_lifetimeGate)
+                _transitionTask = null;
+            await DisposeRejectedContextAsync(replacement).ConfigureAwait(true);
+            completion.TrySetException(ex);
+        }
+    }
+
+    private async Task DisposeOwnedContextAsync(IEditorContext context)
+    {
+        IReadOnlySet<EditorTabItem>? previous = s_ownedDisposals.Value;
+        var current = previous is null
+            ? new HashSet<EditorTabItem>(ReferenceEqualityComparer.Instance)
+            : new HashSet<EditorTabItem>(previous, ReferenceEqualityComparer.Instance);
+        current.Add(this);
+        s_ownedDisposals.Value = current;
+        try { await context.DisposeAsync().ConfigureAwait(true); }
+        finally { s_ownedDisposals.Value = previous; }
+    }
+
+    private static async Task DisposeRejectedContextAsync(IEditorContext context)
+    {
+        try
+        {
+            await context.DisposeAsync().ConfigureAwait(false);
+        }
+        catch
+        {
+            // The caller cannot retain ownership of a rejected context. Preserve the
+            // original replacement/close outcome while ensuring it is not leaked.
+        }
+    }
+
+    private static async Task<bool> DisposeRejectedAndReturnFalseAsync(IEditorContext context)
+    {
+        await DisposeRejectedContextAsync(context).ConfigureAwait(false);
+        return false;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        Task? transition;
+        TaskCompletionSource<object?>? completion = null;
+        bool reentrant = s_ownedDisposals.Value?.Contains(this) == true;
+        lock (_lifetimeGate)
+        {
+            if (_disposeTask is not null)
+            {
+                return reentrant ? ValueTask.CompletedTask : new ValueTask(_disposeTask);
+            }
+
+            _closing = true;
+            transition = _transitionTask;
+            completion = new TaskCompletionSource<object?>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            _disposeTask = completion.Task;
+        }
+
+        _ = DisposeCoreAsync(transition, completion);
+        return reentrant ? ValueTask.CompletedTask : new ValueTask(completion.Task);
+    }
+
+    private async Task DisposeCoreAsync(
+        Task? transition,
+        TaskCompletionSource<object?> completion)
+    {
+        try
+        {
+            if (transition is not null)
+            {
+                try { await transition.ConfigureAwait(true); }
+                catch { }
+            }
+
+            IEditorContext? context;
+            lock (_lifetimeGate)
+            {
+                context = MutableContext.Value;
+                MutableContext.Value = null!;
+            }
+            if (context is not null)
+                await DisposeOwnedContextAsync(context).ConfigureAwait(true);
+
+            MutableContext.Dispose();
+            FilePath.Dispose();
+            FileName.Dispose();
+            Extension.Dispose();
+            Commands.Dispose();
+            IsSelected.Dispose();
+        }
+        catch (Exception ex)
+        {
+            completion.TrySetException(ex);
+            return;
+        }
+
+        completion.TrySetResult(null);
     }
 }
 
@@ -110,7 +256,13 @@ public sealed class EditorService : IOutputOperationLeaseProvider
             .ToReadOnlyReactivePropertySlim();
     }
 
-    public ICoreList<EditorTabItem> TabItems => _tabItems;
+    public ICoreReadOnlyList<EditorTabItem> TabItems => _tabItems;
+
+    internal void ClearTabItems() => _tabItems.Clear();
+
+    internal void AddTabItem(EditorTabItem item) => _tabItems.Add(item);
+
+    internal bool RemoveTabItem(EditorTabItem item) => _tabItems.Remove(item);
 
     internal ExtensionProvider ExtensionProvider => _extensionProvider;
 
@@ -504,7 +656,7 @@ public sealed class EditorService : IOutputOperationLeaseProvider
             if (ext?.TryCreateContext(obj, new EditorContextServices(this, _extensionProvider), out IEditorContext? context) == true)
             {
                 var tabItem2 = new EditorTabItem(context) { IsSelected = { Value = true } };
-                TabItems.Add(tabItem2);
+                AddTabItem(tabItem2);
                 SelectedTabItem.Value = tabItem2;
             }
         }
@@ -514,14 +666,14 @@ public sealed class EditorService : IOutputOperationLeaseProvider
     {
         if (TryGetTabItem(obj, out EditorTabItem? item))
         {
-            TabItems.Remove(item);
+            RemoveTabItem(item);
             await item.DisposeAsync();
         }
     }
 
     public async ValueTask CloseTabItem(EditorTabItem item)
     {
-        TabItems.Remove(item);
+        RemoveTabItem(item);
         await item.DisposeAsync();
     }
 

--- a/src/Beutl/Services/EditorService.cs
+++ b/src/Beutl/Services/EditorService.cs
@@ -20,11 +20,16 @@ internal interface IEditorContextPublicationGate
 public sealed class EditorTabItem : IAsyncDisposable
 {
     private readonly object _lifetimeGate = new();
-    private static readonly AsyncLocal<IReadOnlySet<EditorTabItem>?> s_ownedDisposals = new();
+    private static readonly AsyncLocal<OwnedDisposalScope?> s_ownedDisposals = new();
+    private static readonly AsyncLocal<PublicationScope?> s_publicationScope = new();
     private Task? _disposeTask;
     private Task? _transitionTask;
+    private TaskCompletionSource? _publicationDrain;
+    private TaskCompletionSource? _removalCompletion;
     private bool _closing;
     private bool _contextDisposeAttempted;
+    private bool _publicationActive;
+    private MembershipState _membershipState;
     private Action<EditorTabItem>? _terminalFailureHandler;
     private string? _hash;
 
@@ -56,27 +61,176 @@ public sealed class EditorTabItem : IAsyncDisposable
     internal void AttachOwner(Action<EditorTabItem> terminalFailureHandler)
         => _terminalFailureHandler = terminalFailureHandler;
 
-    // Keep publication (registration and selection) behind the same lifetime gate as disposal.
-    // This also covers editor-context implementations that do not expose the optional
-    // IEditorContextPublicationGate contract.
-    internal bool TryPublish(Action publish)
+    // Serialize publication admission with disposal, then run observer callbacks outside the
+    // lifetime gate. Admitted callbacks are drained before teardown touches reactive surfaces.
+    internal bool TryPublish(Action publish, bool requireContext = true)
     {
         ArgumentNullException.ThrowIfNull(publish);
+        TaskCompletionSource drain;
         lock (_lifetimeGate)
         {
-            if (_closing || _disposeTask is not null || MutableContext.Value is null)
+            if (_closing
+                || _disposeTask is not null
+                || (requireContext && MutableContext.Value is null)
+                || (requireContext && _transitionTask is not null)
+                || _publicationActive)
+            {
                 return false;
+            }
 
+            _publicationActive = true;
+            drain = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            _publicationDrain = drain;
+        }
+
+        PublicationScope? previous = s_publicationScope.Value;
+        var scope = new PublicationScope(this, previous);
+        s_publicationScope.Value = scope;
+        try
+        {
             publish();
-            return !_closing && _disposeTask is null && MutableContext.Value is not null;
+            lock (_lifetimeGate)
+            {
+                return !_closing
+                    && _disposeTask is null
+                    && (!requireContext || MutableContext.Value is not null);
+            }
+        }
+        finally
+        {
+            lock (_lifetimeGate)
+            {
+                scope.Deactivate();
+                _publicationActive = false;
+                if (ReferenceEquals(_publicationDrain, drain))
+                    _publicationDrain = null;
+            }
+            s_publicationScope.Value = previous;
+            drain.TrySetResult();
         }
     }
 
-    internal void MutateLifetime(Action mutation)
+    internal bool TryBeginAttachment()
     {
-        ArgumentNullException.ThrowIfNull(mutation);
         lock (_lifetimeGate)
-            mutation();
+        {
+            if (_closing || _disposeTask is not null || _membershipState != MembershipState.Fresh)
+                return false;
+
+            _membershipState = MembershipState.Adding;
+            return true;
+        }
+    }
+
+    internal bool TryCompleteAttachment()
+    {
+        lock (_lifetimeGate)
+        {
+            if (_closing || _membershipState != MembershipState.Adding)
+                return false;
+
+            _membershipState = MembershipState.Attached;
+            return true;
+        }
+    }
+
+    internal bool TryBeginRemoval(out Task completion)
+    {
+        lock (_lifetimeGate)
+        {
+            _closing = true;
+            if (_membershipState is MembershipState.Removing or MembershipState.Removed)
+            {
+                completion = _removalCompletion?.Task ?? Task.CompletedTask;
+                return false;
+            }
+
+            _membershipState = MembershipState.Removing;
+            _removalCompletion = new TaskCompletionSource(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            completion = _removalCompletion.Task;
+            return true;
+        }
+    }
+
+    internal void CompleteRemoval()
+    {
+        TaskCompletionSource? completion;
+        lock (_lifetimeGate)
+        {
+            _membershipState = MembershipState.Removed;
+            completion = _removalCompletion;
+        }
+        completion?.TrySetResult();
+    }
+
+    internal Task GetRemovalCompletion()
+    {
+        lock (_lifetimeGate)
+            return _removalCompletion?.Task ?? Task.CompletedTask;
+    }
+
+    internal bool IsPublicationCurrent()
+    {
+        lock (_lifetimeGate)
+            return _publicationActive && !_closing && _disposeTask is null && MutableContext.Value is not null;
+    }
+
+    private static bool IsActivePublicationScope(EditorTabItem item)
+    {
+        for (PublicationScope? scope = s_publicationScope.Value; scope is not null; scope = scope.Parent)
+        {
+            if (scope.IsActive && ReferenceEquals(scope.Owner, item))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool IsActiveOwnedDisposalScope(EditorTabItem item)
+    {
+        for (OwnedDisposalScope? scope = s_ownedDisposals.Value; scope is not null; scope = scope.Parent)
+        {
+            if (scope.IsActive && ReferenceEquals(scope.Owner, item))
+                return true;
+        }
+
+        return false;
+    }
+
+    private sealed class PublicationScope(EditorTabItem owner, PublicationScope? parent)
+    {
+        private int _active = 1;
+
+        public EditorTabItem Owner { get; } = owner;
+
+        public PublicationScope? Parent { get; } = parent;
+
+        public bool IsActive => Volatile.Read(ref _active) != 0;
+
+        public void Deactivate() => Interlocked.Exchange(ref _active, 0);
+    }
+
+    private sealed class OwnedDisposalScope(EditorTabItem owner, OwnedDisposalScope? parent)
+    {
+        private int _active = 1;
+
+        public EditorTabItem Owner { get; } = owner;
+
+        public OwnedDisposalScope? Parent { get; } = parent;
+
+        public bool IsActive => Volatile.Read(ref _active) != 0;
+
+        public void Deactivate() => Interlocked.Exchange(ref _active, 0);
+    }
+
+    private enum MembershipState
+    {
+        Fresh,
+        Adding,
+        Attached,
+        Removing,
+        Removed
     }
 
     public IReadOnlyReactiveProperty<string> FilePath { get; }
@@ -119,7 +273,7 @@ public sealed class EditorTabItem : IAsyncDisposable
         bool rejected;
         lock (_lifetimeGate)
         {
-            rejected = _closing || _transitionTask is not null;
+            rejected = _closing || _transitionTask is not null || _publicationActive;
             if (!rejected)
             {
                 oldContext = MutableContext.Value;
@@ -136,7 +290,7 @@ public sealed class EditorTabItem : IAsyncDisposable
 
         try
         {
-            MutableContext.Value = null;
+            _ = TryPublish(() => MutableContext.Value = null, requireContext: false);
         }
         catch (Exception ex)
         {
@@ -262,24 +416,24 @@ public sealed class EditorTabItem : IAsyncDisposable
     {
         bool contextPublished = true;
         bool itemPublished = false;
+
+        void Publish()
+        {
+            MutableContext.Value = replacement;
+            itemPublished = true;
+        }
+
+        bool itemAccepted = TryPublish(() =>
+        {
+            if (replacement is IEditorContextPublicationGate gate)
+                contextPublished = gate.TryPublish(Publish);
+            else
+                Publish();
+        }, requireContext: false);
+
         lock (_lifetimeGate)
         {
-            if (_closing || _disposeTask is not null || MutableContext.Value is not null)
-                return (false, false);
-
-            if (replacement is IEditorContextPublicationGate gate)
-                contextPublished = gate.TryPublish(() =>
-                {
-                    MutableContext.Value = replacement;
-                    itemPublished = true;
-                });
-            else
-            {
-                MutableContext.Value = replacement;
-                itemPublished = true;
-            }
-
-            bool accepted = itemPublished && contextPublished && !_closing && _disposeTask is null
+            bool accepted = itemAccepted && itemPublished && contextPublished && !_closing && _disposeTask is null
                 && ReferenceEquals(MutableContext.Value, replacement);
             return (itemPublished, accepted);
         }
@@ -293,14 +447,16 @@ public sealed class EditorTabItem : IAsyncDisposable
 
     private async Task DisposeOwnedContextAsync(IEditorContext context)
     {
-        IReadOnlySet<EditorTabItem>? previous = s_ownedDisposals.Value;
-        var current = previous is null
-            ? new HashSet<EditorTabItem>(ReferenceEqualityComparer.Instance)
-            : new HashSet<EditorTabItem>(previous, ReferenceEqualityComparer.Instance);
-        current.Add(this);
-        s_ownedDisposals.Value = current;
+        OwnedDisposalScope? previous = s_ownedDisposals.Value;
+        var scope = new OwnedDisposalScope(this, previous);
+        s_ownedDisposals.Value = scope;
         try { await context.DisposeAsync().ConfigureAwait(true); }
-        finally { s_ownedDisposals.Value = previous; }
+        finally
+        {
+            lock (_lifetimeGate)
+                scope.Deactivate();
+            s_ownedDisposals.Value = previous;
+        }
     }
 
     private async Task<Exception?> TryDisposeRejectedContextOwnedAsync(IEditorContext context)
@@ -327,10 +483,13 @@ public sealed class EditorTabItem : IAsyncDisposable
     public ValueTask DisposeAsync()
     {
         Task? transition;
+        Task? publicationDrain;
         TaskCompletionSource<object?>? completion = null;
-        bool reentrant = s_ownedDisposals.Value?.Contains(this) == true;
+        bool reentrant;
         lock (_lifetimeGate)
         {
+            reentrant = IsActiveOwnedDisposalScope(this)
+                || IsActivePublicationScope(this);
             if (_disposeTask is not null)
             {
                 return reentrant ? ValueTask.CompletedTask : new ValueTask(_disposeTask);
@@ -338,28 +497,35 @@ public sealed class EditorTabItem : IAsyncDisposable
 
             _closing = true;
             transition = _transitionTask;
+            publicationDrain = _publicationDrain?.Task;
             completion = new TaskCompletionSource<object?>(
                 TaskCreationOptions.RunContinuationsAsynchronously);
             _disposeTask = completion.Task;
         }
 
-        _ = DisposeCoreAsync(transition, completion);
+        _ = DisposeCoreAsync(transition, publicationDrain, completion);
+        if (reentrant)
+            ObserveDeferredDisposalFailure(completion.Task);
         return reentrant ? ValueTask.CompletedTask : new ValueTask(completion.Task);
     }
 
     private async Task DisposeCoreAsync(
         Task? transition,
+        Task? publicationDrain,
         TaskCompletionSource<object?> completion)
     {
         List<Exception>? failures = null;
-        IReadOnlySet<EditorTabItem>? previous = s_ownedDisposals.Value;
-        var current = previous is null
-            ? new HashSet<EditorTabItem>(ReferenceEqualityComparer.Instance)
-            : new HashSet<EditorTabItem>(previous, ReferenceEqualityComparer.Instance);
-        current.Add(this);
-        s_ownedDisposals.Value = current;
+        OwnedDisposalScope? previous = s_ownedDisposals.Value;
+        var scope = new OwnedDisposalScope(this, previous);
+        s_ownedDisposals.Value = scope;
         try
         {
+            if (publicationDrain is not null)
+            {
+                try { await publicationDrain.ConfigureAwait(true); }
+                catch (Exception ex) { RecordFailure(ref failures, ex); }
+            }
+
             if (transition is not null)
             {
                 try { await transition.ConfigureAwait(true); }
@@ -407,12 +573,23 @@ public sealed class EditorTabItem : IAsyncDisposable
             DisposeSurface(Extension, ref failures);
             DisposeSurface(Commands, ref failures);
             DisposeSurface(IsSelected, ref failures);
+            lock (_lifetimeGate)
+                scope.Deactivate();
             s_ownedDisposals.Value = previous;
             if (failures is null)
                 completion.TrySetResult(null);
             else
                 completion.TrySetException(CreateFailure(failures));
         }
+    }
+
+    private static void ObserveDeferredDisposalFailure(Task task)
+    {
+        _ = task.ContinueWith(
+            static completed => _ = completed.Exception,
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
     }
 
     private static void DisposeSurface(IDisposable surface, ref List<Exception>? failures)
@@ -478,32 +655,73 @@ public sealed class EditorService : IOutputOperationLeaseProvider
 
     internal void AddTabItem(EditorTabItem item)
     {
-        if (!TryAddTabItem(item))
-            _ = item.DisposeAsync();
+        if (!TryAddTabItem(item) && !ContainsTabItem(item))
+            ObserveDeferredTabDisposal(item.DisposeAsync().AsTask());
     }
 
     internal bool TryAddTabItem(EditorTabItem item)
-        => TryAddTabItem(item, select: false);
+        => TryAddTabItem(item, select: false, beforeAdd: null, beforeSelection: null);
+
+    internal bool TryAddTabItem(EditorTabItem item, Action beforeAdd)
+        => TryAddTabItem(item, select: false, beforeAdd: beforeAdd, beforeSelection: null);
 
     internal bool TryAddAndSelectTabItem(EditorTabItem item, Action? beforeSelection = null)
-        => TryAddTabItem(item, select: true, beforeSelection);
+        => TryAddTabItem(item, select: true, beforeAdd: null, beforeSelection: beforeSelection);
 
-    private bool TryAddTabItem(EditorTabItem item, bool select, Action? beforeSelection = null)
+    private bool TryAddTabItem(
+        EditorTabItem item,
+        bool select,
+        Action? beforeAdd,
+        Action? beforeSelection)
     {
+        if (!item.TryBeginAttachment())
+            return false;
+
         bool published = false;
         void Publish()
         {
             void Mutate()
             {
+                beforeAdd?.Invoke();
                 AddTabItemCore(item);
                 if (select && _tabItems.Contains(item))
                 {
-                    beforeSelection?.Invoke();
-                    if (!_tabItems.Contains(item) || item.Context.Value is null)
-                        return;
+                    try
+                    {
+                        beforeSelection?.Invoke();
+                        if (!CanContinuePublication(item))
+                        {
+                            RollbackSelection(item);
+                            return;
+                        }
 
-                    item.IsSelected.Value = true;
-                    SelectedTabItem.Value = item;
+                        item.IsSelected.Value = true;
+                        if (!CanContinuePublication(item))
+                        {
+                            RollbackSelection(item);
+                            return;
+                        }
+
+                        SelectedTabItem.Value = item;
+                        if (!CanContinuePublication(item)
+                            || !ReferenceEquals(SelectedTabItem.Value, item))
+                        {
+                            RollbackSelection(item);
+                        }
+                    }
+                    catch (Exception publicationFailure)
+                    {
+                        try
+                        {
+                            RollbackSelection(item);
+                        }
+                        catch (Exception cleanupFailure)
+                        {
+                            throw new AggregateException(publicationFailure, cleanupFailure);
+                        }
+
+                        throw;
+                    }
                 }
             }
 
@@ -511,15 +729,52 @@ public sealed class EditorService : IOutputOperationLeaseProvider
             bool itemPublished = item.TryPublish(() =>
             {
                 if (item.Context.Value is IEditorContextPublicationGate gate)
-                    contextPublished = gate.TryPublish(Mutate);
-                else
+                    contextPublished = gate.TryPublish(() =>
+                    {
+                        if (item.IsPublicationCurrent())
+                            Mutate();
+                    });
+                else if (item.IsPublicationCurrent())
                     Mutate();
             });
             published = itemPublished && contextPublished;
         }
 
-        Publish();
-        return published && ContainsTabItem(item);
+        try
+        {
+            Publish();
+        }
+        catch (Exception publicationFailure)
+        {
+            Exception? cleanupFailure = null;
+            try
+            {
+                ReconcileRejectedAttachment(item);
+            }
+            catch (Exception ex)
+            {
+                cleanupFailure = ex;
+            }
+            ObserveDeferredTabDisposal(item.DisposeAsync().AsTask());
+
+            if (cleanupFailure is not null)
+                throw new AggregateException(publicationFailure, cleanupFailure);
+            throw;
+        }
+        try
+        {
+            bool accepted = published
+                && ContainsTabItem(item)
+                && item.TryCompleteAttachment();
+            if (!accepted)
+                ReconcileRejectedAttachment(item);
+            return accepted;
+        }
+        catch
+        {
+            ObserveDeferredTabDisposal(item.DisposeAsync().AsTask());
+            throw;
+        }
     }
 
     internal void AddTabItemCore(EditorTabItem item)
@@ -533,33 +788,58 @@ public sealed class EditorService : IOutputOperationLeaseProvider
 
     internal bool RemoveTabItem(EditorTabItem item)
     {
-        List<Exception>? failures = null;
-        bool removed = false;
-        item.MutateLifetime(() =>
+        // Reserve terminal removal without running any collection or reactive observers while
+        // the lifetime gate is held.
+        if (!item.TryBeginRemoval(out _))
+            return false;
+
+        try
         {
-            bool wasPresent = _tabItems.Contains(item);
-            try
-            {
-                removed = _tabItems.Remove(item);
-            }
-            catch (Exception ex)
-            {
-                (failures ??= []).Add(ex);
-                removed = wasPresent && !_tabItems.Contains(item);
-            }
-            // Clear selection even when the collection removal lost a race with another remover.
-            // Otherwise a tab that is no longer live can be re-exposed as the selected item.
-            if (ReferenceEquals(SelectedTabItem.Value, item))
-            {
-                try { SelectedTabItem.Value = null; }
-                catch (Exception ex) { (failures ??= []).Add(ex); }
-            }
-            try { item.IsSelected.Value = false; }
+            return RemoveTabItemFacade(item);
+        }
+        finally
+        {
+            item.CompleteRemoval();
+        }
+    }
+
+    private bool RemoveTabItemFacade(EditorTabItem item)
+    {
+        List<Exception>? failures = null;
+        bool wasPresent = _tabItems.Contains(item);
+        bool removed = false;
+        try
+        {
+            removed = _tabItems.Remove(item);
+        }
+        catch (Exception ex) { (failures ??= []).Add(ex); }
+        if (wasPresent && !_tabItems.Contains(item))
+            removed = true;
+
+        // Clear selection even when the collection removal lost a race with another remover.
+        // Otherwise a tab that is no longer live can be re-exposed as the selected item.
+        if (ReferenceEquals(SelectedTabItem.Value, item))
+        {
+            try { SelectedTabItem.Value = null; }
             catch (Exception ex) { (failures ??= []).Add(ex); }
-        });
+        }
+        try { item.IsSelected.Value = false; }
+        catch (Exception ex) { (failures ??= []).Add(ex); }
+
         if (failures is not null)
             throw failures.Count == 1 ? failures[0] : new AggregateException(failures);
         return removed;
+    }
+
+    private void ReconcileRejectedAttachment(EditorTabItem item)
+    {
+        bool removed = RemoveTabItem(item);
+        if (removed || !ContainsTabItem(item))
+            return;
+
+        item.GetRemovalCompletion().GetAwaiter().GetResult();
+        if (ContainsTabItem(item))
+            _ = RemoveTabItemFacade(item);
     }
 
     private void RemoveFailedTabItem(EditorTabItem item)
@@ -973,7 +1253,7 @@ public sealed class EditorService : IOutputOperationLeaseProvider
             {
                 var tabItem2 = new EditorTabItem(context) { IsSelected = { Value = true } };
                 if (!TryAddAndSelectTabItem(tabItem2))
-                    _ = tabItem2.DisposeAsync();
+                    ObserveDeferredTabDisposal(tabItem2.DisposeAsync().AsTask());
             }
         }
     }
@@ -985,26 +1265,89 @@ public sealed class EditorService : IOutputOperationLeaseProvider
         {
             void Mutate()
             {
-                if (!_tabItems.Contains(item) || item.Context.Value is null)
-                    return;
+                try
+                {
+                    if (!CanContinuePublication(item))
+                        return;
 
-                item.IsSelected.Value = true;
-                SelectedTabItem.Value = item;
+                    item.IsSelected.Value = true;
+                    if (!CanContinuePublication(item))
+                    {
+                        RollbackSelection(item);
+                        return;
+                    }
+
+                    SelectedTabItem.Value = item;
+                    if (!CanContinuePublication(item)
+                        || !ReferenceEquals(SelectedTabItem.Value, item))
+                    {
+                        RollbackSelection(item);
+                        return;
+                    }
+
+                    selected = true;
+                }
+                catch (Exception publicationFailure)
+                {
+                    try
+                    {
+                        RollbackSelection(item);
+                    }
+                    catch (Exception cleanupFailure)
+                    {
+                        throw new AggregateException(publicationFailure, cleanupFailure);
+                    }
+
+                    throw;
+                }
             }
 
             bool contextPublished = true;
             bool itemPublished = item.TryPublish(() =>
             {
                 if (item.Context.Value is IEditorContextPublicationGate gate)
-                    contextPublished = gate.TryPublish(Mutate);
-                else
+                    contextPublished = gate.TryPublish(() =>
+                    {
+                        if (CanContinuePublication(item))
+                            Mutate();
+                    });
+                else if (CanContinuePublication(item))
                     Mutate();
             });
-            selected = itemPublished && contextPublished;
+            selected = selected && itemPublished && contextPublished;
         }
 
         Publish();
         return selected && ReferenceEquals(SelectedTabItem.Value, item);
+    }
+
+    private bool CanContinuePublication(EditorTabItem item)
+        => item.IsPublicationCurrent()
+            && _tabItems.Contains(item)
+            && item.Context.Value is not null;
+
+    private void RollbackSelection(EditorTabItem item)
+    {
+        List<Exception>? failures = null;
+        if (ReferenceEquals(SelectedTabItem.Value, item))
+        {
+            try { SelectedTabItem.Value = null; }
+            catch (Exception ex) { (failures ??= []).Add(ex); }
+        }
+        try { item.IsSelected.Value = false; }
+        catch (Exception ex) { (failures ??= []).Add(ex); }
+
+        if (failures is not null)
+            throw failures.Count == 1 ? failures[0] : new AggregateException(failures);
+    }
+
+    private static void ObserveDeferredTabDisposal(Task task)
+    {
+        _ = task.ContinueWith(
+            static completed => _ = completed.Exception,
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
     }
 
     public async ValueTask CloseTabItem(CoreObject obj)

--- a/src/Beutl/Services/EditorService.cs
+++ b/src/Beutl/Services/EditorService.cs
@@ -1,8 +1,8 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
-using Avalonia.Threading;
 using System.Threading;
+using Avalonia.Threading;
 using Beutl.Api.Services;
 using Beutl.Configuration;
 using Beutl.Editor;
@@ -2406,6 +2406,29 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
             }
         }
 
+        _projectFileWriteGate.Release();
+        return null;
+    }
+
+    internal async ValueTask<IProjectFileWriteLease?> BeginFinalProjectFileWriteAsync()
+    {
+        lock (_workspaceOperationSync)
+        {
+            if (_worktreeMutationActive)
+                return null;
+        }
+
+        await _projectFileWriteGate.WaitAsync();
+        lock (_workspaceOperationSync)
+        {
+            if (!_worktreeMutationActive)
+            {
+                _activeProjectFileWrites++;
+                return new WorkspaceOperationLease(this, WorkspaceOperationKind.ProjectFileWrite);
+            }
+        }
+
+        // A Git close may be waiting for this editor's teardown. Never wait for that mutation.
         _projectFileWriteGate.Release();
         return null;
     }

--- a/src/Beutl/Services/EditorService.cs
+++ b/src/Beutl/Services/EditorService.cs
@@ -441,6 +441,22 @@ public sealed class EditorService : IOutputOperationLeaseProvider
 
     internal ExtensionProvider ExtensionProvider => _extensionProvider;
 
+    internal void RequestContextShutdown(IEditorContext context)
+    {
+        EditorTabItem? item = _tabItems.FirstOrDefault(tab =>
+            ReferenceEquals(tab.Context.Value, context));
+        if (item is null)
+            return;
+
+        try { RemoveTabItem(item); }
+        catch { }
+        _ = item.DisposeAsync().AsTask().ContinueWith(
+            static task => _ = task.Exception,
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+    }
+
     public IReactiveProperty<EditorTabItem?> SelectedTabItem { get; } = new ReactivePropertySlim<EditorTabItem?>();
 
     internal IReadOnlyReactiveProperty<IProjectVersionControlService?>

--- a/src/Beutl/Services/EditorService.cs
+++ b/src/Beutl/Services/EditorService.cs
@@ -35,6 +35,17 @@ internal readonly record struct EditorContextClaimResult(
     EditorContextRegistration? Registration = null,
     EditorContextOwnershipLease? CleanupLease = null);
 
+internal enum ActivationContextOwnershipStatus
+{
+    New,
+    AlreadyOwned,
+    ForeignUnowned
+}
+
+internal readonly record struct ActivationContextOwnershipResult(
+    ActivationContextOwnershipStatus Status,
+    EditorContextOwnershipLease? Lease = null);
+
 public sealed class EditorTabItem : IAsyncDisposable
 {
     private readonly object _lifetimeGate = new();
@@ -979,6 +990,8 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
 
     internal Action? BeforeContextCloseAdmission { get; set; }
 
+    internal Action? AfterTabAdmissionClosed { get; set; }
+
     internal Action? BeforeHostCloseStart { get; set; }
 
     internal Action? BeforePhysicalAdd { get; set; }
@@ -1020,9 +1033,9 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
     {
         ArgumentNullException.ThrowIfNull(items);
         await _tabReconciliationGate.WaitAsync();
-        Task admissionDrain = CloseTabAdmission();
         try
         {
+            Task admissionDrain = CloseTabAdmission();
             await admissionDrain;
             List<Exception>? failures = null;
             foreach (EditorTabItem item in _tabItems.ToArray())
@@ -1077,24 +1090,35 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
 
     private Task CloseTabAdmission()
     {
+        Task drain;
         lock (_tabAdmissionGate)
         {
             _tabAdmissionClosed = true;
             if (_activeTabAdmissions == 0)
-                return Task.CompletedTask;
-
-            _tabAdmissionDrain ??= new TaskCompletionSource(
-                TaskCreationOptions.RunContinuationsAsynchronously);
-            return _tabAdmissionDrain.Task;
+                drain = Task.CompletedTask;
+            else
+            {
+                _tabAdmissionDrain ??= new TaskCompletionSource(
+                    TaskCreationOptions.RunContinuationsAsynchronously);
+                drain = _tabAdmissionDrain.Task;
+            }
         }
+
+        AfterTabAdmissionClosed?.Invoke();
+        return drain;
     }
 
     private void OpenTabAdmission()
     {
+        TaskCompletionSource? abandonedDrain;
         lock (_tabAdmissionGate)
         {
             _tabAdmissionClosed = false;
+            abandonedDrain = _tabAdmissionDrain;
+            _tabAdmissionDrain = null;
         }
+
+        abandonedDrain?.TrySetResult();
     }
 
     internal void AddTabItem(EditorTabItem item)
@@ -1123,72 +1147,82 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
         ArgumentNullException.ThrowIfNull(item);
         ArgumentNullException.ThrowIfNull(extension);
 
-        if (!item.TryGetAttachedContext(_hostToken, out IEditorContext? current, out EditorContextRegistration registration)
-            || current is null)
-        {
-            return EditorContextReplacementStatus.NotOwned;
-        }
+        if (!TryEnterTabAdmission())
+            return EditorContextReplacementStatus.Busy;
 
-        if (!extension.TryCreateContext(
-                current.Object,
-                new EditorContextServices(this, _extensionProvider),
-                out IEditorContext? replacement)
-            || replacement is null)
-        {
-            return EditorContextReplacementStatus.CreationFailed;
-        }
-
-        EditorContextClaimResult claim;
         try
         {
-            claim = TryClaimContext(item, replacement, claimInvalidHostForCleanup: true);
-        }
-        catch (Exception claimException)
-        {
+            if (!item.TryGetAttachedContext(_hostToken, out IEditorContext? current, out EditorContextRegistration registration)
+                || current is null)
+            {
+                return EditorContextReplacementStatus.NotOwned;
+            }
+
+            if (!extension.TryCreateContext(
+                    current.Object,
+                    new EditorContextServices(this, _extensionProvider),
+                    out IEditorContext? replacement)
+                || replacement is null)
+            {
+                return EditorContextReplacementStatus.CreationFailed;
+            }
+
+            EditorContextClaimResult claim;
             try
             {
+                claim = TryClaimContext(item, replacement, claimInvalidHostForCleanup: true);
+            }
+            catch (Exception claimException)
+            {
+                try
+                {
+                    await replacement.DisposeAsync().ConfigureAwait(true);
+                }
+                catch (Exception disposalException)
+                {
+                    throw new AggregateException(claimException, disposalException);
+                }
+
+                throw;
+            }
+
+            if (claim.Status == EditorContextClaimStatus.AlreadyOwned)
+            {
+                return ReferenceEquals(replacement, current)
+                    ? EditorContextReplacementStatus.AlreadyActive
+                    : EditorContextReplacementStatus.NotOwned;
+            }
+
+            if (claim.Status == EditorContextClaimStatus.InvalidHostClaimedForCleanup)
+            {
+                try
+                {
+                    await replacement.DisposeAsync().ConfigureAwait(true);
+                }
+                finally
+                {
+                    claim.CleanupLease!.Dispose();
+                }
+
+                return EditorContextReplacementStatus.NotOwned;
+            }
+
+            if (claim.Status != EditorContextClaimStatus.Claimed)
+            {
                 await replacement.DisposeAsync().ConfigureAwait(true);
-            }
-            catch (Exception disposalException)
-            {
-                throw new AggregateException(claimException, disposalException);
+                return EditorContextReplacementStatus.NotOwned;
             }
 
-            throw;
+            EditorContextReplacementResult result = await item.ReplaceClaimedContextAsync(
+                replacement,
+                claim.Registration!.Value,
+                registration);
+            return result.Status;
         }
-
-        if (claim.Status == EditorContextClaimStatus.AlreadyOwned)
+        finally
         {
-            return ReferenceEquals(replacement, current)
-                ? EditorContextReplacementStatus.AlreadyActive
-                : EditorContextReplacementStatus.NotOwned;
+            ExitTabAdmission();
         }
-
-        if (claim.Status == EditorContextClaimStatus.InvalidHostClaimedForCleanup)
-        {
-            try
-            {
-                await replacement.DisposeAsync().ConfigureAwait(true);
-            }
-            finally
-            {
-                claim.CleanupLease!.Dispose();
-            }
-
-            return EditorContextReplacementStatus.NotOwned;
-        }
-
-        if (claim.Status != EditorContextClaimStatus.Claimed)
-        {
-            await replacement.DisposeAsync().ConfigureAwait(true);
-            return EditorContextReplacementStatus.NotOwned;
-        }
-
-        EditorContextReplacementResult result = await item.ReplaceClaimedContextAsync(
-            replacement,
-            claim.Registration!.Value,
-            registration);
-        return result.Status;
     }
 
     internal bool TryAddTabItem(EditorTabItem item)
@@ -1235,12 +1269,13 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
         EditorTabItem item,
         bool select,
         Action? beforeAdd,
-        Action? beforeSelection)
+        Action? beforeSelection,
+        EditorContextOwnershipLease? provisionalLease = null)
     {
         if (item.Context.Value is not { } context || !HasMatchingHostToken(context))
             return false;
 
-        if (!item.IsHostOwned && !TryAttachOwner(item))
+        if (!item.IsHostOwned && !TryAttachOwner(item, provisionalLease))
             return false;
         if (!item.TryBeginAttachment())
             return false;
@@ -1473,7 +1508,9 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
         ObserveDeferredTaskFailure(request.Completion);
     }
 
-    private bool TryAttachOwner(EditorTabItem item)
+    private bool TryAttachOwner(
+        EditorTabItem item,
+        EditorContextOwnershipLease? provisionalLease = null)
     {
         IEditorContext? context = item.Context.Value;
         if (context is null || !HasMatchingHostToken(context))
@@ -1483,7 +1520,10 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
         {
             if (_contextItems.ContainsKey(context) || _reservedContextItems.ContainsKey(context))
                 return false;
-            if (!_hostToken.TryAcquireContext(context, out EditorContextOwnershipLease? ownershipLease))
+            EditorContextOwnershipLease? ownershipLease = provisionalLease;
+            bool leaseSuppliedByCaller = ownershipLease is not null;
+            if (ownershipLease is null
+                && !_hostToken.TryAcquireContext(context, out ownershipLease))
                 return false;
 
             bool registered = false;
@@ -1512,8 +1552,10 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
             }
             finally
             {
-                if (!registered && (!ownerAttached || item.TryDetachOwner(registration)))
-                    ownershipLease.Dispose();
+                if (!registered
+                    && (!ownerAttached || item.TryDetachOwner(registration))
+                    && !leaseSuppliedByCaller)
+                    ownershipLease!.Dispose();
             }
         }
     }
@@ -1709,8 +1751,17 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
     {
         if (status == EditorContextCloseRequestStatus.Accepted)
         {
-            BeforeHostCloseStart?.Invoke();
-            _ = CompleteHostCloseAsync(item, completionSource!);
+            Exception? startupFailure = null;
+            try
+            {
+                BeforeHostCloseStart?.Invoke();
+            }
+            catch (Exception ex)
+            {
+                startupFailure = ex;
+            }
+
+            _ = CompleteHostCloseAsync(item, completionSource!, startupFailure);
             ObserveDeferredTaskFailure(completion);
         }
 
@@ -1721,9 +1772,10 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
 
     private async Task CompleteHostCloseAsync(
         EditorTabItem item,
-        TaskCompletionSource<object?> completion)
+        TaskCompletionSource<object?> completion,
+        Exception? startupFailure = null)
     {
-        List<Exception>? failures = null;
+        List<Exception>? failures = startupFailure is null ? null : [startupFailure];
         try { await RemoveTabItemAsync(item).ConfigureAwait(false); }
         catch (Exception ex) { (failures ??= []).Add(ex); }
 
@@ -2140,8 +2192,31 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
         {
             EditorExtension? ext = _extensionProvider.MatchEditorExtension(path);
 
-            if (ext?.TryCreateContext(obj, new EditorContextServices(this, _extensionProvider), out IEditorContext? context) == true)
+            if (ext is not null
+                && ext.TryCreateContext(
+                    obj,
+                    new EditorContextServices(this, _extensionProvider),
+                    out IEditorContext? context)
+                && context is not null)
             {
+                ActivationContextOwnershipResult ownership;
+                try
+                {
+                    ownership = AcquireActivationContextOwnership(context);
+                }
+                catch
+                {
+                    ObserveDeferredContextDisposal(context);
+                    throw;
+                }
+                if (ownership.Status == ActivationContextOwnershipStatus.AlreadyOwned)
+                    return;
+                if (ownership.Status == ActivationContextOwnershipStatus.ForeignUnowned)
+                {
+                    ObserveDeferredContextDisposal(context, ownership.Lease!);
+                    return;
+                }
+
                 EditorTabItem? tabItem2 = null;
                 bool added = false;
                 try
@@ -2153,20 +2228,42 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
                         tabItem2,
                         select: true,
                         beforeAdd: null,
-                        beforeSelection: null);
+                        beforeSelection: null,
+                        provisionalLease: ownership.Lease);
                 }
                 finally
                 {
                     if (!added)
                     {
                         if (tabItem2 is not null)
-                            ObserveDeferredTabDisposal(tabItem2.DisposeAsync().AsTask());
+                            ObserveDeferredTabDisposal(
+                                tabItem2,
+                                ownership.Lease!);
                         else
-                            ObserveDeferredContextDisposal(context);
+                            ObserveDeferredContextDisposal(context, ownership.Lease!);
                     }
                 }
             }
         }
+    }
+
+    private ActivationContextOwnershipResult AcquireActivationContextOwnership(IEditorContext context)
+    {
+        EditorContextHostToken contextHostToken = context.CloseService.HostToken;
+        if (ReferenceEquals(contextHostToken, _hostToken))
+        {
+            return _hostToken.TryAcquireContext(context, out EditorContextOwnershipLease? lease)
+                ? new ActivationContextOwnershipResult(
+                    ActivationContextOwnershipStatus.New,
+                    lease)
+                : new ActivationContextOwnershipResult(ActivationContextOwnershipStatus.AlreadyOwned);
+        }
+
+        return contextHostToken.TryAcquireContext(context, out EditorContextOwnershipLease? cleanupLease)
+            ? new ActivationContextOwnershipResult(
+                ActivationContextOwnershipStatus.ForeignUnowned,
+                cleanupLease)
+            : new ActivationContextOwnershipResult(ActivationContextOwnershipStatus.AlreadyOwned);
     }
 
     private bool TrySelectTabItem(EditorTabItem item)
@@ -2261,6 +2358,72 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
             TaskScheduler.Default);
     }
 
+    private void ObserveDeferredTabDisposal(
+        EditorTabItem item,
+        EditorContextOwnershipLease ownershipLease)
+    {
+        Task disposal;
+        try
+        {
+            disposal = item.DisposeAsync().AsTask();
+        }
+        catch (Exception ex)
+        {
+            disposal = ForceDisposeTabAfterStartFailureAsync(item, ex);
+        }
+
+        ObserveDeferredTabDisposal(ReleaseLeaseAfterAsync(disposal, ownershipLease));
+    }
+
+    private async Task ForceDisposeTabAfterStartFailureAsync(
+        EditorTabItem item,
+        Exception startupFailure)
+    {
+        List<Exception> failures = [startupFailure];
+        try
+        {
+            await RemoveTabItemAsync(item).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            failures.Add(ex);
+        }
+
+        try
+        {
+            await item.DisposeResourcesAsync().ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            failures.Add(ex);
+        }
+
+        try
+        {
+            item.ReleaseContextRegistration();
+        }
+        catch (Exception ex)
+        {
+            failures.Add(ex);
+        }
+
+        throw failures.Count == 1 ? failures[0] : new AggregateException(failures);
+    }
+
+    private static async Task ReleaseLeaseAfterAsync(
+        Task disposal,
+        EditorContextOwnershipLease ownershipLease)
+    {
+        try
+        {
+            await disposal.ConfigureAwait(false);
+        }
+        finally
+        {
+            ownershipLease.Dispose();
+        }
+    }
+
     private static void ObserveDeferredContextDisposal(IEditorContext context)
     {
         Task disposal;
@@ -2274,6 +2437,38 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
         }
 
         ObserveDeferredTabDisposal(disposal);
+    }
+
+    private static void ObserveDeferredContextDisposal(
+        IEditorContext context,
+        EditorContextOwnershipLease ownershipLease)
+    {
+        Task disposal;
+        try
+        {
+            disposal = DisposeContextAndReleaseLeaseAsync(context, ownershipLease);
+        }
+        catch (Exception ex)
+        {
+            ownershipLease.Dispose();
+            disposal = Task.FromException(ex);
+        }
+
+        ObserveDeferredTabDisposal(disposal);
+    }
+
+    private static async Task DisposeContextAndReleaseLeaseAsync(
+        IEditorContext context,
+        EditorContextOwnershipLease ownershipLease)
+    {
+        try
+        {
+            await context.DisposeAsync().ConfigureAwait(false);
+        }
+        finally
+        {
+            ownershipLease.Dispose();
+        }
     }
 
     private static void ObserveDeferredTaskFailure(Task task)

--- a/src/Beutl/Services/EditorService.cs
+++ b/src/Beutl/Services/EditorService.cs
@@ -34,6 +34,7 @@ public sealed class EditorTabItem : IAsyncDisposable
     private bool _publicationActive;
     private MembershipState _membershipState;
     private Task? _hostCloseTask;
+    private EditorContextHostToken? _ownerHostToken;
     private Action<EditorTabItem>? _terminalFailureHandler;
     private Func<EditorTabItem, IEditorContext, EditorContextRegistration?>? _claimContextHandler;
     private Func<EditorTabItem, EditorContextRegistration, bool>? _publishContextHandler;
@@ -69,6 +70,7 @@ public sealed class EditorTabItem : IAsyncDisposable
     public IReadOnlyReactiveProperty<IEditorContext?> Context => MutableContext;
 
     internal bool TryAttachOwner(
+        EditorContextHostToken hostToken,
         Action<EditorTabItem> terminalFailureHandler,
         EditorContextRegistration registration,
         Func<EditorTabItem, IEditorContext, EditorContextRegistration?> claimContextHandler,
@@ -80,6 +82,7 @@ public sealed class EditorTabItem : IAsyncDisposable
             if (_closing || _disposeTask is not null || _claimContextHandler is not null)
                 return false;
 
+            _ownerHostToken = hostToken;
             _terminalFailureHandler = terminalFailureHandler;
             _contextRegistration = registration;
             _claimContextHandler = claimContextHandler;
@@ -96,6 +99,12 @@ public sealed class EditorTabItem : IAsyncDisposable
             lock (_lifetimeGate)
                 return _claimContextHandler is not null;
         }
+    }
+
+    internal bool IsOwnedBy(EditorContextHostToken hostToken)
+    {
+        lock (_lifetimeGate)
+            return ReferenceEquals(_ownerHostToken, hostToken);
     }
 
     // Serialize publication admission with disposal, then run observer callbacks outside the
@@ -331,8 +340,9 @@ public sealed class EditorTabItem : IAsyncDisposable
     /// Replaces the owned editor context after the previous context has fully torn down.
     /// </summary>
     /// <remarks>
-    /// A context already claimed by this or another tab is rejected without being consumed.
-    /// All other supplied contexts are consumed for both return values.
+    /// A context already active in this tab, claimed by this or another tab, or bound to another
+    /// editor host is rejected without being consumed. All other supplied contexts are consumed
+    /// for both return values.
     /// </remarks>
     public ValueTask<bool> ReplaceContextAsync(IEditorContext context)
     {
@@ -767,6 +777,7 @@ public sealed class EditorTabItem : IAsyncDisposable
 
 public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContextCloseService
 {
+    private readonly EditorContextHostToken _hostToken = new();
     private readonly CoreList<EditorTabItem> _tabItems;
     private readonly ExtensionProvider _extensionProvider;
     private readonly Action<Project, Uri> _serializeProject;
@@ -824,6 +835,9 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
         ProjectVersionControlService = _projectVersionControlService
             .ToReadOnlyReactivePropertySlim();
     }
+
+    /// <summary>Gets the opaque identity retained by contexts created for this host.</summary>
+    public EditorContextHostToken HostToken => _hostToken;
 
     public ICoreReadOnlyList<EditorTabItem> TabItems => _tabItems;
 
@@ -913,7 +927,9 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
 
     internal void AddTabItem(EditorTabItem item)
     {
-        if (!TryAddTabItem(item) && item.IsHostOwned && !ContainsTabItem(item))
+        if (!TryAddTabItem(item)
+            && item.IsOwnedBy(_hostToken)
+            && !ContainsTabItem(item))
             ObserveDeferredTabDisposal(item.DisposeAsync().AsTask());
     }
 
@@ -963,6 +979,9 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
         Action? beforeAdd,
         Action? beforeSelection)
     {
+        if (item.Context.Value is not { } context || !HasMatchingHostToken(context))
+            return false;
+
         if (!item.IsHostOwned && !TryAttachOwner(item))
             return false;
         if (!item.TryBeginAttachment())
@@ -1199,7 +1218,7 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
     private bool TryAttachOwner(EditorTabItem item)
     {
         IEditorContext? context = item.Context.Value;
-        if (context is null)
+        if (context is null || !HasMatchingHostToken(context))
             return false;
 
         lock (_contextRegistryGate)
@@ -1211,6 +1230,7 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
             var registration = new EditorContextRegistration(context, generation);
             BeforeInitialOwnerAttach?.Invoke();
             if (!item.TryAttachOwner(
+                    _hostToken,
                     RemoveFailedTabItem,
                     registration,
                     TryClaimContext,
@@ -1230,6 +1250,9 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
         EditorTabItem item,
         IEditorContext context)
     {
+        if (!HasMatchingHostToken(context))
+            return null;
+
         lock (_contextRegistryGate)
         {
             if (_contextItems.ContainsKey(context) || _reservedContextItems.ContainsKey(context))
@@ -1239,6 +1262,11 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
             _reservedContextItems.Add(context, (item, generation));
             return new EditorContextRegistration(context, generation);
         }
+    }
+
+    private bool HasMatchingHostToken(IEditorContext context)
+    {
+        return ReferenceEquals(context.CloseService.HostToken, _hostToken);
     }
 
     private bool PublishContextClaim(

--- a/src/Beutl/Services/EditorService.cs
+++ b/src/Beutl/Services/EditorService.cs
@@ -70,9 +70,11 @@ public sealed class EditorTabItem : IAsyncDisposable
         new(ReferenceEqualityComparer.Instance);
     private string? _hash;
 
-    public EditorTabItem(IEditorContext context)
+    internal EditorTabItem(IEditorContext context)
     {
         MutableContext = new ReactiveProperty<IEditorContext?>(context);
+        Context = MutableContext.ToReadOnlyReactivePropertySlim();
+        IsSelected = MutableIsSelected.ToReadOnlyReactivePropertySlim();
         FilePath = Context
             .Where(static ctxt => ctxt is not null)
             .Select(static ctxt => ctxt!.Object.Uri?.LocalPath)
@@ -93,7 +95,7 @@ public sealed class EditorTabItem : IAsyncDisposable
     private IReactiveProperty<IEditorContext?> MutableContext { get; }
 
     /// <summary>The active editor context, or <see langword="null"/> while replacement or closure is in progress.</summary>
-    public IReadOnlyReactiveProperty<IEditorContext?> Context => MutableContext;
+    public IReadOnlyReactiveProperty<IEditorContext?> Context { get; }
 
     internal bool TryAttachOwner(
         EditorContextHostToken hostToken,
@@ -400,7 +402,12 @@ public sealed class EditorTabItem : IAsyncDisposable
 
     public IReadOnlyReactiveProperty<IKnownEditorCommands?> Commands { get; }
 
-    public IReactiveProperty<bool> IsSelected { get; } = new ReactivePropertySlim<bool>();
+    private IReactiveProperty<bool> MutableIsSelected { get; } = new ReactivePropertySlim<bool>();
+
+    public IReadOnlyReactiveProperty<bool> IsSelected { get; }
+
+    internal void SetIsSelected(bool value)
+        => MutableIsSelected.Value = value;
 
     public string GetFileNameHash()
     {
@@ -938,10 +945,12 @@ public sealed class EditorTabItem : IAsyncDisposable
         finally
         {
             DisposeSurface(MutableContext, ref failures);
+            DisposeSurface(Context, ref failures);
             DisposeSurface(FilePath, ref failures);
             DisposeSurface(FileName, ref failures);
             DisposeSurface(Extension, ref failures);
             DisposeSurface(Commands, ref failures);
+            DisposeSurface(MutableIsSelected, ref failures);
             DisposeSurface(IsSelected, ref failures);
             if (failures is null)
                 completion.TrySetResult(null);
@@ -959,8 +968,41 @@ public sealed class EditorTabItem : IAsyncDisposable
 
 public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContextCloseService
 {
+    private sealed class ReadOnlyCoreListView<T> : ICoreReadOnlyList<T>
+    {
+        private readonly ICoreReadOnlyList<T> _source;
+
+        public ReadOnlyCoreListView(ICoreReadOnlyList<T> source)
+        {
+            _source = source;
+            _source.CollectionChanged += OnCollectionChanged;
+            _source.PropertyChanged += OnPropertyChanged;
+        }
+
+        public int Count => _source.Count;
+
+        public T this[int index] => _source[index];
+
+        public event System.Collections.Specialized.NotifyCollectionChangedEventHandler? CollectionChanged;
+
+        public event System.ComponentModel.PropertyChangedEventHandler? PropertyChanged;
+
+        public IEnumerator<T> GetEnumerator() => _source.GetEnumerator();
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
+
+        private void OnCollectionChanged(
+            object? sender,
+            System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+            => CollectionChanged?.Invoke(this, e);
+
+        private void OnPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+            => PropertyChanged?.Invoke(this, e);
+    }
+
     private readonly EditorContextHostToken _hostToken = new();
     private readonly CoreList<EditorTabItem> _tabItems;
+    private readonly ICoreReadOnlyList<EditorTabItem> _tabItemsView;
     private readonly ExtensionProvider _extensionProvider;
     private readonly Action<Project, Uri> _serializeProject;
     private readonly ReactivePropertySlim<IProjectVersionControlService?>
@@ -975,6 +1017,7 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
     private int _activeOutputOperations;
     private int _activeProjectFileWrites;
     private bool _worktreeMutationActive;
+    private readonly IReactiveProperty<EditorTabItem?> _selectedTabItem = new ReactivePropertySlim<EditorTabItem?>();
     private readonly object _tabAdmissionGate = new();
     private readonly SemaphoreSlim _tabReconciliationGate = new(1, 1);
     private static readonly AsyncLocal<TabAdmissionOperation?> s_tabAdmissionOperation = new();
@@ -1027,6 +1070,8 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
         _tabItems = new() { ResetBehavior = ResetBehavior.Remove };
         ProjectVersionControlService = _projectVersionControlService
             .ToReadOnlyReactivePropertySlim();
+        _tabItemsView = new ReadOnlyCoreListView<EditorTabItem>(_tabItems);
+        SelectedTabItem = _selectedTabItem.ToReadOnlyReactivePropertySlim();
     }
 
     /// <summary>Gets the opaque identity retained by contexts created for this host.</summary>
@@ -1034,7 +1079,7 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
 
     internal ExtensionProvider ExtensionProvider => _extensionProvider;
 
-    public ICoreReadOnlyList<EditorTabItem> TabItems => _tabItems;
+    public ICoreReadOnlyList<EditorTabItem> TabItems => _tabItemsView;
 
     internal async ValueTask ClearTabItemsAsync()
         => await ReconcileTabItemsAsync([]);
@@ -1077,7 +1122,7 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
 
             foreach (CoreObject item in items)
             {
-                try { ActivateTabItemCore(item); }
+                try { await ActivateTabItemCoreAsync(item); }
                 catch (Exception ex) { (failures ??= []).Add(ex); }
             }
             foreach (Exception ex in await DrainActiveLifecycleTeardownsAsync())
@@ -1197,11 +1242,10 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
                 return EditorContextReplacementStatus.NotOwned;
             }
 
-            if (!extension.TryCreateContext(
-                    current.Object,
-                    new EditorContextServices(this, _extensionProvider),
-                    out IEditorContext? replacement)
-                || replacement is null)
+            IEditorContext? replacement = await extension.CreateContextAsync(
+                current.Object,
+                new EditorContextServices(this, _extensionProvider));
+            if (replacement is null)
             {
                 return EditorContextReplacementStatus.CreationFailed;
             }
@@ -1451,14 +1495,14 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
                             return;
                         }
 
-                        item.IsSelected.Value = true;
+                        item.SetIsSelected(true);
                         if (!CanContinuePublication(item))
                         {
                             RollbackSelection(item);
                             return;
                         }
 
-                        SelectedTabItem.Value = item;
+                        _selectedTabItem.Value = item;
                         if (!CanContinuePublication(item)
                             || !ReferenceEquals(SelectedTabItem.Value, item))
                         {
@@ -1630,10 +1674,10 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
         // Otherwise a tab that is no longer live can be re-exposed as the selected item.
         if (ReferenceEquals(SelectedTabItem.Value, item))
         {
-            try { SelectedTabItem.Value = null; }
+            try { _selectedTabItem.Value = null; }
             catch (Exception ex) { (failures ??= []).Add(ex); }
         }
-        try { item.IsSelected.Value = false; }
+        try { item.SetIsSelected(false); }
         catch (Exception ex) { (failures ??= []).Add(ex); }
 
         if (failures is not null)
@@ -2171,7 +2215,7 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
         return null;
     }
 
-    public IReactiveProperty<EditorTabItem?> SelectedTabItem { get; } = new ReactivePropertySlim<EditorTabItem?>();
+    public IReadOnlyReactiveProperty<EditorTabItem?> SelectedTabItem { get; }
 
     internal IReadOnlyReactiveProperty<IProjectVersionControlService?>
         ProjectVersionControlService
@@ -2543,7 +2587,7 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
         return result != null;
     }
 
-    public void ActivateTabItem(CoreObject obj)
+    public async Task ActivateTabItemAsync(CoreObject obj)
     {
         if (!TryEnterTabAdmission())
             return;
@@ -2555,7 +2599,7 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
             previousOperation = s_tabAdmissionOperation.Value;
             operation = BeginTabAdmissionOperation();
             s_tabAdmissionOperation.Value = operation;
-            ActivateTabItemCore(obj);
+            await ActivateTabItemCoreAsync(obj);
         }
         finally
         {
@@ -2564,7 +2608,31 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
         }
     }
 
-    private void ActivateTabItemCore(CoreObject obj)
+    /// <summary>Activates a tab that is currently owned and published by this editor host.</summary>
+    /// <returns><see langword="true"/> when the tab was selected; otherwise <see langword="false"/>.</returns>
+    public bool ActivateTabItem(EditorTabItem item)
+    {
+        ArgumentNullException.ThrowIfNull(item);
+        if (!TryEnterTabAdmission())
+            return false;
+
+        TabAdmissionOperation? operation = null;
+        TabAdmissionOperation? previousOperation = null;
+        try
+        {
+            previousOperation = s_tabAdmissionOperation.Value;
+            operation = BeginTabAdmissionOperation();
+            s_tabAdmissionOperation.Value = operation;
+            return TrySelectTabItem(item);
+        }
+        finally
+        {
+            CompleteTabAdmissionOperation(operation, previousOperation);
+            ExitTabAdmission();
+        }
+    }
+
+    private async Task ActivateTabItemCoreAsync(CoreObject obj)
     {
         ViewConfig viewConfig = GlobalConfiguration.Instance.ViewConfig;
         string path = Uri.UnescapeDataString(obj.Uri!.LocalPath);
@@ -2578,13 +2646,14 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
         {
             EditorExtension? ext = _extensionProvider.MatchEditorExtension(path);
 
-            if (ext is not null
-                && ext.TryCreateContext(
-                    obj,
-                    new EditorContextServices(this, _extensionProvider),
-                    out IEditorContext? context)
-                && context is not null)
+            if (ext is not null)
             {
+                IEditorContext? context = await ext.CreateContextAsync(
+                    obj,
+                    new EditorContextServices(this, _extensionProvider));
+                if (context is null)
+                    return;
+
                 ActivationContextOwnershipResult ownership;
                 try
                 {
@@ -2609,7 +2678,7 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
                 {
                     BeforeActivationTabConstruction?.Invoke(context);
                     tabItem2 = new EditorTabItem(context);
-                    tabItem2.IsSelected.Value = true;
+                    tabItem2.SetIsSelected(true);
                     added = TryAddTabItemCore(
                         tabItem2,
                         select: true,
@@ -2664,14 +2733,14 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
                     if (!CanContinuePublication(item))
                         return;
 
-                    item.IsSelected.Value = true;
+                    item.SetIsSelected(true);
                     if (!CanContinuePublication(item))
                     {
                         RollbackSelection(item);
                         return;
                     }
 
-                    SelectedTabItem.Value = item;
+                    _selectedTabItem.Value = item;
                     if (!CanContinuePublication(item)
                         || !ReferenceEquals(SelectedTabItem.Value, item))
                     {
@@ -2725,10 +2794,10 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
         List<Exception>? failures = null;
         if (ReferenceEquals(SelectedTabItem.Value, item))
         {
-            try { SelectedTabItem.Value = null; }
+            try { _selectedTabItem.Value = null; }
             catch (Exception ex) { (failures ??= []).Add(ex); }
         }
-        try { item.IsSelected.Value = false; }
+        try { item.SetIsSelected(false); }
         catch (Exception ex) { (failures ??= []).Add(ex); }
 
         if (failures is not null)

--- a/src/Beutl/Services/EditorService.cs
+++ b/src/Beutl/Services/EditorService.cs
@@ -968,6 +968,9 @@ public sealed class EditorTabItem : IAsyncDisposable
 
 public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContextCloseService
 {
+    private readonly object _activationPublicationGate = new();
+    private readonly HashSet<CoreObject> _activationPublications = new(ReferenceEqualityComparer.Instance);
+
     private sealed class ReadOnlyCoreListView<T> : ICoreReadOnlyList<T>
     {
         private readonly ICoreReadOnlyList<T> _source;
@@ -2697,8 +2700,23 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
 
                 EditorTabItem? tabItem2 = null;
                 bool added = false;
+                bool reserved = false;
                 try
                 {
+                    EditorTabItem? existing;
+                    lock (_activationPublicationGate)
+                    {
+                        TryGetTabItem(obj, out existing);
+                        if (existing is null)
+                            reserved = _activationPublications.Add(obj);
+                    }
+                    if (existing is not null)
+                    {
+                        TrySelectTabItem(existing);
+                        return;
+                    }
+                    if (!reserved)
+                        return;
                     BeforeActivationTabConstruction?.Invoke(context);
                     tabItem2 = new EditorTabItem(context);
                     tabItem2.SetIsSelected(true);
@@ -2711,6 +2729,11 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
                 }
                 finally
                 {
+                    if (reserved)
+                    {
+                        lock (_activationPublicationGate)
+                            _activationPublications.Remove(obj);
+                    }
                     if (!added)
                     {
                         if (tabItem2 is not null)

--- a/src/Beutl/Services/EditorService.cs
+++ b/src/Beutl/Services/EditorService.cs
@@ -17,9 +17,23 @@ internal interface IEditorContextPublicationGate
     bool TryPublish(Action publish);
 }
 
+internal enum EditorContextClaimStatus
+{
+    Claimed,
+    AlreadyOwned,
+    InvalidHost,
+    InvalidHostClaimedForCleanup
+}
+
 internal readonly record struct EditorContextRegistration(
     IEditorContext Context,
-    long Generation);
+    long Generation,
+    EditorContextOwnershipLease OwnershipLease);
+
+internal readonly record struct EditorContextClaimResult(
+    EditorContextClaimStatus Status,
+    EditorContextRegistration? Registration = null,
+    EditorContextOwnershipLease? CleanupLease = null);
 
 public sealed class EditorTabItem : IAsyncDisposable
 {
@@ -36,7 +50,7 @@ public sealed class EditorTabItem : IAsyncDisposable
     private Task? _hostCloseTask;
     private EditorContextHostToken? _ownerHostToken;
     private Action<EditorTabItem>? _terminalFailureHandler;
-    private Func<EditorTabItem, IEditorContext, EditorContextRegistration?>? _claimContextHandler;
+    private Func<EditorTabItem, IEditorContext, EditorContextClaimResult>? _claimContextHandler;
     private Func<EditorTabItem, EditorContextRegistration, bool>? _publishContextHandler;
     private Action<EditorTabItem, EditorContextRegistration>? _releaseContextHandler;
     private EditorContextRegistration? _contextRegistration;
@@ -73,7 +87,7 @@ public sealed class EditorTabItem : IAsyncDisposable
         EditorContextHostToken hostToken,
         Action<EditorTabItem> terminalFailureHandler,
         EditorContextRegistration registration,
-        Func<EditorTabItem, IEditorContext, EditorContextRegistration?> claimContextHandler,
+        Func<EditorTabItem, IEditorContext, EditorContextClaimResult> claimContextHandler,
         Func<EditorTabItem, EditorContextRegistration, bool> publishContextHandler,
         Action<EditorTabItem, EditorContextRegistration> releaseContextHandler)
     {
@@ -92,12 +106,58 @@ public sealed class EditorTabItem : IAsyncDisposable
         }
     }
 
+    internal bool TryDetachOwner(EditorContextRegistration registration)
+    {
+        lock (_lifetimeGate)
+        {
+            if (_membershipState != MembershipState.Fresh
+                || _closing
+                || _disposeTask is not null
+                || !_contextRegistration.Equals(registration))
+            {
+                return false;
+            }
+
+            _ownerHostToken = null;
+            _terminalFailureHandler = null;
+            _contextRegistration = null;
+            _claimContextHandler = null;
+            _publishContextHandler = null;
+            _releaseContextHandler = null;
+            return true;
+        }
+    }
+
     internal bool IsHostOwned
     {
         get
         {
             lock (_lifetimeGate)
                 return _claimContextHandler is not null;
+        }
+    }
+
+    internal bool TryGetAttachedContext(
+        EditorContextHostToken hostToken,
+        out IEditorContext? context,
+        out EditorContextRegistration registration)
+    {
+        lock (_lifetimeGate)
+        {
+            if (!ReferenceEquals(_ownerHostToken, hostToken)
+                || _membershipState != MembershipState.Attached
+                || _contextRegistration is not { } current
+                || MutableContext.Value is not { } active
+                || !ReferenceEquals(current.Context, active))
+            {
+                context = null;
+                registration = default;
+                return false;
+            }
+
+            context = active;
+            registration = current;
+            return true;
         }
     }
 
@@ -348,44 +408,83 @@ public sealed class EditorTabItem : IAsyncDisposable
     /// Replaces the owned editor context after the previous context has fully torn down.
     /// </summary>
     /// <remarks>
-    /// A context already active in this tab, claimed by this or another tab, or bound to another
-    /// editor host is rejected without being consumed. All other supplied contexts are consumed
-    /// for both return values.
+    /// Replacement is host-mediated: an unowned tab cannot adopt a context. A context already
+    /// active in this tab, claimed by this or another tab, or bound to another editor host is
+    /// rejected without being consumed. Once this tab claims a context, the host consumes it even
+    /// when a later transition step fails; inspect <see cref="EditorContextReplacementResult.InputConsumed"/>
+    /// to determine whether the host consumed the supplied value.
     /// </remarks>
-    public ValueTask<bool> ReplaceContextAsync(IEditorContext context)
+    internal ValueTask<EditorContextReplacementResult> ReplaceContextAsync(IEditorContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        bool sameInstance;
+        Func<EditorTabItem, IEditorContext, EditorContextClaimResult>? claimContextHandler;
+        lock (_lifetimeGate)
+        {
+            sameInstance = ReferenceEquals(MutableContext.Value, context);
+            claimContextHandler = _claimContextHandler;
+
+            // Replacement is deliberately mediated by the owning host. An unowned tab must not
+            // publish a context or dispose one that belongs to another tab/host.
+            if (claimContextHandler is null
+                || _membershipState != MembershipState.Attached)
+            {
+                return new ValueTask<EditorContextReplacementResult>(
+                    new EditorContextReplacementResult(
+                        EditorContextReplacementStatus.NotOwned,
+                        inputConsumed: false));
+            }
+        }
+
+        if (sameInstance)
+            return new ValueTask<EditorContextReplacementResult>(
+                new EditorContextReplacementResult(
+                    EditorContextReplacementStatus.AlreadyActive,
+                    inputConsumed: false));
+
+        EditorContextClaimResult claim = claimContextHandler.Invoke(this, context);
+        if (claim.Status != EditorContextClaimStatus.Claimed)
+        {
+            return new ValueTask<EditorContextReplacementResult>(
+                new EditorContextReplacementResult(
+                    EditorContextReplacementStatus.NotOwned,
+                    inputConsumed: false));
+        }
+
+        return ReplaceClaimedContextAsync(context, claim.Registration!.Value);
+    }
+
+    internal ValueTask<EditorContextReplacementResult> ReplaceClaimedContextAsync(
+        IEditorContext context,
+        EditorContextRegistration replacementRegistration,
+        EditorContextRegistration? expectedRegistration = null)
     {
         ArgumentNullException.ThrowIfNull(context);
         IEditorContext? oldContext = null;
         EditorContextRegistration? oldRegistration = null;
         TaskCompletionSource? transition = null;
-        TaskCompletionSource<bool>? result = null;
+        TaskCompletionSource<EditorContextReplacementResult>? result = null;
         Exception? publicationFailure = null;
-        bool sameInstance;
-        Func<EditorTabItem, IEditorContext, EditorContextRegistration?>? claimContextHandler;
-        lock (_lifetimeGate)
-        {
-            sameInstance = ReferenceEquals(MutableContext.Value, context);
-            claimContextHandler = _claimContextHandler;
-        }
-
-        if (sameInstance)
-            return new ValueTask<bool>(false);
-
-        EditorContextRegistration? replacementRegistration = claimContextHandler?.Invoke(this, context);
-        if (claimContextHandler is not null && replacementRegistration is null)
-            return new ValueTask<bool>(false);
 
         bool rejected;
         lock (_lifetimeGate)
         {
-            rejected = _closing || _transitionTask is not null || _publicationActive;
+            bool staleExpected = expectedRegistration is { } expected
+                && (!_contextRegistration.Equals(expected)
+                    || !ReferenceEquals(MutableContext.Value, expected.Context));
+            rejected = staleExpected
+                || _claimContextHandler is null
+                || _membershipState != MembershipState.Attached
+                || _closing
+                || _transitionTask is not null
+                || _publicationActive;
             if (!rejected)
             {
                 oldContext = MutableContext.Value;
                 oldRegistration = _contextRegistration;
                 transition = new TaskCompletionSource(
                     TaskCreationOptions.RunContinuationsAsynchronously);
-                result = new TaskCompletionSource<bool>(
+                result = new TaskCompletionSource<EditorContextReplacementResult>(
                     TaskCreationOptions.RunContinuationsAsynchronously);
                 _transitionTask = transition.Task;
             }
@@ -393,18 +492,34 @@ public sealed class EditorTabItem : IAsyncDisposable
 
         if (rejected)
         {
-            return replacementRegistration is { } reserved
-                ? new ValueTask<bool>(DisposeRejectedAndReleaseContextAsync(context, reserved))
-                : new ValueTask<bool>(DisposeRejectedAndReturnFalseAsync(context));
+            return new ValueTask<EditorContextReplacementResult>(
+                DisposeRejectedAndReleaseContextAsync(context, replacementRegistration));
         }
 
-        if (replacementRegistration is { } claimed
-            && _publishContextHandler?.Invoke(this, claimed) != true)
+        bool claimPublished;
+        try
+        {
+            claimPublished = _publishContextHandler?.Invoke(this, replacementRegistration) == true;
+        }
+        catch (Exception publicationException)
         {
             lock (_lifetimeGate)
                 _transitionTask = null;
             transition!.TrySetResult();
-            return new ValueTask<bool>(DisposeRejectedAndReleaseContextAsync(context, claimed));
+            return new ValueTask<EditorContextReplacementResult>(
+                DisposeClaimedContextAfterFailureAsync(
+                    context,
+                    replacementRegistration,
+                    publicationException));
+        }
+
+        if (!claimPublished)
+        {
+            lock (_lifetimeGate)
+                _transitionTask = null;
+            transition!.TrySetResult();
+            return new ValueTask<EditorContextReplacementResult>(
+                DisposeRejectedAndReleaseContextAsync(context, replacementRegistration));
         }
 
         try
@@ -427,7 +542,7 @@ public sealed class EditorTabItem : IAsyncDisposable
             transition!,
             result!,
             publicationFailure);
-        return new ValueTask<bool>(result!.Task);
+        return new ValueTask<EditorContextReplacementResult>(result!.Task);
     }
 
     private async Task CompleteReplacementAsync(
@@ -436,7 +551,7 @@ public sealed class EditorTabItem : IAsyncDisposable
         EditorContextRegistration? oldRegistration,
         EditorContextRegistration? replacementRegistration,
         TaskCompletionSource transition,
-        TaskCompletionSource<bool> result,
+        TaskCompletionSource<EditorContextReplacementResult> result,
         Exception? publicationFailure)
     {
         bool published = false;
@@ -492,11 +607,16 @@ public sealed class EditorTabItem : IAsyncDisposable
         if (published)
         {
             if (oldRegistration is { } old)
-                _releaseContextHandler?.Invoke(this, old);
-        }
-        else if (replacementRegistration is { } reserved)
-        {
-            _releaseContextHandler?.Invoke(this, reserved);
+            {
+                try
+                {
+                    _releaseContextHandler?.Invoke(this, old);
+                }
+                catch (Exception ex)
+                {
+                    RecordFailure(ref failures, ex);
+                }
+            }
         }
 
         bool closeWonAfterPublication;
@@ -520,12 +640,25 @@ public sealed class EditorTabItem : IAsyncDisposable
                 .ConfigureAwait(true);
             if (rejectionFailure is not null)
                 RecordFailure(ref failures, rejectionFailure);
+            if (replacementRegistration is { } reserved)
+            {
+                try
+                {
+                    _releaseContextHandler?.Invoke(this, reserved);
+                }
+                catch (Exception ex)
+                {
+                    RecordFailure(ref failures, ex);
+                }
+            }
         }
 
         transition.TrySetResult();
         if (failures is null && accepted && !closeWonAfterPublication)
         {
-            result.TrySetResult(true);
+            result.TrySetResult(new EditorContextReplacementResult(
+                EditorContextReplacementStatus.Succeeded,
+                inputConsumed: true));
             return;
         }
 
@@ -550,7 +683,9 @@ public sealed class EditorTabItem : IAsyncDisposable
             RecordFailure(ref failures, ex);
         }
         if (failures is null)
-            result.TrySetResult(false);
+            result.TrySetResult(new EditorContextReplacementResult(
+                EditorContextReplacementStatus.Busy,
+                inputConsumed: true));
         else
             result.TrySetException(CreateFailure(failures));
     }
@@ -617,26 +752,51 @@ public sealed class EditorTabItem : IAsyncDisposable
         }
     }
 
-    private async Task<bool> DisposeRejectedAndReturnFalseAsync(IEditorContext context)
+    private async Task<EditorContextReplacementResult> DisposeRejectedAndReturnResultAsync(
+        IEditorContext context,
+        EditorContextReplacementStatus status)
     {
         Exception? failure = await TryDisposeRejectedContextOwnedAsync(context).ConfigureAwait(true);
         if (failure is not null)
             throw failure;
-        return false;
+        return new EditorContextReplacementResult(status, inputConsumed: true);
     }
 
-    private async Task<bool> DisposeRejectedAndReleaseContextAsync(
+    private async Task<EditorContextReplacementResult> DisposeRejectedAndReleaseContextAsync(
         IEditorContext context,
         EditorContextRegistration registration)
     {
         try
         {
-            return await DisposeRejectedAndReturnFalseAsync(context).ConfigureAwait(true);
+            return await DisposeRejectedAndReturnResultAsync(
+                context,
+                EditorContextReplacementStatus.Busy).ConfigureAwait(true);
         }
         finally
         {
             _releaseContextHandler?.Invoke(this, registration);
         }
+    }
+
+    private async Task<EditorContextReplacementResult> DisposeClaimedContextAfterFailureAsync(
+        IEditorContext context,
+        EditorContextRegistration registration,
+        Exception failure)
+    {
+        List<Exception> failures = [failure];
+        Exception? disposalFailure = await TryDisposeRejectedContextOwnedAsync(context).ConfigureAwait(true);
+        if (disposalFailure is not null)
+            failures.Add(disposalFailure);
+        try
+        {
+            _releaseContextHandler?.Invoke(this, registration);
+        }
+        catch (Exception releaseFailure)
+        {
+            failures.Add(releaseFailure);
+        }
+
+        throw CreateFailure(failures);
     }
 
     /// <summary>Requests terminal disposal of the tab and its owned context.</summary>
@@ -849,6 +1009,8 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
     /// <summary>Gets the opaque identity retained by contexts created for this host.</summary>
     public EditorContextHostToken HostToken => _hostToken;
 
+    internal ExtensionProvider ExtensionProvider => _extensionProvider;
+
     public ICoreReadOnlyList<EditorTabItem> TabItems => _tabItems;
 
     internal async ValueTask ClearTabItemsAsync()
@@ -941,6 +1103,92 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
             && item.IsOwnedBy(_hostToken)
             && !ContainsTabItem(item))
             ObserveDeferredTabDisposal(item.DisposeAsync().AsTask());
+    }
+
+    /// <summary>
+    /// Creates and host-mediates a replacement context for an attached tab.
+    /// </summary>
+    /// <remarks>
+    /// A successful context factory call transfers ownership to this host. New factory results are
+    /// disposed here when replacement is rejected; a context already claimed by any host remains
+    /// with that owner. Callers never own a context returned by this operation.
+    /// </remarks>
+    /// <param name="item">The attached tab whose context will be replaced.</param>
+    /// <param name="extension">The extension that creates the replacement context.</param>
+    /// <returns>The terminal replacement status.</returns>
+    public async ValueTask<EditorContextReplacementStatus> ReplaceContextAsync(
+        EditorTabItem item,
+        EditorExtension extension)
+    {
+        ArgumentNullException.ThrowIfNull(item);
+        ArgumentNullException.ThrowIfNull(extension);
+
+        if (!item.TryGetAttachedContext(_hostToken, out IEditorContext? current, out EditorContextRegistration registration)
+            || current is null)
+        {
+            return EditorContextReplacementStatus.NotOwned;
+        }
+
+        if (!extension.TryCreateContext(
+                current.Object,
+                new EditorContextServices(this, _extensionProvider),
+                out IEditorContext? replacement)
+            || replacement is null)
+        {
+            return EditorContextReplacementStatus.CreationFailed;
+        }
+
+        EditorContextClaimResult claim;
+        try
+        {
+            claim = TryClaimContext(item, replacement, claimInvalidHostForCleanup: true);
+        }
+        catch (Exception claimException)
+        {
+            try
+            {
+                await replacement.DisposeAsync().ConfigureAwait(true);
+            }
+            catch (Exception disposalException)
+            {
+                throw new AggregateException(claimException, disposalException);
+            }
+
+            throw;
+        }
+
+        if (claim.Status == EditorContextClaimStatus.AlreadyOwned)
+        {
+            return ReferenceEquals(replacement, current)
+                ? EditorContextReplacementStatus.AlreadyActive
+                : EditorContextReplacementStatus.NotOwned;
+        }
+
+        if (claim.Status == EditorContextClaimStatus.InvalidHostClaimedForCleanup)
+        {
+            try
+            {
+                await replacement.DisposeAsync().ConfigureAwait(true);
+            }
+            finally
+            {
+                claim.CleanupLease!.Dispose();
+            }
+
+            return EditorContextReplacementStatus.NotOwned;
+        }
+
+        if (claim.Status != EditorContextClaimStatus.Claimed)
+        {
+            await replacement.DisposeAsync().ConfigureAwait(true);
+            return EditorContextReplacementStatus.NotOwned;
+        }
+
+        EditorContextReplacementResult result = await item.ReplaceClaimedContextAsync(
+            replacement,
+            claim.Registration!.Value,
+            registration);
+        return result.Status;
     }
 
     internal bool TryAddTabItem(EditorTabItem item)
@@ -1235,42 +1483,94 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
         {
             if (_contextItems.ContainsKey(context) || _reservedContextItems.ContainsKey(context))
                 return false;
-
-            long generation = ++_contextRegistrationGeneration;
-            var registration = new EditorContextRegistration(context, generation);
-            BeforeInitialOwnerAttach?.Invoke();
-            if (!item.TryAttachOwner(
-                    _hostToken,
-                    RemoveFailedTabItem,
-                    registration,
-                    TryClaimContext,
-                    PublishContextClaim,
-                    ReleaseContext))
-            {
+            if (!_hostToken.TryAcquireContext(context, out EditorContextOwnershipLease? ownershipLease))
                 return false;
-            }
 
-            BeforeInitialContextClaimPublish?.Invoke();
-            _contextItems.Add(context, (item, generation));
-            return true;
+            bool registered = false;
+            bool ownerAttached = false;
+            long generation = ++_contextRegistrationGeneration;
+            var registration = new EditorContextRegistration(context, generation, ownershipLease);
+            try
+            {
+                BeforeInitialOwnerAttach?.Invoke();
+                if (!item.TryAttachOwner(
+                        _hostToken,
+                        RemoveFailedTabItem,
+                        registration,
+                        TryClaimContext,
+                        PublishContextClaim,
+                        ReleaseContext))
+                {
+                    return false;
+                }
+                ownerAttached = true;
+
+                BeforeInitialContextClaimPublish?.Invoke();
+                _contextItems.Add(context, (item, generation));
+                registered = true;
+                return true;
+            }
+            finally
+            {
+                if (!registered && (!ownerAttached || item.TryDetachOwner(registration)))
+                    ownershipLease.Dispose();
+            }
         }
     }
 
-    private EditorContextRegistration? TryClaimContext(
+    private EditorContextClaimResult TryClaimContext(
         EditorTabItem item,
         IEditorContext context)
+        => TryClaimContext(item, context, claimInvalidHostForCleanup: false);
+
+    private EditorContextClaimResult TryClaimContext(
+        EditorTabItem item,
+        IEditorContext context,
+        bool claimInvalidHostForCleanup)
     {
-        if (!HasMatchingHostToken(context))
-            return null;
+        EditorContextHostToken contextHostToken = context.CloseService.HostToken;
+        if (!ReferenceEquals(contextHostToken, _hostToken))
+        {
+            if (!claimInvalidHostForCleanup)
+                return new EditorContextClaimResult(EditorContextClaimStatus.InvalidHost);
+
+            bool cleanupClaimed = contextHostToken.TryAcquireContext(
+                context,
+                out EditorContextOwnershipLease? cleanupLease);
+            return cleanupClaimed
+                ? new EditorContextClaimResult(
+                    EditorContextClaimStatus.InvalidHostClaimedForCleanup,
+                    CleanupLease: cleanupLease)
+                : new EditorContextClaimResult(EditorContextClaimStatus.AlreadyOwned);
+        }
 
         lock (_contextRegistryGate)
         {
             if (_contextItems.ContainsKey(context) || _reservedContextItems.ContainsKey(context))
-                return null;
+                return new EditorContextClaimResult(EditorContextClaimStatus.AlreadyOwned);
+
+            if (!_hostToken.TryAcquireContext(context, out EditorContextOwnershipLease? ownershipLease))
+                return new EditorContextClaimResult(EditorContextClaimStatus.AlreadyOwned);
 
             long generation = ++_contextRegistrationGeneration;
-            _reservedContextItems.Add(context, (item, generation));
-            return new EditorContextRegistration(context, generation);
+            try
+            {
+                _reservedContextItems.Add(context, (item, generation));
+                return new EditorContextClaimResult(
+                    EditorContextClaimStatus.Claimed,
+                    new EditorContextRegistration(context, generation, ownershipLease));
+            }
+            catch
+            {
+                if (_reservedContextItems.TryGetValue(context, out var reserved)
+                    && ReferenceEquals(reserved.Item, item)
+                    && reserved.Generation == generation)
+                {
+                    _reservedContextItems.Remove(context);
+                }
+                ownershipLease.Dispose();
+                throw;
+            }
         }
     }
 
@@ -1318,6 +1618,8 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
                 _reservedContextItems.Remove(registration.Context);
             }
         }
+
+        registration.OwnershipLease.Dispose();
     }
 
     internal ExtensionProvider ExtensionProvider => _extensionProvider;

--- a/src/Beutl/Services/EditorService.cs
+++ b/src/Beutl/Services/EditorService.cs
@@ -17,11 +17,13 @@ internal interface IEditorContextPublicationGate
     bool TryPublish(Action publish);
 }
 
+internal readonly record struct EditorContextRegistration(
+    IEditorContext Context,
+    long Generation);
+
 public sealed class EditorTabItem : IAsyncDisposable
 {
     private readonly object _lifetimeGate = new();
-    private static readonly AsyncLocal<OwnedDisposalScope?> s_ownedDisposals = new();
-    private static readonly AsyncLocal<PublicationScope?> s_publicationScope = new();
     private Task? _disposeTask;
     private Task? _transitionTask;
     private TaskCompletionSource? _publicationDrain;
@@ -30,7 +32,14 @@ public sealed class EditorTabItem : IAsyncDisposable
     private bool _contextDisposeAttempted;
     private bool _publicationActive;
     private MembershipState _membershipState;
+    private Task? _hostCloseTask;
     private Action<EditorTabItem>? _terminalFailureHandler;
+    private Func<EditorTabItem, IEditorContext, EditorContextRegistration?>? _claimContextHandler;
+    private Func<EditorTabItem, EditorContextRegistration, bool>? _publishContextHandler;
+    private Action<EditorTabItem, EditorContextRegistration>? _releaseContextHandler;
+    private EditorContextRegistration? _contextRegistration;
+    private readonly HashSet<IEditorContext> _hostDisposingContexts =
+        new(ReferenceEqualityComparer.Instance);
     private string? _hash;
 
     public EditorTabItem(IEditorContext context)
@@ -58,8 +67,35 @@ public sealed class EditorTabItem : IAsyncDisposable
     /// <summary>The active editor context, or <see langword="null"/> while replacement or closure is in progress.</summary>
     public IReadOnlyReactiveProperty<IEditorContext?> Context => MutableContext;
 
-    internal void AttachOwner(Action<EditorTabItem> terminalFailureHandler)
-        => _terminalFailureHandler = terminalFailureHandler;
+    internal bool TryAttachOwner(
+        Action<EditorTabItem> terminalFailureHandler,
+        EditorContextRegistration registration,
+        Func<EditorTabItem, IEditorContext, EditorContextRegistration?> claimContextHandler,
+        Func<EditorTabItem, EditorContextRegistration, bool> publishContextHandler,
+        Action<EditorTabItem, EditorContextRegistration> releaseContextHandler)
+    {
+        lock (_lifetimeGate)
+        {
+            if (_closing || _disposeTask is not null || _claimContextHandler is not null)
+                return false;
+
+            _terminalFailureHandler = terminalFailureHandler;
+            _contextRegistration = registration;
+            _claimContextHandler = claimContextHandler;
+            _publishContextHandler = publishContextHandler;
+            _releaseContextHandler = releaseContextHandler;
+            return true;
+        }
+    }
+
+    internal bool IsHostOwned
+    {
+        get
+        {
+            lock (_lifetimeGate)
+                return _claimContextHandler is not null;
+        }
+    }
 
     // Serialize publication admission with disposal, then run observer callbacks outside the
     // lifetime gate. Admitted callbacks are drained before teardown touches reactive surfaces.
@@ -83,9 +119,6 @@ public sealed class EditorTabItem : IAsyncDisposable
             _publicationDrain = drain;
         }
 
-        PublicationScope? previous = s_publicationScope.Value;
-        var scope = new PublicationScope(this, previous);
-        s_publicationScope.Value = scope;
         try
         {
             publish();
@@ -100,12 +133,10 @@ public sealed class EditorTabItem : IAsyncDisposable
         {
             lock (_lifetimeGate)
             {
-                scope.Deactivate();
                 _publicationActive = false;
                 if (ReferenceEquals(_publicationDrain, drain))
                     _publicationDrain = null;
             }
-            s_publicationScope.Value = previous;
             drain.TrySetResult();
         }
     }
@@ -134,11 +165,33 @@ public sealed class EditorTabItem : IAsyncDisposable
         }
     }
 
-    internal bool TryBeginRemoval(out Task completion)
+    internal bool TryBeginHostClose(
+        out Task completion,
+        out TaskCompletionSource<object?>? completionSource)
+    {
+        lock (_lifetimeGate)
+        {
+            if (_hostCloseTask is not null)
+            {
+                completion = _hostCloseTask;
+                completionSource = null;
+                return false;
+            }
+
+            completionSource = new TaskCompletionSource<object?>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            completion = completionSource.Task;
+            _hostCloseTask = completion;
+            return true;
+        }
+    }
+
+    internal bool TryBeginRemoval(out Task completion, out Task? publicationDrain)
     {
         lock (_lifetimeGate)
         {
             _closing = true;
+            publicationDrain = _publicationDrain?.Task;
             if (_membershipState is MembershipState.Removing or MembershipState.Removed)
             {
                 completion = _removalCompletion?.Task ?? Task.CompletedTask;
@@ -153,7 +206,7 @@ public sealed class EditorTabItem : IAsyncDisposable
         }
     }
 
-    internal void CompleteRemoval()
+    internal void CompleteRemoval(Exception? failure = null)
     {
         TaskCompletionSource? completion;
         lock (_lifetimeGate)
@@ -161,7 +214,10 @@ public sealed class EditorTabItem : IAsyncDisposable
             _membershipState = MembershipState.Removed;
             completion = _removalCompletion;
         }
-        completion?.TrySetResult();
+        if (failure is null)
+            completion?.TrySetResult();
+        else
+            completion?.TrySetException(failure);
     }
 
     internal Task GetRemovalCompletion()
@@ -176,52 +232,22 @@ public sealed class EditorTabItem : IAsyncDisposable
             return _publicationActive && !_closing && _disposeTask is null && MutableContext.Value is not null;
     }
 
-    private static bool IsActivePublicationScope(EditorTabItem item)
+    internal bool IsHostDisposingContext(IEditorContext context)
     {
-        for (PublicationScope? scope = s_publicationScope.Value; scope is not null; scope = scope.Parent)
+        lock (_lifetimeGate)
+            return _hostDisposingContexts.Contains(context);
+    }
+
+    internal void ReleaseContextRegistration()
+    {
+        EditorContextRegistration? registration;
+        lock (_lifetimeGate)
         {
-            if (scope.IsActive && ReferenceEquals(scope.Owner, item))
-                return true;
+            registration = _contextRegistration;
+            _contextRegistration = null;
         }
-
-        return false;
-    }
-
-    private static bool IsActiveOwnedDisposalScope(EditorTabItem item)
-    {
-        for (OwnedDisposalScope? scope = s_ownedDisposals.Value; scope is not null; scope = scope.Parent)
-        {
-            if (scope.IsActive && ReferenceEquals(scope.Owner, item))
-                return true;
-        }
-
-        return false;
-    }
-
-    private sealed class PublicationScope(EditorTabItem owner, PublicationScope? parent)
-    {
-        private int _active = 1;
-
-        public EditorTabItem Owner { get; } = owner;
-
-        public PublicationScope? Parent { get; } = parent;
-
-        public bool IsActive => Volatile.Read(ref _active) != 0;
-
-        public void Deactivate() => Interlocked.Exchange(ref _active, 0);
-    }
-
-    private sealed class OwnedDisposalScope(EditorTabItem owner, OwnedDisposalScope? parent)
-    {
-        private int _active = 1;
-
-        public EditorTabItem Owner { get; } = owner;
-
-        public OwnedDisposalScope? Parent { get; } = parent;
-
-        public bool IsActive => Volatile.Read(ref _active) != 0;
-
-        public void Deactivate() => Interlocked.Exchange(ref _active, 0);
+        if (registration is { } owned)
+            _releaseContextHandler?.Invoke(this, owned);
     }
 
     private enum MembershipState
@@ -261,15 +287,34 @@ public sealed class EditorTabItem : IAsyncDisposable
 
     /// <summary>
     /// Replaces the owned editor context after the previous context has fully torn down.
-    /// The supplied context is consumed even when replacement is rejected.
     /// </summary>
+    /// <remarks>
+    /// A context already claimed by this or another tab is rejected without being consumed.
+    /// All other supplied contexts are consumed for both return values.
+    /// </remarks>
     public ValueTask<bool> ReplaceContextAsync(IEditorContext context)
     {
         ArgumentNullException.ThrowIfNull(context);
         IEditorContext? oldContext = null;
+        EditorContextRegistration? oldRegistration = null;
         TaskCompletionSource? transition = null;
         TaskCompletionSource<bool>? result = null;
         Exception? publicationFailure = null;
+        bool sameInstance;
+        Func<EditorTabItem, IEditorContext, EditorContextRegistration?>? claimContextHandler;
+        lock (_lifetimeGate)
+        {
+            sameInstance = ReferenceEquals(MutableContext.Value, context);
+            claimContextHandler = _claimContextHandler;
+        }
+
+        if (sameInstance)
+            return new ValueTask<bool>(false);
+
+        EditorContextRegistration? replacementRegistration = claimContextHandler?.Invoke(this, context);
+        if (claimContextHandler is not null && replacementRegistration is null)
+            return new ValueTask<bool>(false);
+
         bool rejected;
         lock (_lifetimeGate)
         {
@@ -277,6 +322,7 @@ public sealed class EditorTabItem : IAsyncDisposable
             if (!rejected)
             {
                 oldContext = MutableContext.Value;
+                oldRegistration = _contextRegistration;
                 transition = new TaskCompletionSource(
                     TaskCreationOptions.RunContinuationsAsynchronously);
                 result = new TaskCompletionSource<bool>(
@@ -286,11 +332,27 @@ public sealed class EditorTabItem : IAsyncDisposable
         }
 
         if (rejected)
-            return new ValueTask<bool>(DisposeRejectedAndReturnFalseAsync(context));
+        {
+            return replacementRegistration is { } reserved
+                ? new ValueTask<bool>(DisposeRejectedAndReleaseContextAsync(context, reserved))
+                : new ValueTask<bool>(DisposeRejectedAndReturnFalseAsync(context));
+        }
+
+        if (replacementRegistration is { } claimed
+            && _publishContextHandler?.Invoke(this, claimed) != true)
+        {
+            lock (_lifetimeGate)
+                _transitionTask = null;
+            transition!.TrySetResult();
+            return new ValueTask<bool>(DisposeRejectedAndReleaseContextAsync(context, claimed));
+        }
 
         try
         {
-            _ = TryPublish(() => MutableContext.Value = null, requireContext: false);
+            _ = TryPublish(() =>
+            {
+                MutableContext.Value = null;
+            }, requireContext: false);
         }
         catch (Exception ex)
         {
@@ -300,6 +362,8 @@ public sealed class EditorTabItem : IAsyncDisposable
         _ = CompleteReplacementAsync(
             oldContext!,
             context,
+            oldRegistration,
+            replacementRegistration,
             transition!,
             result!,
             publicationFailure);
@@ -309,6 +373,8 @@ public sealed class EditorTabItem : IAsyncDisposable
     private async Task CompleteReplacementAsync(
         IEditorContext oldContext,
         IEditorContext replacement,
+        EditorContextRegistration? oldRegistration,
+        EditorContextRegistration? replacementRegistration,
         TaskCompletionSource transition,
         TaskCompletionSource<bool> result,
         Exception? publicationFailure)
@@ -347,13 +413,30 @@ public sealed class EditorTabItem : IAsyncDisposable
         {
             try
             {
-                (published, accepted) = TryPublishReplacementContext(replacement);
+                (published, accepted) = TryPublishReplacementContext(
+                    replacement,
+                    replacementRegistration);
             }
             catch (Exception ex)
             {
                 published = ReferenceEquals(MutableContext.Value, replacement);
+                if (published)
+                {
+                    lock (_lifetimeGate)
+                        _contextRegistration = replacementRegistration;
+                }
                 RecordFailure(ref failures, ex);
             }
+        }
+
+        if (published)
+        {
+            if (oldRegistration is { } old)
+                _releaseContextHandler?.Invoke(this, old);
+        }
+        else if (replacementRegistration is { } reserved)
+        {
+            _releaseContextHandler?.Invoke(this, reserved);
         }
 
         bool closeWonAfterPublication;
@@ -412,7 +495,9 @@ public sealed class EditorTabItem : IAsyncDisposable
             result.TrySetException(CreateFailure(failures));
     }
 
-    private (bool Published, bool Accepted) TryPublishReplacementContext(IEditorContext replacement)
+    private (bool Published, bool Accepted) TryPublishReplacementContext(
+        IEditorContext replacement,
+        EditorContextRegistration? replacementRegistration)
     {
         bool contextPublished = true;
         bool itemPublished = false;
@@ -420,6 +505,8 @@ public sealed class EditorTabItem : IAsyncDisposable
         void Publish()
         {
             MutableContext.Value = replacement;
+            lock (_lifetimeGate)
+                _contextRegistration = replacementRegistration;
             itemPublished = true;
         }
 
@@ -447,15 +534,13 @@ public sealed class EditorTabItem : IAsyncDisposable
 
     private async Task DisposeOwnedContextAsync(IEditorContext context)
     {
-        OwnedDisposalScope? previous = s_ownedDisposals.Value;
-        var scope = new OwnedDisposalScope(this, previous);
-        s_ownedDisposals.Value = scope;
+        lock (_lifetimeGate)
+            _hostDisposingContexts.Add(context);
         try { await context.DisposeAsync().ConfigureAwait(true); }
         finally
         {
             lock (_lifetimeGate)
-                scope.Deactivate();
-            s_ownedDisposals.Value = previous;
+                _hostDisposingContexts.Remove(context);
         }
     }
 
@@ -480,49 +565,90 @@ public sealed class EditorTabItem : IAsyncDisposable
         return false;
     }
 
+    private async Task<bool> DisposeRejectedAndReleaseContextAsync(
+        IEditorContext context,
+        EditorContextRegistration registration)
+    {
+        try
+        {
+            return await DisposeRejectedAndReturnFalseAsync(context).ConfigureAwait(true);
+        }
+        finally
+        {
+            _releaseContextHandler?.Invoke(this, registration);
+        }
+    }
+
+    /// <summary>Requests terminal disposal of the tab and its owned context.</summary>
     public ValueTask DisposeAsync()
+    {
+        Action<EditorTabItem>? requestHostClose;
+        lock (_lifetimeGate)
+        {
+            if (_hostCloseTask is not null)
+                return new ValueTask(_hostCloseTask);
+            requestHostClose = _terminalFailureHandler;
+        }
+
+        if (requestHostClose is not null)
+        {
+            requestHostClose(this);
+            lock (_lifetimeGate)
+            {
+                if (_hostCloseTask is not null)
+                    return new ValueTask(_hostCloseTask);
+            }
+        }
+
+        return DisposeResourcesAsync();
+    }
+
+    internal ValueTask DisposeResourcesAsync()
     {
         Task? transition;
         Task? publicationDrain;
+        Task? removalCompletion;
         TaskCompletionSource<object?>? completion = null;
-        bool reentrant;
         lock (_lifetimeGate)
         {
-            reentrant = IsActiveOwnedDisposalScope(this)
-                || IsActivePublicationScope(this);
             if (_disposeTask is not null)
-            {
-                return reentrant ? ValueTask.CompletedTask : new ValueTask(_disposeTask);
-            }
+                return new ValueTask(_disposeTask);
 
             _closing = true;
             transition = _transitionTask;
             publicationDrain = _publicationDrain?.Task;
+            removalCompletion = _removalCompletion?.Task;
             completion = new TaskCompletionSource<object?>(
                 TaskCreationOptions.RunContinuationsAsynchronously);
             _disposeTask = completion.Task;
         }
 
-        _ = DisposeCoreAsync(transition, publicationDrain, completion);
-        if (reentrant)
-            ObserveDeferredDisposalFailure(completion.Task);
-        return reentrant ? ValueTask.CompletedTask : new ValueTask(completion.Task);
+        _ = DisposeCoreAsync(
+            transition,
+            publicationDrain,
+            removalCompletion,
+            completion);
+        return new ValueTask(completion.Task);
     }
 
     private async Task DisposeCoreAsync(
         Task? transition,
         Task? publicationDrain,
+        Task? removalCompletion,
         TaskCompletionSource<object?> completion)
     {
         List<Exception>? failures = null;
-        OwnedDisposalScope? previous = s_ownedDisposals.Value;
-        var scope = new OwnedDisposalScope(this, previous);
-        s_ownedDisposals.Value = scope;
         try
         {
             if (publicationDrain is not null)
             {
                 try { await publicationDrain.ConfigureAwait(true); }
+                catch (Exception ex) { RecordFailure(ref failures, ex); }
+            }
+
+            if (removalCompletion is not null)
+            {
+                try { await removalCompletion.ConfigureAwait(true); }
                 catch (Exception ex) { RecordFailure(ref failures, ex); }
             }
 
@@ -573,23 +699,11 @@ public sealed class EditorTabItem : IAsyncDisposable
             DisposeSurface(Extension, ref failures);
             DisposeSurface(Commands, ref failures);
             DisposeSurface(IsSelected, ref failures);
-            lock (_lifetimeGate)
-                scope.Deactivate();
-            s_ownedDisposals.Value = previous;
             if (failures is null)
                 completion.TrySetResult(null);
             else
                 completion.TrySetException(CreateFailure(failures));
         }
-    }
-
-    private static void ObserveDeferredDisposalFailure(Task task)
-    {
-        _ = task.ContinueWith(
-            static completed => _ = completed.Exception,
-            CancellationToken.None,
-            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
-            TaskScheduler.Default);
     }
 
     private static void DisposeSurface(IDisposable surface, ref List<Exception>? failures)
@@ -599,7 +713,7 @@ public sealed class EditorTabItem : IAsyncDisposable
     }
 }
 
-public sealed class EditorService : IOutputOperationLeaseProvider
+public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContextCloseService
 {
     private readonly CoreList<EditorTabItem> _tabItems;
     private readonly ExtensionProvider _extensionProvider;
@@ -616,6 +730,17 @@ public sealed class EditorService : IOutputOperationLeaseProvider
     private int _activeOutputOperations;
     private int _activeProjectFileWrites;
     private bool _worktreeMutationActive;
+    private readonly object _contextRegistryGate = new();
+    private readonly Dictionary<IEditorContext, (EditorTabItem Item, long Generation)> _contextItems =
+        new(ReferenceEqualityComparer.Instance);
+    private readonly Dictionary<IEditorContext, (EditorTabItem Item, long Generation)> _reservedContextItems =
+        new(ReferenceEqualityComparer.Instance);
+    private long _contextRegistrationGeneration;
+
+    internal Action? BeforeInitialOwnerAttach { get; set; }
+
+    internal Action? BeforeInitialContextClaimPublish { get; set; }
+
 
     public EditorService(ExtensionProvider extensionProvider)
         : this(
@@ -655,7 +780,7 @@ public sealed class EditorService : IOutputOperationLeaseProvider
 
     internal void AddTabItem(EditorTabItem item)
     {
-        if (!TryAddTabItem(item) && !ContainsTabItem(item))
+        if (!TryAddTabItem(item) && item.IsHostOwned && !ContainsTabItem(item))
             ObserveDeferredTabDisposal(item.DisposeAsync().AsTask());
     }
 
@@ -674,6 +799,8 @@ public sealed class EditorService : IOutputOperationLeaseProvider
         Action? beforeAdd,
         Action? beforeSelection)
     {
+        if (!item.IsHostOwned && !TryAttachOwner(item))
+            return false;
         if (!item.TryBeginAttachment())
             return false;
 
@@ -683,6 +810,9 @@ public sealed class EditorService : IOutputOperationLeaseProvider
             void Mutate()
             {
                 beforeAdd?.Invoke();
+                if (!item.TryCompleteAttachment())
+                    return;
+
                 AddTabItemCore(item);
                 if (select && _tabItems.Contains(item))
                 {
@@ -764,8 +894,7 @@ public sealed class EditorService : IOutputOperationLeaseProvider
         try
         {
             bool accepted = published
-                && ContainsTabItem(item)
-                && item.TryCompleteAttachment();
+                && ContainsTabItem(item);
             if (!accepted)
                 ReconcileRejectedAttachment(item);
             return accepted;
@@ -779,7 +908,6 @@ public sealed class EditorService : IOutputOperationLeaseProvider
 
     internal void AddTabItemCore(EditorTabItem item)
     {
-        item.AttachOwner(RemoveFailedTabItem);
         _tabItems.Add(item);
     }
 
@@ -790,8 +918,15 @@ public sealed class EditorService : IOutputOperationLeaseProvider
     {
         // Reserve terminal removal without running any collection or reactive observers while
         // the lifetime gate is held.
-        if (!item.TryBeginRemoval(out _))
+        if (!item.TryBeginRemoval(out Task completion, out Task? publicationDrain))
             return false;
+
+        if (publicationDrain is not null)
+        {
+            _ = CompleteRemovalAfterPublicationAsync(item, publicationDrain);
+            ObserveDeferredTaskFailure(completion);
+            return true;
+        }
 
         try
         {
@@ -800,6 +935,26 @@ public sealed class EditorService : IOutputOperationLeaseProvider
         finally
         {
             item.CompleteRemoval();
+        }
+    }
+
+    private async Task CompleteRemovalAfterPublicationAsync(
+        EditorTabItem item,
+        Task publicationDrain)
+    {
+        Exception? failure = null;
+        try
+        {
+            await publicationDrain.ConfigureAwait(false);
+            _ = RemoveTabItemFacade(item);
+        }
+        catch (Exception ex)
+        {
+            failure = ex;
+        }
+        finally
+        {
+            item.CompleteRemoval(failure);
         }
     }
 
@@ -833,34 +988,178 @@ public sealed class EditorService : IOutputOperationLeaseProvider
 
     private void ReconcileRejectedAttachment(EditorTabItem item)
     {
-        bool removed = RemoveTabItem(item);
-        if (removed || !ContainsTabItem(item))
-            return;
-
-        item.GetRemovalCompletion().GetAwaiter().GetResult();
-        if (ContainsTabItem(item))
-            _ = RemoveTabItemFacade(item);
+        if (!RemoveTabItem(item))
+            ObserveDeferredTaskFailure(item.GetRemovalCompletion());
     }
 
     private void RemoveFailedTabItem(EditorTabItem item)
-        => RemoveTabItem(item);
+    {
+        EditorContextCloseRequest request = RequestClose(item);
+        ObserveDeferredTaskFailure(request.Completion);
+    }
+
+    private bool TryAttachOwner(EditorTabItem item)
+    {
+        IEditorContext? context = item.Context.Value;
+        if (context is null)
+            return false;
+
+        lock (_contextRegistryGate)
+        {
+            if (_contextItems.ContainsKey(context) || _reservedContextItems.ContainsKey(context))
+                return false;
+
+            long generation = ++_contextRegistrationGeneration;
+            var registration = new EditorContextRegistration(context, generation);
+            BeforeInitialOwnerAttach?.Invoke();
+            if (!item.TryAttachOwner(
+                    RemoveFailedTabItem,
+                    registration,
+                    TryClaimContext,
+                    PublishContextClaim,
+                    ReleaseContext))
+            {
+                return false;
+            }
+
+            BeforeInitialContextClaimPublish?.Invoke();
+            _contextItems.Add(context, (item, generation));
+            return true;
+        }
+    }
+
+    private EditorContextRegistration? TryClaimContext(
+        EditorTabItem item,
+        IEditorContext context)
+    {
+        lock (_contextRegistryGate)
+        {
+            if (_contextItems.ContainsKey(context) || _reservedContextItems.ContainsKey(context))
+                return null;
+
+            long generation = ++_contextRegistrationGeneration;
+            _reservedContextItems.Add(context, (item, generation));
+            return new EditorContextRegistration(context, generation);
+        }
+    }
+
+    private bool PublishContextClaim(
+        EditorTabItem item,
+        EditorContextRegistration registration)
+    {
+        lock (_contextRegistryGate)
+        {
+            if (!_reservedContextItems.TryGetValue(registration.Context, out var reserved)
+                || !ReferenceEquals(reserved.Item, item)
+                || reserved.Generation != registration.Generation
+                || _contextItems.ContainsKey(registration.Context))
+            {
+                return false;
+            }
+
+            _reservedContextItems.Remove(registration.Context);
+            _contextItems.Add(registration.Context, (item, registration.Generation));
+            return true;
+        }
+    }
+
+    private void ReleaseContext(
+        EditorTabItem item,
+        EditorContextRegistration registration)
+    {
+        lock (_contextRegistryGate)
+        {
+            if (_contextItems.TryGetValue(registration.Context, out var current)
+                && ReferenceEquals(current.Item, item)
+                && current.Generation == registration.Generation)
+            {
+                _contextItems.Remove(registration.Context);
+            }
+            if (_reservedContextItems.TryGetValue(registration.Context, out var reserved)
+                && ReferenceEquals(reserved.Item, item)
+                && reserved.Generation == registration.Generation)
+            {
+                _reservedContextItems.Remove(registration.Context);
+            }
+        }
+    }
 
     internal ExtensionProvider ExtensionProvider => _extensionProvider;
 
     internal void RequestContextShutdown(IEditorContext context)
     {
-        EditorTabItem? item = _tabItems.FirstOrDefault(tab =>
-            ReferenceEquals(tab.Context.Value, context));
-        if (item is null)
+        EditorTabItem? item = GetRegisteredItem(context);
+        if (item is null || item.IsHostDisposingContext(context))
             return;
 
+        EditorContextCloseRequest request = RequestClose(item);
+        if (request.Status != EditorContextCloseRequestStatus.NotOwned)
+            ObserveDeferredTaskFailure(request.Completion);
+    }
+
+    public EditorContextCloseRequest RequestClose(IEditorContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        EditorTabItem? item = GetRegisteredItem(context);
+        if (item is null)
+        {
+            return new EditorContextCloseRequest(
+                EditorContextCloseRequestStatus.NotOwned,
+                Task.CompletedTask);
+        }
+
+        return RequestClose(item);
+    }
+
+    private EditorTabItem? GetRegisteredItem(IEditorContext context)
+    {
+        lock (_contextRegistryGate)
+        {
+            return _contextItems.TryGetValue(context, out var registration)
+                ? registration.Item
+                : null;
+        }
+    }
+
+    private EditorContextCloseRequest RequestClose(EditorTabItem item)
+    {
+        bool accepted = item.TryBeginHostClose(
+            out Task completion,
+            out TaskCompletionSource<object?>? completionSource);
+        if (accepted)
+        {
+            _ = CompleteHostCloseAsync(item, completionSource!);
+            ObserveDeferredTaskFailure(completion);
+        }
+
+        return new EditorContextCloseRequest(
+            accepted
+                ? EditorContextCloseRequestStatus.Accepted
+                : EditorContextCloseRequestStatus.AlreadyClosing,
+            completion);
+    }
+
+    private async Task CompleteHostCloseAsync(
+        EditorTabItem item,
+        TaskCompletionSource<object?> completion)
+    {
+        List<Exception>? failures = null;
         try { RemoveTabItem(item); }
-        catch { }
-        _ = item.DisposeAsync().AsTask().ContinueWith(
-            static task => _ = task.Exception,
-            CancellationToken.None,
-            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
-            TaskScheduler.Default);
+        catch (Exception ex) { failures = [ex]; }
+
+        try { await item.GetRemovalCompletion().ConfigureAwait(false); }
+        catch (Exception ex) { (failures ??= []).Add(ex); }
+
+        try { await item.DisposeResourcesAsync().ConfigureAwait(false); }
+        catch (Exception ex) { (failures ??= []).Add(ex); }
+
+        try { item.ReleaseContextRegistration(); }
+        catch (Exception ex) { (failures ??= []).Add(ex); }
+
+        if (failures is null)
+            completion.TrySetResult(null);
+        else
+            completion.TrySetException(failures.Count == 1 ? failures[0] : new AggregateException(failures));
     }
 
     public IReactiveProperty<EditorTabItem?> SelectedTabItem { get; } = new ReactivePropertySlim<EditorTabItem?>();
@@ -1252,7 +1551,7 @@ public sealed class EditorService : IOutputOperationLeaseProvider
             if (ext?.TryCreateContext(obj, new EditorContextServices(this, _extensionProvider), out IEditorContext? context) == true)
             {
                 var tabItem2 = new EditorTabItem(context) { IsSelected = { Value = true } };
-                if (!TryAddAndSelectTabItem(tabItem2))
+                if (!TryAddAndSelectTabItem(tabItem2) && tabItem2.IsHostOwned)
                     ObserveDeferredTabDisposal(tabItem2.DisposeAsync().AsTask());
             }
         }
@@ -1350,6 +1649,15 @@ public sealed class EditorService : IOutputOperationLeaseProvider
             TaskScheduler.Default);
     }
 
+    private static void ObserveDeferredTaskFailure(Task task)
+    {
+        _ = task.ContinueWith(
+            static completed => _ = completed.Exception,
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+    }
+
     public async ValueTask CloseTabItem(CoreObject obj)
     {
         if (TryGetTabItem(obj, out EditorTabItem? item))
@@ -1358,13 +1666,8 @@ public sealed class EditorService : IOutputOperationLeaseProvider
 
     public async ValueTask CloseTabItem(EditorTabItem item)
     {
-        List<Exception>? failures = null;
-        try { RemoveTabItem(item); }
-        catch (Exception ex) { failures = [ex]; }
-        try { await item.DisposeAsync(); }
-        catch (Exception ex) { (failures ??= []).Add(ex); }
-        if (failures is not null)
-            throw failures.Count == 1 ? failures[0] : new AggregateException(failures);
+        EditorContextCloseRequest request = RequestClose(item);
+        await request.Completion.ConfigureAwait(false);
     }
 
     private sealed class EditorSuspension(IDisposable[] suspensions) : IDisposable

--- a/src/Beutl/Services/EditorService.cs
+++ b/src/Beutl/Services/EditorService.cs
@@ -2,6 +2,7 @@
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using Avalonia.Threading;
+using System.Threading;
 using Beutl.Api.Services;
 using Beutl.Configuration;
 using Beutl.Editor;
@@ -282,6 +283,7 @@ public sealed class EditorTabItem : IAsyncDisposable
 
     internal EditorContextCloseRequestStatus TryBeginHostClose(
         EditorContextHostToken expectedHostToken,
+        Action<Task> trackClose,
         out Task completion,
         out TaskCompletionSource<object?>? completionSource)
     {
@@ -306,6 +308,7 @@ public sealed class EditorTabItem : IAsyncDisposable
             completion = completionSource.Task;
             _hostCloseTask = completion;
             _closing = true;
+            trackClose(completion);
             return EditorContextCloseRequestStatus.Accepted;
         }
     }
@@ -974,6 +977,7 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
     private bool _worktreeMutationActive;
     private readonly object _tabAdmissionGate = new();
     private readonly SemaphoreSlim _tabReconciliationGate = new(1, 1);
+    private static readonly AsyncLocal<TabAdmissionOperation?> s_tabAdmissionOperation = new();
     private TaskCompletionSource? _tabAdmissionDrain;
     private int _activeTabAdmissions;
     private bool _tabAdmissionClosed;
@@ -983,6 +987,8 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
     private readonly Dictionary<IEditorContext, (EditorTabItem Item, long Generation)> _reservedContextItems =
         new(ReferenceEqualityComparer.Instance);
     private long _contextRegistrationGeneration;
+    private readonly object _lifecycleTeardownGate = new();
+    private readonly HashSet<Task> _activeLifecycleTeardowns = [];
 
     internal Action? BeforeInitialOwnerAttach { get; set; }
 
@@ -1032,9 +1038,25 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
     internal async ValueTask ReconcileTabItemsAsync(IReadOnlyList<CoreObject> items)
     {
         ArgumentNullException.ThrowIfNull(items);
+        for (TabAdmissionOperation? operation = s_tabAdmissionOperation.Value;
+             operation is not null;
+             operation = operation.Parent)
+        {
+            if (ReferenceEquals(operation.ActiveOwner, this))
+            {
+                throw new InvalidOperationException(
+                    "Tab reconciliation cannot be entered from an active editor tab operation.");
+            }
+        }
+
         await _tabReconciliationGate.WaitAsync();
+        TabAdmissionOperation? reconciliationOperation = null;
+        TabAdmissionOperation? previousOperation = null;
         try
         {
+            previousOperation = s_tabAdmissionOperation.Value;
+            reconciliationOperation = BeginTabAdmissionOperation();
+            s_tabAdmissionOperation.Value = reconciliationOperation;
             Task admissionDrain = CloseTabAdmission();
             await admissionDrain;
             List<Exception>? failures = null;
@@ -1043,18 +1065,23 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
                 try { await CloseTabItem(item); }
                 catch (Exception ex) { (failures ??= []).Add(ex); }
             }
+            foreach (Exception ex in await DrainActiveLifecycleTeardownsAsync())
+                (failures ??= []).Add(ex);
 
             foreach (CoreObject item in items)
             {
                 try { ActivateTabItemCore(item); }
                 catch (Exception ex) { (failures ??= []).Add(ex); }
             }
+            foreach (Exception ex in await DrainActiveLifecycleTeardownsAsync())
+                (failures ??= []).Add(ex);
 
             if (failures is not null)
                 throw failures.Count == 1 ? failures[0] : new AggregateException(failures);
         }
         finally
         {
+            CompleteTabAdmissionOperation(reconciliationOperation, previousOperation);
             OpenTabAdmission();
             _tabReconciliationGate.Release();
         }
@@ -1150,8 +1177,13 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
         if (!TryEnterTabAdmission())
             return EditorContextReplacementStatus.Busy;
 
+        TabAdmissionOperation? operation = null;
+        TabAdmissionOperation? previousOperation = null;
         try
         {
+            previousOperation = s_tabAdmissionOperation.Value;
+            operation = BeginTabAdmissionOperation();
+            s_tabAdmissionOperation.Value = operation;
             if (!item.TryGetAttachedContext(_hostToken, out IEditorContext? current, out EditorContextRegistration registration)
                 || current is null)
             {
@@ -1221,7 +1253,57 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
         }
         finally
         {
+            CompleteTabAdmissionOperation(operation, previousOperation);
             ExitTabAdmission();
+        }
+    }
+
+    private sealed class TabAdmissionOperation
+    {
+        public TabAdmissionOperation(
+            EditorService owner,
+            TabAdmissionOperation? parent)
+        {
+            _activeOwner = owner;
+            Parent = parent;
+        }
+
+        private EditorService? _activeOwner;
+
+        public TabAdmissionOperation? Parent { get; }
+
+        public EditorService? ActiveOwner => Volatile.Read(ref _activeOwner);
+
+        public void Complete() => Interlocked.Exchange(ref _activeOwner, null);
+    }
+
+    internal static bool IsTabLifecycleOperationActive
+    {
+        get
+        {
+            for (TabAdmissionOperation? operation = s_tabAdmissionOperation.Value;
+                 operation is not null;
+                 operation = operation.Parent)
+            {
+                if (operation.ActiveOwner is not null)
+                    return true;
+            }
+
+            return false;
+        }
+    }
+
+    private TabAdmissionOperation BeginTabAdmissionOperation()
+        => new(this, s_tabAdmissionOperation.Value);
+
+    private static void CompleteTabAdmissionOperation(
+        TabAdmissionOperation? operation,
+        TabAdmissionOperation? previousOperation)
+    {
+        if (operation is not null)
+        {
+            operation.Complete();
+            s_tabAdmissionOperation.Value = previousOperation;
         }
     }
 
@@ -1255,12 +1337,18 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
         if (!TryEnterTabAdmission())
             return false;
 
+        TabAdmissionOperation? operation = null;
+        TabAdmissionOperation? previousOperation = null;
         try
         {
+            previousOperation = s_tabAdmissionOperation.Value;
+            operation = BeginTabAdmissionOperation();
+            s_tabAdmissionOperation.Value = operation;
             return TryAddTabItemCore(item, select, beforeAdd, beforeSelection);
         }
         finally
         {
+            CompleteTabAdmissionOperation(operation, previousOperation);
             ExitTabAdmission();
         }
     }
@@ -1723,6 +1811,7 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
 
             status = registration.Item.TryBeginHostClose(
                 _hostToken,
+                TrackHostClose,
                 out completion,
                 out completionSource);
         }
@@ -1738,6 +1827,7 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
     {
         EditorContextCloseRequestStatus status = item.TryBeginHostClose(
             _hostToken,
+            TrackHostClose,
             out Task completion,
             out TaskCompletionSource<object?>? completionSource);
         return StartHostClose(item, status, completion, completionSource);
@@ -1761,7 +1851,11 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
                 startupFailure = ex;
             }
 
-            _ = CompleteHostCloseAsync(item, completionSource!, startupFailure);
+            _ = CompleteHostCloseAsync(
+                item,
+                completionSource!,
+                completion,
+                startupFailure);
             ObserveDeferredTaskFailure(completion);
         }
 
@@ -1773,22 +1867,85 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
     private async Task CompleteHostCloseAsync(
         EditorTabItem item,
         TaskCompletionSource<object?> completion,
+        Task hostCloseTask,
         Exception? startupFailure = null)
     {
         List<Exception>? failures = startupFailure is null ? null : [startupFailure];
-        try { await RemoveTabItemAsync(item).ConfigureAwait(false); }
-        catch (Exception ex) { (failures ??= []).Add(ex); }
+        TabAdmissionOperation? operation = null;
+        TabAdmissionOperation? previousOperation = null;
+        try
+        {
+            previousOperation = s_tabAdmissionOperation.Value;
+            operation = BeginTabAdmissionOperation();
+            s_tabAdmissionOperation.Value = operation;
 
-        try { await item.DisposeResourcesAsync().ConfigureAwait(false); }
-        catch (Exception ex) { (failures ??= []).Add(ex); }
+            try { await RemoveTabItemAsync(item).ConfigureAwait(false); }
+            catch (Exception ex) { (failures ??= []).Add(ex); }
 
-        try { item.ReleaseContextRegistration(); }
-        catch (Exception ex) { (failures ??= []).Add(ex); }
+            try { await item.DisposeResourcesAsync().ConfigureAwait(false); }
+            catch (Exception ex) { (failures ??= []).Add(ex); }
 
-        if (failures is null)
-            completion.TrySetResult(null);
-        else
-            completion.TrySetException(failures.Count == 1 ? failures[0] : new AggregateException(failures));
+            try { item.ReleaseContextRegistration(); }
+            catch (Exception ex) { (failures ??= []).Add(ex); }
+        }
+        catch (Exception ex)
+        {
+            (failures ??= []).Add(ex);
+        }
+        finally
+        {
+            CompleteTabAdmissionOperation(operation, previousOperation);
+        }
+
+        CompleteTrackedHostClose(completion, hostCloseTask, failures);
+    }
+
+    private void TrackHostClose(Task completion)
+    {
+        lock (_lifecycleTeardownGate)
+            _activeLifecycleTeardowns.Add(completion);
+    }
+
+    private void CompleteTrackedHostClose(
+        TaskCompletionSource<object?> completion,
+        Task hostCloseTask,
+        List<Exception>? failures)
+    {
+        lock (_lifecycleTeardownGate)
+        {
+            if (failures is null)
+                completion.TrySetResult(null);
+            else
+                completion.TrySetException(failures.Count == 1 ? failures[0] : new AggregateException(failures));
+            _activeLifecycleTeardowns.Remove(hostCloseTask);
+        }
+    }
+
+    private async Task<List<Exception>> DrainActiveLifecycleTeardownsAsync()
+    {
+        List<Exception>? failures = null;
+        while (true)
+        {
+            Task[] active;
+            lock (_lifecycleTeardownGate)
+            {
+                if (_activeLifecycleTeardowns.Count == 0)
+                    return failures ?? [];
+                active = _activeLifecycleTeardowns.ToArray();
+            }
+
+            foreach (Task close in active)
+            {
+                try
+                {
+                    await close.ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    (failures ??= []).Add(ex);
+                }
+            }
+        }
     }
 
     public IReactiveProperty<EditorTabItem?> SelectedTabItem { get; } = new ReactivePropertySlim<EditorTabItem?>();
@@ -2168,12 +2325,18 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
         if (!TryEnterTabAdmission())
             return;
 
+        TabAdmissionOperation? operation = null;
+        TabAdmissionOperation? previousOperation = null;
         try
         {
+            previousOperation = s_tabAdmissionOperation.Value;
+            operation = BeginTabAdmissionOperation();
+            s_tabAdmissionOperation.Value = operation;
             ActivateTabItemCore(obj);
         }
         finally
         {
+            CompleteTabAdmissionOperation(operation, previousOperation);
             ExitTabAdmission();
         }
     }
@@ -2358,6 +2521,31 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
             TaskScheduler.Default);
     }
 
+    private void TrackAndObserveLifecycleTeardown(Task teardown)
+    {
+        TrackDeferredLifecycleTeardown(teardown);
+        ObserveDeferredTabDisposal(teardown);
+    }
+
+    private void TrackDeferredLifecycleTeardown(Task teardown)
+    {
+        lock (_lifecycleTeardownGate)
+            _activeLifecycleTeardowns.Add(teardown);
+        _ = teardown.ContinueWith(
+            static (completed, state) =>
+                ((EditorService)state!).UntrackDeferredLifecycleTeardown(completed),
+            this,
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+    }
+
+    private void UntrackDeferredLifecycleTeardown(Task teardown)
+    {
+        lock (_lifecycleTeardownGate)
+            _activeLifecycleTeardowns.Remove(teardown);
+    }
+
     private void ObserveDeferredTabDisposal(
         EditorTabItem item,
         EditorContextOwnershipLease ownershipLease)
@@ -2372,7 +2560,7 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
             disposal = ForceDisposeTabAfterStartFailureAsync(item, ex);
         }
 
-        ObserveDeferredTabDisposal(ReleaseLeaseAfterAsync(disposal, ownershipLease));
+        TrackAndObserveLifecycleTeardown(ReleaseLeaseAfterAsync(disposal, ownershipLease));
     }
 
     private async Task ForceDisposeTabAfterStartFailureAsync(
@@ -2424,7 +2612,7 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
         }
     }
 
-    private static void ObserveDeferredContextDisposal(IEditorContext context)
+    private void ObserveDeferredContextDisposal(IEditorContext context)
     {
         Task disposal;
         try
@@ -2436,10 +2624,10 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
             disposal = Task.FromException(ex);
         }
 
-        ObserveDeferredTabDisposal(disposal);
+        TrackAndObserveLifecycleTeardown(disposal);
     }
 
-    private static void ObserveDeferredContextDisposal(
+    private void ObserveDeferredContextDisposal(
         IEditorContext context,
         EditorContextOwnershipLease ownershipLease)
     {
@@ -2454,7 +2642,7 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
             disposal = Task.FromException(ex);
         }
 
-        ObserveDeferredTabDisposal(disposal);
+        TrackAndObserveLifecycleTeardown(disposal);
     }
 
     private static async Task DisposeContextAndReleaseLeaseAsync(

--- a/src/Beutl/Services/EditorService.cs
+++ b/src/Beutl/Services/EditorService.cs
@@ -7,9 +7,15 @@ using Beutl.Configuration;
 using Beutl.Editor;
 using Beutl.Editor.VersionControl;
 using Beutl.Serialization;
+using Beutl.ViewModels;
 using Reactive.Bindings;
 
 namespace Beutl.Services;
+
+internal interface IEditorContextPublicationGate
+{
+    bool TryPublish(Action publish);
+}
 
 public sealed class EditorTabItem : IAsyncDisposable
 {
@@ -163,8 +169,9 @@ public sealed class EditorTabItem : IAsyncDisposable
         {
             try
             {
-                MutableContext.Value = replacement;
-                published = true;
+                published = replacement is IEditorContextPublicationGate gate
+                    ? gate.TryPublish(() => MutableContext.Value = replacement)
+                    : PublishReplacementContext(replacement);
             }
             catch (Exception ex)
             {
@@ -219,11 +226,16 @@ public sealed class EditorTabItem : IAsyncDisposable
         {
             RecordFailure(ref failures, ex);
         }
-
         if (failures is null)
             result.TrySetResult(false);
         else
             result.TrySetException(CreateFailure(failures));
+    }
+
+    private bool PublishReplacementContext(IEditorContext replacement)
+    {
+        MutableContext.Value = replacement;
+        return true;
     }
 
     private static void RecordFailure(ref List<Exception>? failures, Exception exception)
@@ -408,9 +420,27 @@ public sealed class EditorService : IOutputOperationLeaseProvider
 
     internal void AddTabItem(EditorTabItem item)
     {
+        if (!TryAddTabItem(item))
+            _ = item.DisposeAsync();
+    }
+
+    internal bool TryAddTabItem(EditorTabItem item)
+    {
+        if (item.Context.Value is IEditorContextPublicationGate gate)
+            return gate.TryPublish(() => AddTabItemCore(item)) && ContainsTabItem(item);
+
+        AddTabItemCore(item);
+        return true;
+    }
+
+    internal void AddTabItemCore(EditorTabItem item)
+    {
         item.AttachOwner(RemoveFailedTabItem);
         _tabItems.Add(item);
     }
+
+    internal bool ContainsTabItem(EditorTabItem item)
+        => _tabItems.Contains(item);
 
     internal bool RemoveTabItem(EditorTabItem item)
     {
@@ -847,8 +877,10 @@ public sealed class EditorService : IOutputOperationLeaseProvider
             if (ext?.TryCreateContext(obj, new EditorContextServices(this, _extensionProvider), out IEditorContext? context) == true)
             {
                 var tabItem2 = new EditorTabItem(context) { IsSelected = { Value = true } };
-                AddTabItem(tabItem2);
-                SelectedTabItem.Value = tabItem2;
+                if (TryAddTabItem(tabItem2))
+                    SelectedTabItem.Value = tabItem2;
+                else
+                    _ = tabItem2.DisposeAsync();
             }
         }
     }

--- a/src/Beutl/Services/EditorService.cs
+++ b/src/Beutl/Services/EditorService.cs
@@ -27,6 +27,7 @@ public sealed class EditorTabItem : IAsyncDisposable
     private Task? _disposeTask;
     private Task? _transitionTask;
     private TaskCompletionSource? _publicationDrain;
+    private TaskCompletionSource? _membershipDrain;
     private TaskCompletionSource? _removalCompletion;
     private bool _closing;
     private bool _contextDisposeAttempted;
@@ -160,9 +161,43 @@ public sealed class EditorTabItem : IAsyncDisposable
             if (_closing || _membershipState != MembershipState.Adding)
                 return false;
 
-            _membershipState = MembershipState.Attached;
+            _membershipState = MembershipState.AttachmentCommitted;
             return true;
         }
+    }
+
+    // Keep attachment commit distinct from physical insertion so terminal removal can cancel a
+    // pending add; collection observers still run outside the lifetime gate.
+    internal bool TryBeginPhysicalAdd()
+    {
+        lock (_lifetimeGate)
+        {
+            if (_closing || _membershipState != MembershipState.AttachmentCommitted)
+                return false;
+
+            _membershipState = MembershipState.PhysicalAdding;
+            var drain = new TaskCompletionSource(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            _membershipDrain = drain;
+            return true;
+        }
+    }
+
+    internal void CompletePhysicalAdd(bool added)
+    {
+        TaskCompletionSource? drain;
+        lock (_lifetimeGate)
+        {
+            if (_membershipState == MembershipState.PhysicalAdding)
+            {
+                _membershipState = added
+                    ? MembershipState.Attached
+                    : MembershipState.AttachmentCommitted;
+            }
+            drain = _membershipDrain;
+            _membershipDrain = null;
+        }
+        drain?.TrySetResult();
     }
 
     internal bool TryBeginHostClose(
@@ -182,16 +217,21 @@ public sealed class EditorTabItem : IAsyncDisposable
                 TaskCreationOptions.RunContinuationsAsynchronously);
             completion = completionSource.Task;
             _hostCloseTask = completion;
+            _closing = true;
             return true;
         }
     }
 
-    internal bool TryBeginRemoval(out Task completion, out Task? publicationDrain)
+    internal bool TryBeginRemoval(
+        out Task completion,
+        out Task? publicationDrain,
+        out Task? membershipDrain)
     {
         lock (_lifetimeGate)
         {
             _closing = true;
             publicationDrain = _publicationDrain?.Task;
+            membershipDrain = _membershipDrain?.Task;
             if (_membershipState is MembershipState.Removing or MembershipState.Removed)
             {
                 completion = _removalCompletion?.Task ?? Task.CompletedTask;
@@ -254,6 +294,8 @@ public sealed class EditorTabItem : IAsyncDisposable
     {
         Fresh,
         Adding,
+        AttachmentCommitted,
+        PhysicalAdding,
         Attached,
         Removing,
         Removed
@@ -607,6 +649,7 @@ public sealed class EditorTabItem : IAsyncDisposable
     {
         Task? transition;
         Task? publicationDrain;
+        Task? membershipDrain;
         Task? removalCompletion;
         TaskCompletionSource<object?>? completion = null;
         lock (_lifetimeGate)
@@ -617,6 +660,7 @@ public sealed class EditorTabItem : IAsyncDisposable
             _closing = true;
             transition = _transitionTask;
             publicationDrain = _publicationDrain?.Task;
+            membershipDrain = _membershipDrain?.Task;
             removalCompletion = _removalCompletion?.Task;
             completion = new TaskCompletionSource<object?>(
                 TaskCreationOptions.RunContinuationsAsynchronously);
@@ -626,6 +670,7 @@ public sealed class EditorTabItem : IAsyncDisposable
         _ = DisposeCoreAsync(
             transition,
             publicationDrain,
+            membershipDrain,
             removalCompletion,
             completion);
         return new ValueTask(completion.Task);
@@ -634,6 +679,7 @@ public sealed class EditorTabItem : IAsyncDisposable
     private async Task DisposeCoreAsync(
         Task? transition,
         Task? publicationDrain,
+        Task? membershipDrain,
         Task? removalCompletion,
         TaskCompletionSource<object?> completion)
     {
@@ -643,6 +689,12 @@ public sealed class EditorTabItem : IAsyncDisposable
             if (publicationDrain is not null)
             {
                 try { await publicationDrain.ConfigureAwait(true); }
+                catch (Exception ex) { RecordFailure(ref failures, ex); }
+            }
+
+            if (membershipDrain is not null)
+            {
+                try { await membershipDrain.ConfigureAwait(true); }
                 catch (Exception ex) { RecordFailure(ref failures, ex); }
             }
 
@@ -730,6 +782,11 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
     private int _activeOutputOperations;
     private int _activeProjectFileWrites;
     private bool _worktreeMutationActive;
+    private readonly object _tabAdmissionGate = new();
+    private readonly SemaphoreSlim _tabReconciliationGate = new(1, 1);
+    private TaskCompletionSource? _tabAdmissionDrain;
+    private int _activeTabAdmissions;
+    private bool _tabAdmissionClosed;
     private readonly object _contextRegistryGate = new();
     private readonly Dictionary<IEditorContext, (EditorTabItem Item, long Generation)> _contextItems =
         new(ReferenceEqualityComparer.Instance);
@@ -741,6 +798,11 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
 
     internal Action? BeforeInitialContextClaimPublish { get; set; }
 
+    internal Action? BeforeContextCloseAdmission { get; set; }
+
+    internal Action? BeforeHostCloseStart { get; set; }
+
+    internal Action? BeforePhysicalAdd { get; set; }
 
     public EditorService(ExtensionProvider extensionProvider)
         : this(
@@ -765,17 +827,88 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
 
     public ICoreReadOnlyList<EditorTabItem> TabItems => _tabItems;
 
-    internal void ClearTabItems()
+    internal async ValueTask ClearTabItemsAsync()
+        => await ReconcileTabItemsAsync([]);
+
+    internal async ValueTask ReconcileTabItemsAsync(IReadOnlyList<CoreObject> items)
     {
-        List<Exception>? failures = null;
-        foreach (EditorTabItem item in _tabItems.ToArray())
+        ArgumentNullException.ThrowIfNull(items);
+        await _tabReconciliationGate.WaitAsync();
+        Task admissionDrain = CloseTabAdmission();
+        try
         {
-            try { RemoveTabItem(item); }
-            catch (Exception ex) { (failures ??= []).Add(ex); }
+            await admissionDrain;
+            List<Exception>? failures = null;
+            foreach (EditorTabItem item in _tabItems.ToArray())
+            {
+                try { await CloseTabItem(item); }
+                catch (Exception ex) { (failures ??= []).Add(ex); }
+            }
+
+            foreach (CoreObject item in items)
+            {
+                try { ActivateTabItemCore(item); }
+                catch (Exception ex) { (failures ??= []).Add(ex); }
+            }
+
+            if (failures is not null)
+                throw failures.Count == 1 ? failures[0] : new AggregateException(failures);
+        }
+        finally
+        {
+            OpenTabAdmission();
+            _tabReconciliationGate.Release();
+        }
+    }
+
+    private bool TryEnterTabAdmission()
+    {
+        lock (_tabAdmissionGate)
+        {
+            if (_tabAdmissionClosed)
+                return false;
+
+            _activeTabAdmissions++;
+            return true;
+        }
+    }
+
+    private void ExitTabAdmission()
+    {
+        TaskCompletionSource? drain = null;
+        lock (_tabAdmissionGate)
+        {
+            _activeTabAdmissions--;
+            if (_tabAdmissionClosed && _activeTabAdmissions == 0)
+            {
+                drain = _tabAdmissionDrain;
+                _tabAdmissionDrain = null;
+            }
         }
 
-        if (failures is not null)
-            throw failures.Count == 1 ? failures[0] : new AggregateException(failures);
+        drain?.TrySetResult();
+    }
+
+    private Task CloseTabAdmission()
+    {
+        lock (_tabAdmissionGate)
+        {
+            _tabAdmissionClosed = true;
+            if (_activeTabAdmissions == 0)
+                return Task.CompletedTask;
+
+            _tabAdmissionDrain ??= new TaskCompletionSource(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            return _tabAdmissionDrain.Task;
+        }
+    }
+
+    private void OpenTabAdmission()
+    {
+        lock (_tabAdmissionGate)
+        {
+            _tabAdmissionClosed = false;
+        }
     }
 
     internal void AddTabItem(EditorTabItem item)
@@ -785,15 +918,46 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
     }
 
     internal bool TryAddTabItem(EditorTabItem item)
-        => TryAddTabItem(item, select: false, beforeAdd: null, beforeSelection: null);
+        => TryAddTabItemWithAdmission(
+            item,
+            select: false,
+            beforeAdd: null,
+            beforeSelection: null);
 
     internal bool TryAddTabItem(EditorTabItem item, Action beforeAdd)
-        => TryAddTabItem(item, select: false, beforeAdd: beforeAdd, beforeSelection: null);
+        => TryAddTabItemWithAdmission(
+            item,
+            select: false,
+            beforeAdd: beforeAdd,
+            beforeSelection: null);
 
     internal bool TryAddAndSelectTabItem(EditorTabItem item, Action? beforeSelection = null)
-        => TryAddTabItem(item, select: true, beforeAdd: null, beforeSelection: beforeSelection);
+        => TryAddTabItemWithAdmission(
+            item,
+            select: true,
+            beforeAdd: null,
+            beforeSelection: beforeSelection);
 
-    private bool TryAddTabItem(
+    private bool TryAddTabItemWithAdmission(
+        EditorTabItem item,
+        bool select,
+        Action? beforeAdd,
+        Action? beforeSelection)
+    {
+        if (!TryEnterTabAdmission())
+            return false;
+
+        try
+        {
+            return TryAddTabItemCore(item, select, beforeAdd, beforeSelection);
+        }
+        finally
+        {
+            ExitTabAdmission();
+        }
+    }
+
+    private bool TryAddTabItemCore(
         EditorTabItem item,
         bool select,
         Action? beforeAdd,
@@ -805,6 +969,7 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
             return false;
 
         bool published = false;
+        bool itemAdded = false;
         void Publish()
         {
             void Mutate()
@@ -813,7 +978,11 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
                 if (!item.TryCompleteAttachment())
                     return;
 
-                AddTabItemCore(item);
+                BeforePhysicalAdd?.Invoke();
+                if (!AddTabItemCore(item))
+                    return;
+
+                itemAdded = true;
                 if (select && _tabItems.Contains(item))
                 {
                     try
@@ -867,7 +1036,7 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
                 else if (item.IsPublicationCurrent())
                     Mutate();
             });
-            published = itemPublished && contextPublished;
+            published = itemPublished && contextPublished && itemAdded;
         }
 
         try
@@ -906,26 +1075,42 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
         }
     }
 
-    internal void AddTabItemCore(EditorTabItem item)
+    internal bool AddTabItemCore(EditorTabItem item)
     {
-        _tabItems.Add(item);
+        if (!item.TryBeginPhysicalAdd())
+            return false;
+
+        bool added = false;
+        try
+        {
+            _tabItems.Add(item);
+            added = _tabItems.Contains(item);
+            return added;
+        }
+        finally
+        {
+            item.CompletePhysicalAdd(added);
+        }
     }
 
     internal bool ContainsTabItem(EditorTabItem item)
         => _tabItems.Contains(item);
 
-    internal bool RemoveTabItem(EditorTabItem item)
+    internal bool RequestTabRemoval(EditorTabItem item)
     {
         // Reserve terminal removal without running any collection or reactive observers while
         // the lifetime gate is held.
-        if (!item.TryBeginRemoval(out Task completion, out Task? publicationDrain))
+        if (!item.TryBeginRemoval(
+                out Task completion,
+                out Task? publicationDrain,
+                out Task? membershipDrain))
             return false;
 
-        if (publicationDrain is not null)
+        if (publicationDrain is not null || membershipDrain is not null)
         {
-            _ = CompleteRemovalAfterPublicationAsync(item, publicationDrain);
+            _ = CompleteRemovalAfterDrainsAsync(item, publicationDrain, membershipDrain);
             ObserveDeferredTaskFailure(completion);
-            return true;
+            return false;
         }
 
         try
@@ -938,14 +1123,27 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
         }
     }
 
-    private async Task CompleteRemovalAfterPublicationAsync(
+    internal async ValueTask<bool> RemoveTabItemAsync(EditorTabItem item)
+    {
+        bool wasPresent = ContainsTabItem(item);
+        bool removed = RequestTabRemoval(item);
+        if (!removed)
+            await item.GetRemovalCompletion().ConfigureAwait(false);
+        return wasPresent && (removed || !ContainsTabItem(item));
+    }
+
+    private async Task CompleteRemovalAfterDrainsAsync(
         EditorTabItem item,
-        Task publicationDrain)
+        Task? publicationDrain,
+        Task? membershipDrain)
     {
         Exception? failure = null;
         try
         {
-            await publicationDrain.ConfigureAwait(false);
+            if (publicationDrain is not null)
+                await publicationDrain.ConfigureAwait(false);
+            if (membershipDrain is not null)
+                await membershipDrain.ConfigureAwait(false);
             _ = RemoveTabItemFacade(item);
         }
         catch (Exception ex)
@@ -988,7 +1186,7 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
 
     private void ReconcileRejectedAttachment(EditorTabItem item)
     {
-        if (!RemoveTabItem(item))
+        if (!RequestTabRemoval(item))
             ObserveDeferredTaskFailure(item.GetRemovalCompletion());
     }
 
@@ -1088,11 +1286,12 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
 
     internal void RequestContextShutdown(IEditorContext context)
     {
-        EditorTabItem? item = GetRegisteredItem(context);
-        if (item is null || item.IsHostDisposingContext(context))
+        var registration = GetRegisteredItem(context);
+        if (registration is null || registration.Value.Item.IsHostDisposingContext(context))
             return;
 
-        EditorContextCloseRequest request = RequestClose(item);
+        BeforeContextCloseAdmission?.Invoke();
+        EditorContextCloseRequest request = RequestClose(context, registration.Value);
         if (request.Status != EditorContextCloseRequestStatus.NotOwned)
             ObserveDeferredTaskFailure(request.Completion);
     }
@@ -1100,25 +1299,56 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
     public EditorContextCloseRequest RequestClose(IEditorContext context)
     {
         ArgumentNullException.ThrowIfNull(context);
-        EditorTabItem? item = GetRegisteredItem(context);
-        if (item is null)
+        var registration = GetRegisteredItem(context);
+        if (registration is null)
         {
             return new EditorContextCloseRequest(
                 EditorContextCloseRequestStatus.NotOwned,
                 Task.CompletedTask);
         }
 
-        return RequestClose(item);
+        BeforeContextCloseAdmission?.Invoke();
+        return RequestClose(context, registration.Value);
     }
 
-    private EditorTabItem? GetRegisteredItem(IEditorContext context)
+    private (EditorTabItem Item, long Generation)? GetRegisteredItem(IEditorContext context)
     {
         lock (_contextRegistryGate)
         {
             return _contextItems.TryGetValue(context, out var registration)
-                ? registration.Item
+                ? registration
                 : null;
         }
+    }
+
+    private EditorContextCloseRequest RequestClose(
+        IEditorContext context,
+        (EditorTabItem Item, long Generation) registration)
+    {
+        bool accepted;
+        Task completion;
+        TaskCompletionSource<object?>? completionSource;
+        lock (_contextRegistryGate)
+        {
+            if (!_contextItems.TryGetValue(context, out var current)
+                || !ReferenceEquals(current.Item, registration.Item)
+                || current.Generation != registration.Generation)
+            {
+                return new EditorContextCloseRequest(
+                    EditorContextCloseRequestStatus.NotOwned,
+                    Task.CompletedTask);
+            }
+
+            accepted = registration.Item.TryBeginHostClose(
+                out completion,
+                out completionSource);
+        }
+
+        return StartHostClose(
+            registration.Item,
+            accepted,
+            completion,
+            completionSource);
     }
 
     private EditorContextCloseRequest RequestClose(EditorTabItem item)
@@ -1126,8 +1356,18 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
         bool accepted = item.TryBeginHostClose(
             out Task completion,
             out TaskCompletionSource<object?>? completionSource);
+        return StartHostClose(item, accepted, completion, completionSource);
+    }
+
+    private EditorContextCloseRequest StartHostClose(
+        EditorTabItem item,
+        bool accepted,
+        Task completion,
+        TaskCompletionSource<object?>? completionSource)
+    {
         if (accepted)
         {
+            BeforeHostCloseStart?.Invoke();
             _ = CompleteHostCloseAsync(item, completionSource!);
             ObserveDeferredTaskFailure(completion);
         }
@@ -1144,10 +1384,7 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
         TaskCompletionSource<object?> completion)
     {
         List<Exception>? failures = null;
-        try { RemoveTabItem(item); }
-        catch (Exception ex) { failures = [ex]; }
-
-        try { await item.GetRemovalCompletion().ConfigureAwait(false); }
+        try { await RemoveTabItemAsync(item).ConfigureAwait(false); }
         catch (Exception ex) { (failures ??= []).Add(ex); }
 
         try { await item.DisposeResourcesAsync().ConfigureAwait(false); }
@@ -1536,6 +1773,21 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
 
     public void ActivateTabItem(CoreObject obj)
     {
+        if (!TryEnterTabAdmission())
+            return;
+
+        try
+        {
+            ActivateTabItemCore(obj);
+        }
+        finally
+        {
+            ExitTabAdmission();
+        }
+    }
+
+    private void ActivateTabItemCore(CoreObject obj)
+    {
         ViewConfig viewConfig = GlobalConfiguration.Instance.ViewConfig;
         string path = Uri.UnescapeDataString(obj.Uri!.LocalPath);
         viewConfig.UpdateRecentFile(path);
@@ -1551,7 +1803,12 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
             if (ext?.TryCreateContext(obj, new EditorContextServices(this, _extensionProvider), out IEditorContext? context) == true)
             {
                 var tabItem2 = new EditorTabItem(context) { IsSelected = { Value = true } };
-                if (!TryAddAndSelectTabItem(tabItem2) && tabItem2.IsHostOwned)
+                if (!TryAddTabItemCore(
+                        tabItem2,
+                        select: true,
+                        beforeAdd: null,
+                        beforeSelection: null)
+                    && tabItem2.IsHostOwned)
                     ObserveDeferredTabDisposal(tabItem2.DisposeAsync().AsTask());
             }
         }

--- a/src/Beutl/Services/EditorService.cs
+++ b/src/Beutl/Services/EditorService.cs
@@ -18,25 +18,37 @@ public sealed class EditorTabItem : IAsyncDisposable
     private Task? _disposeTask;
     private Task? _transitionTask;
     private bool _closing;
+    private bool _contextDisposeAttempted;
+    private Action<EditorTabItem>? _terminalFailureHandler;
     private string? _hash;
 
     public EditorTabItem(IEditorContext context)
     {
-        MutableContext = new ReactiveProperty<IEditorContext>(context);
-        FilePath = Context.Select(ctxt => ctxt?.Object.Uri?.LocalPath)
+        MutableContext = new ReactiveProperty<IEditorContext?>(context);
+        FilePath = Context
+            .Where(static ctxt => ctxt is not null)
+            .Select(static ctxt => ctxt!.Object.Uri?.LocalPath)
+            .Where(static path => path is not null)
+            .Select(static path => path!)
             .ToReadOnlyReactivePropertySlim()!;
         FileName = FilePath.Select(Path.GetFileName)
             .Do(_ => _hash = null)
             .ToReadOnlyReactivePropertySlim()!;
-        Extension = Context.Select(ctxt => ctxt?.Extension!)
+        Extension = Context
+            .Where(static ctxt => ctxt is not null)
+            .Select(static ctxt => ctxt!.Extension)
             .ToReadOnlyReactivePropertySlim()!;
         Commands = Context.Select(ctxt => ctxt?.Commands)
             .ToReadOnlyReactivePropertySlim();
     }
 
-    private IReactiveProperty<IEditorContext> MutableContext { get; }
+    private IReactiveProperty<IEditorContext?> MutableContext { get; }
 
-    public IReadOnlyReactiveProperty<IEditorContext> Context => MutableContext;
+    /// <summary>The active editor context, or <see langword="null"/> while replacement or closure is in progress.</summary>
+    public IReadOnlyReactiveProperty<IEditorContext?> Context => MutableContext;
+
+    internal void AttachOwner(Action<EditorTabItem> terminalFailureHandler)
+        => _terminalFailureHandler = terminalFailureHandler;
 
     public IReadOnlyReactiveProperty<string> FilePath { get; }
 
@@ -72,7 +84,9 @@ public sealed class EditorTabItem : IAsyncDisposable
     {
         ArgumentNullException.ThrowIfNull(context);
         IEditorContext? oldContext = null;
-        TaskCompletionSource<bool>? completion = null;
+        TaskCompletionSource? transition = null;
+        TaskCompletionSource<bool>? result = null;
+        Exception? publicationFailure = null;
         bool rejected;
         lock (_lifetimeGate)
         {
@@ -80,50 +94,143 @@ public sealed class EditorTabItem : IAsyncDisposable
             if (!rejected)
             {
                 oldContext = MutableContext.Value;
-                MutableContext.Value = null!;
-                completion = new TaskCompletionSource<bool>(
+                transition = new TaskCompletionSource(
                     TaskCreationOptions.RunContinuationsAsynchronously);
-                _transitionTask = completion.Task;
+                result = new TaskCompletionSource<bool>(
+                    TaskCreationOptions.RunContinuationsAsynchronously);
+                _transitionTask = transition.Task;
             }
         }
 
         if (rejected)
             return new ValueTask<bool>(DisposeRejectedAndReturnFalseAsync(context));
 
-        _ = CompleteReplacementAsync(oldContext!, context, completion!);
-        return new ValueTask<bool>(completion!.Task);
+        try
+        {
+            MutableContext.Value = null;
+        }
+        catch (Exception ex)
+        {
+            publicationFailure = ex;
+        }
+
+        _ = CompleteReplacementAsync(
+            oldContext!,
+            context,
+            transition!,
+            result!,
+            publicationFailure);
+        return new ValueTask<bool>(result!.Task);
     }
 
     private async Task CompleteReplacementAsync(
         IEditorContext oldContext,
         IEditorContext replacement,
-        TaskCompletionSource<bool> completion)
+        TaskCompletionSource transition,
+        TaskCompletionSource<bool> result,
+        Exception? publicationFailure)
     {
         bool published = false;
+        List<Exception>? failures = publicationFailure is null ? null : [publicationFailure];
+
+        lock (_lifetimeGate)
+            _contextDisposeAttempted = true;
         try
         {
             await DisposeOwnedContextAsync(oldContext).ConfigureAwait(true);
-            lock (_lifetimeGate)
-            {
-                if (!_closing)
-                {
-                    MutableContext.Value = replacement;
-                    published = true;
-                }
-                _transitionTask = null;
-            }
-            if (!published)
-                await DisposeRejectedContextAsync(replacement).ConfigureAwait(true);
-            completion.TrySetResult(published);
         }
         catch (Exception ex)
         {
-            lock (_lifetimeGate)
-                _transitionTask = null;
-            await DisposeRejectedContextAsync(replacement).ConfigureAwait(true);
-            completion.TrySetException(ex);
+            RecordFailure(ref failures, ex);
         }
+
+        bool shouldPublish;
+        lock (_lifetimeGate)
+        {
+            shouldPublish = failures is null && !_closing;
+            if (shouldPublish)
+            {
+                _contextDisposeAttempted = false;
+            }
+            else if (failures is not null)
+            {
+                _closing = true;
+                _contextDisposeAttempted = true;
+            }
+        }
+
+        if (shouldPublish)
+        {
+            try
+            {
+                MutableContext.Value = replacement;
+                published = true;
+            }
+            catch (Exception ex)
+            {
+                RecordFailure(ref failures, ex);
+            }
+        }
+
+        bool closeWonAfterPublication;
+        lock (_lifetimeGate)
+        {
+            if (failures is not null)
+            {
+                _closing = true;
+                _contextDisposeAttempted = true;
+            }
+            closeWonAfterPublication = published && _closing;
+            _transitionTask = null;
+        }
+
+        if (!published)
+        {
+            Exception? rejectionFailure = await TryDisposeRejectedContextOwnedAsync(replacement)
+                .ConfigureAwait(true);
+            if (rejectionFailure is not null)
+                RecordFailure(ref failures, rejectionFailure);
+        }
+
+        transition.TrySetResult();
+        if (failures is null && published && !closeWonAfterPublication)
+        {
+            result.TrySetResult(true);
+            return;
+        }
+
+        if (failures is not null)
+        {
+            try
+            {
+                _terminalFailureHandler?.Invoke(this);
+            }
+            catch (Exception ex)
+            {
+                RecordFailure(ref failures, ex);
+            }
+        }
+
+        try
+        {
+            await DisposeAsync().ConfigureAwait(true);
+        }
+        catch (Exception ex)
+        {
+            RecordFailure(ref failures, ex);
+        }
+
+        if (failures is null)
+            result.TrySetResult(false);
+        else
+            result.TrySetException(CreateFailure(failures));
     }
+
+    private static void RecordFailure(ref List<Exception>? failures, Exception exception)
+        => (failures ??= []).Add(exception);
+
+    private static Exception CreateFailure(List<Exception> failures)
+        => failures.Count == 1 ? failures[0] : new AggregateException(failures);
 
     private async Task DisposeOwnedContextAsync(IEditorContext context)
     {
@@ -137,22 +244,24 @@ public sealed class EditorTabItem : IAsyncDisposable
         finally { s_ownedDisposals.Value = previous; }
     }
 
-    private static async Task DisposeRejectedContextAsync(IEditorContext context)
+    private async Task<Exception?> TryDisposeRejectedContextOwnedAsync(IEditorContext context)
     {
         try
         {
-            await context.DisposeAsync().ConfigureAwait(false);
+            await DisposeOwnedContextAsync(context).ConfigureAwait(true);
+            return null;
         }
-        catch
+        catch (Exception ex)
         {
-            // The caller cannot retain ownership of a rejected context. Preserve the
-            // original replacement/close outcome while ensuring it is not leaked.
+            return ex;
         }
     }
 
-    private static async Task<bool> DisposeRejectedAndReturnFalseAsync(IEditorContext context)
+    private async Task<bool> DisposeRejectedAndReturnFalseAsync(IEditorContext context)
     {
-        await DisposeRejectedContextAsync(context).ConfigureAwait(false);
+        Exception? failure = await TryDisposeRejectedContextOwnedAsync(context).ConfigureAwait(true);
+        if (failure is not null)
+            throw failure;
         return false;
     }
 
@@ -183,37 +292,74 @@ public sealed class EditorTabItem : IAsyncDisposable
         Task? transition,
         TaskCompletionSource<object?> completion)
     {
+        List<Exception>? failures = null;
+        IReadOnlySet<EditorTabItem>? previous = s_ownedDisposals.Value;
+        var current = previous is null
+            ? new HashSet<EditorTabItem>(ReferenceEqualityComparer.Instance)
+            : new HashSet<EditorTabItem>(previous, ReferenceEqualityComparer.Instance);
+        current.Add(this);
+        s_ownedDisposals.Value = current;
         try
         {
             if (transition is not null)
             {
                 try { await transition.ConfigureAwait(true); }
-                catch { }
+                catch (Exception ex) { RecordFailure(ref failures, ex); }
             }
 
             IEditorContext? context;
+            bool disposeContext;
             lock (_lifetimeGate)
             {
                 context = MutableContext.Value;
-                MutableContext.Value = null!;
+                disposeContext = context is not null && !_contextDisposeAttempted;
+                if (disposeContext)
+                    _contextDisposeAttempted = true;
             }
-            if (context is not null)
-                await DisposeOwnedContextAsync(context).ConfigureAwait(true);
-
-            MutableContext.Dispose();
-            FilePath.Dispose();
-            FileName.Dispose();
-            Extension.Dispose();
-            Commands.Dispose();
-            IsSelected.Dispose();
+            try
+            {
+                MutableContext.Value = null;
+            }
+            catch (Exception ex)
+            {
+                RecordFailure(ref failures, ex);
+            }
+            if (disposeContext && context is not null)
+            {
+                try
+                {
+                    await DisposeOwnedContextAsync(context).ConfigureAwait(true);
+                }
+                catch (Exception ex)
+                {
+                    RecordFailure(ref failures, ex);
+                }
+            }
         }
         catch (Exception ex)
         {
-            completion.TrySetException(ex);
-            return;
+            RecordFailure(ref failures, ex);
         }
+        finally
+        {
+            DisposeSurface(MutableContext, ref failures);
+            DisposeSurface(FilePath, ref failures);
+            DisposeSurface(FileName, ref failures);
+            DisposeSurface(Extension, ref failures);
+            DisposeSurface(Commands, ref failures);
+            DisposeSurface(IsSelected, ref failures);
+            s_ownedDisposals.Value = previous;
+            if (failures is null)
+                completion.TrySetResult(null);
+            else
+                completion.TrySetException(CreateFailure(failures));
+        }
+    }
 
-        completion.TrySetResult(null);
+    private static void DisposeSurface(IDisposable surface, ref List<Exception>? failures)
+    {
+        try { surface.Dispose(); }
+        catch (Exception ex) { RecordFailure(ref failures, ex); }
     }
 }
 
@@ -260,9 +406,38 @@ public sealed class EditorService : IOutputOperationLeaseProvider
 
     internal void ClearTabItems() => _tabItems.Clear();
 
-    internal void AddTabItem(EditorTabItem item) => _tabItems.Add(item);
+    internal void AddTabItem(EditorTabItem item)
+    {
+        item.AttachOwner(RemoveFailedTabItem);
+        _tabItems.Add(item);
+    }
 
-    internal bool RemoveTabItem(EditorTabItem item) => _tabItems.Remove(item);
+    internal bool RemoveTabItem(EditorTabItem item)
+    {
+        List<Exception>? failures = null;
+        bool wasPresent = _tabItems.Contains(item);
+        bool removed = false;
+        try
+        {
+            removed = _tabItems.Remove(item);
+        }
+        catch (Exception ex)
+        {
+            failures = [ex];
+            removed = wasPresent && !_tabItems.Contains(item);
+        }
+        if (removed && ReferenceEquals(SelectedTabItem.Value, item))
+        {
+            try { SelectedTabItem.Value = null; }
+            catch (Exception ex) { (failures ??= []).Add(ex); }
+        }
+        if (failures is not null)
+            throw failures.Count == 1 ? failures[0] : new AggregateException(failures);
+        return removed;
+    }
+
+    private void RemoveFailedTabItem(EditorTabItem item)
+        => RemoveTabItem(item);
 
     internal ExtensionProvider ExtensionProvider => _extensionProvider;
 
@@ -665,16 +840,18 @@ public sealed class EditorService : IOutputOperationLeaseProvider
     public async ValueTask CloseTabItem(CoreObject obj)
     {
         if (TryGetTabItem(obj, out EditorTabItem? item))
-        {
-            RemoveTabItem(item);
-            await item.DisposeAsync();
-        }
+            await CloseTabItem(item);
     }
 
     public async ValueTask CloseTabItem(EditorTabItem item)
     {
-        RemoveTabItem(item);
-        await item.DisposeAsync();
+        List<Exception>? failures = null;
+        try { RemoveTabItem(item); }
+        catch (Exception ex) { failures = [ex]; }
+        try { await item.DisposeAsync(); }
+        catch (Exception ex) { (failures ??= []).Add(ex); }
+        if (failures is not null)
+            throw failures.Count == 1 ? failures[0] : new AggregateException(failures);
     }
 
     private sealed class EditorSuspension(IDisposable[] suspensions) : IDisposable

--- a/src/Beutl/Services/EditorService.cs
+++ b/src/Beutl/Services/EditorService.cs
@@ -1856,8 +1856,6 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
         registration.OwnershipLease.Dispose();
     }
 
-    internal ExtensionProvider ExtensionProvider => _extensionProvider;
-
     internal void RequestContextShutdown(IEditorContext context)
     {
         var registration = GetRegisteredItem(context);

--- a/src/Beutl/Services/EditorService.cs
+++ b/src/Beutl/Services/EditorService.cs
@@ -988,7 +988,8 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
         new(ReferenceEqualityComparer.Instance);
     private long _contextRegistrationGeneration;
     private readonly object _lifecycleTeardownGate = new();
-    private readonly HashSet<Task> _activeLifecycleTeardowns = [];
+    private readonly HashSet<DeferredLifecycleTeardown> _activeLifecycleTeardowns = [];
+    private readonly Queue<Exception> _deferredLifecycleFailures = new();
 
     internal Action? BeforeInitialOwnerAttach { get; set; }
 
@@ -1063,7 +1064,10 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
             foreach (EditorTabItem item in _tabItems.ToArray())
             {
                 try { await CloseTabItem(item); }
-                catch (Exception ex) { (failures ??= []).Add(ex); }
+                catch
+                {
+                    // The lifecycle tracker persists this failure until the drain below consumes it.
+                }
             }
             foreach (Exception ex in await DrainActiveLifecycleTeardownsAsync())
                 (failures ??= []).Add(ex);
@@ -1275,6 +1279,27 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
         public EditorService? ActiveOwner => Volatile.Read(ref _activeOwner);
 
         public void Complete() => Interlocked.Exchange(ref _activeOwner, null);
+    }
+
+    private sealed class DeferredLifecycleTeardown
+    {
+        public DeferredLifecycleTeardown(Task task)
+        {
+            Task = task;
+        }
+
+        public DeferredLifecycleTeardown()
+        {
+            Completion = new TaskCompletionSource(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            Task = Completion.Task;
+        }
+
+        public Task Task { get; }
+
+        public TaskCompletionSource? Completion { get; }
+
+        public bool Taken { get; set; }
     }
 
     internal static bool IsTabLifecycleOperationActive
@@ -1903,7 +1928,7 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
     private void TrackHostClose(Task completion)
     {
         lock (_lifecycleTeardownGate)
-            _activeLifecycleTeardowns.Add(completion);
+            _activeLifecycleTeardowns.Add(new DeferredLifecycleTeardown(completion));
     }
 
     private void CompleteTrackedHostClose(
@@ -1913,39 +1938,63 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
     {
         lock (_lifecycleTeardownGate)
         {
-            if (failures is null)
+            Exception? terminalFailure = failures switch
+            {
+                null => null,
+                [Exception failure] => failure,
+                _ => new AggregateException(failures)
+            };
+            if (terminalFailure is null)
                 completion.TrySetResult(null);
             else
-                completion.TrySetException(failures.Count == 1 ? failures[0] : new AggregateException(failures));
-            _activeLifecycleTeardowns.Remove(hostCloseTask);
+                completion.TrySetException(terminalFailure);
+
+            DeferredLifecycleTeardown? entry = null;
+            foreach (DeferredLifecycleTeardown candidate in _activeLifecycleTeardowns)
+            {
+                if (ReferenceEquals(candidate.Task, hostCloseTask))
+                {
+                    entry = candidate;
+                    break;
+                }
+            }
+            if (entry is not null && !entry.Taken)
+            {
+                _activeLifecycleTeardowns.Remove(entry);
+                if (terminalFailure is not null)
+                    _deferredLifecycleFailures.Enqueue(terminalFailure);
+            }
         }
     }
 
     private async Task<List<Exception>> DrainActiveLifecycleTeardownsAsync()
     {
         List<Exception>? failures = null;
-        while (true)
+        DeferredLifecycleTeardown[] active;
+        lock (_lifecycleTeardownGate)
         {
-            Task[] active;
-            lock (_lifecycleTeardownGate)
-            {
-                if (_activeLifecycleTeardowns.Count == 0)
-                    return failures ?? [];
-                active = _activeLifecycleTeardowns.ToArray();
-            }
+            while (_deferredLifecycleFailures.TryDequeue(out Exception? failure))
+                (failures ??= []).Add(failure);
 
-            foreach (Task close in active)
+            active = _activeLifecycleTeardowns.ToArray();
+            _activeLifecycleTeardowns.Clear();
+            foreach (DeferredLifecycleTeardown teardown in active)
+                teardown.Taken = true;
+        }
+
+        foreach (DeferredLifecycleTeardown teardown in active)
+        {
+            try
             {
-                try
-                {
-                    await close.ConfigureAwait(false);
-                }
-                catch (Exception ex)
-                {
-                    (failures ??= []).Add(ex);
-                }
+                await teardown.Task.ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                (failures ??= []).Add(ex);
             }
         }
+
+        return failures ?? [];
     }
 
     public IReactiveProperty<EditorTabItem?> SelectedTabItem { get; } = new ReactivePropertySlim<EditorTabItem?>();
@@ -2521,46 +2570,105 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
             TaskScheduler.Default);
     }
 
-    private void TrackAndObserveLifecycleTeardown(Task teardown)
+    private void TrackAndObserveLifecycleTeardown(Func<Task> teardownFactory)
     {
-        TrackDeferredLifecycleTeardown(teardown);
-        ObserveDeferredTabDisposal(teardown);
+        ArgumentNullException.ThrowIfNull(teardownFactory);
+        TabAdmissionOperation? parent = s_tabAdmissionOperation.Value;
+        TabAdmissionOperation child = new(this, parent);
+        var entry = new DeferredLifecycleTeardown();
+        lock (_lifecycleTeardownGate)
+            _activeLifecycleTeardowns.Add(entry);
+        _ = CompleteDeferredLifecycleTeardownAsync(entry, teardownFactory, child);
+        ObserveDeferredTabDisposal(entry.Task);
     }
 
-    private void TrackDeferredLifecycleTeardown(Task teardown)
+    private async Task RunLifecycleTeardownAsync(
+        Func<Task> teardownFactory,
+        TabAdmissionOperation operation)
     {
-        lock (_lifecycleTeardownGate)
-            _activeLifecycleTeardowns.Add(teardown);
-        _ = teardown.ContinueWith(
-            static (completed, state) =>
-                ((EditorService)state!).UntrackDeferredLifecycleTeardown(completed),
-            this,
-            CancellationToken.None,
-            TaskContinuationOptions.ExecuteSynchronously,
-            TaskScheduler.Default);
+        TabAdmissionOperation? previous = s_tabAdmissionOperation.Value;
+        s_tabAdmissionOperation.Value = operation;
+        try
+        {
+            await teardownFactory().ConfigureAwait(false);
+        }
+        finally
+        {
+            CompleteTabAdmissionOperation(operation, previous);
+        }
     }
 
-    private void UntrackDeferredLifecycleTeardown(Task teardown)
+    private async Task CompleteDeferredLifecycleTeardownAsync(
+        DeferredLifecycleTeardown entry,
+        Func<Task> teardownFactory,
+        TabAdmissionOperation operation)
     {
+        Exception? failure = null;
+        OperationCanceledException? cancellation = null;
+        try
+        {
+            await RunLifecycleTeardownAsync(teardownFactory, operation).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException ex)
+        {
+            cancellation = ex;
+            failure = ex;
+        }
+        catch (Exception ex)
+        {
+            failure = ex;
+        }
+
         lock (_lifecycleTeardownGate)
-            _activeLifecycleTeardowns.Remove(teardown);
+        {
+            if (!entry.Taken)
+            {
+                _activeLifecycleTeardowns.Remove(entry);
+                if (failure is not null)
+                    _deferredLifecycleFailures.Enqueue(failure);
+            }
+
+            if (cancellation is not null)
+                entry.Completion!.TrySetCanceled(cancellation.CancellationToken);
+            else if (failure is not null)
+                entry.Completion!.TrySetException(failure);
+            else
+                entry.Completion!.TrySetResult();
+        }
     }
 
     private void ObserveDeferredTabDisposal(
         EditorTabItem item,
         EditorContextOwnershipLease ownershipLease)
     {
-        Task disposal;
-        try
+        if (item.IsHostOwned)
         {
-            disposal = item.DisposeAsync().AsTask();
-        }
-        catch (Exception ex)
-        {
-            disposal = ForceDisposeTabAfterStartFailureAsync(item, ex);
+            try
+            {
+                ObserveDeferredTabDisposal(item.DisposeAsync().AsTask());
+            }
+            catch (Exception ex)
+            {
+                TrackAndObserveLifecycleTeardown(
+                    () => ForceDisposeTabAfterStartFailureAsync(item, ex));
+            }
+            return;
         }
 
-        TrackAndObserveLifecycleTeardown(ReleaseLeaseAfterAsync(disposal, ownershipLease));
+        TrackAndObserveLifecycleTeardown(async () =>
+        {
+            Task disposal;
+            try
+            {
+                disposal = item.DisposeAsync().AsTask();
+            }
+            catch (Exception ex)
+            {
+                disposal = ForceDisposeTabAfterStartFailureAsync(item, ex);
+            }
+
+            await ReleaseLeaseAfterAsync(disposal, ownershipLease).ConfigureAwait(false);
+        });
     }
 
     private async Task ForceDisposeTabAfterStartFailureAsync(
@@ -2614,35 +2722,18 @@ public sealed class EditorService : IOutputOperationLeaseProvider, IEditorContex
 
     private void ObserveDeferredContextDisposal(IEditorContext context)
     {
-        Task disposal;
-        try
+        TrackAndObserveLifecycleTeardown(async () =>
         {
-            disposal = context.DisposeAsync().AsTask();
-        }
-        catch (Exception ex)
-        {
-            disposal = Task.FromException(ex);
-        }
-
-        TrackAndObserveLifecycleTeardown(disposal);
+            await context.DisposeAsync().ConfigureAwait(false);
+        });
     }
 
     private void ObserveDeferredContextDisposal(
         IEditorContext context,
         EditorContextOwnershipLease ownershipLease)
     {
-        Task disposal;
-        try
-        {
-            disposal = DisposeContextAndReleaseLeaseAsync(context, ownershipLease);
-        }
-        catch (Exception ex)
-        {
-            ownershipLease.Dispose();
-            disposal = Task.FromException(ex);
-        }
-
-        TrackAndObserveLifecycleTeardown(disposal);
+        TrackAndObserveLifecycleTeardown(
+            () => DisposeContextAndReleaseLeaseAsync(context, ownershipLease));
     }
 
     private static async Task DisposeContextAndReleaseLeaseAsync(

--- a/src/Beutl/Services/EditorService.cs
+++ b/src/Beutl/Services/EditorService.cs
@@ -56,6 +56,29 @@ public sealed class EditorTabItem : IAsyncDisposable
     internal void AttachOwner(Action<EditorTabItem> terminalFailureHandler)
         => _terminalFailureHandler = terminalFailureHandler;
 
+    // Keep publication (registration and selection) behind the same lifetime gate as disposal.
+    // This also covers editor-context implementations that do not expose the optional
+    // IEditorContextPublicationGate contract.
+    internal bool TryPublish(Action publish)
+    {
+        ArgumentNullException.ThrowIfNull(publish);
+        lock (_lifetimeGate)
+        {
+            if (_closing || _disposeTask is not null || MutableContext.Value is null)
+                return false;
+
+            publish();
+            return !_closing && _disposeTask is null && MutableContext.Value is not null;
+        }
+    }
+
+    internal void MutateLifetime(Action mutation)
+    {
+        ArgumentNullException.ThrowIfNull(mutation);
+        lock (_lifetimeGate)
+            mutation();
+    }
+
     public IReadOnlyReactiveProperty<string> FilePath { get; }
 
     public IReadOnlyReactiveProperty<string> FileName { get; }
@@ -137,6 +160,7 @@ public sealed class EditorTabItem : IAsyncDisposable
         Exception? publicationFailure)
     {
         bool published = false;
+        bool accepted = false;
         List<Exception>? failures = publicationFailure is null ? null : [publicationFailure];
 
         lock (_lifetimeGate)
@@ -169,12 +193,11 @@ public sealed class EditorTabItem : IAsyncDisposable
         {
             try
             {
-                published = replacement is IEditorContextPublicationGate gate
-                    ? gate.TryPublish(() => MutableContext.Value = replacement)
-                    : PublishReplacementContext(replacement);
+                (published, accepted) = TryPublishReplacementContext(replacement);
             }
             catch (Exception ex)
             {
+                published = ReferenceEquals(MutableContext.Value, replacement);
                 RecordFailure(ref failures, ex);
             }
         }
@@ -185,7 +208,10 @@ public sealed class EditorTabItem : IAsyncDisposable
             if (failures is not null)
             {
                 _closing = true;
-                _contextDisposeAttempted = true;
+                // A published replacement is now owned by the tab even when a subscriber
+                // throws. Leave its disposal to the terminal tab close; only rejected
+                // replacements are disposed directly below.
+                _contextDisposeAttempted = !published;
             }
             closeWonAfterPublication = published && _closing;
             _transitionTask = null;
@@ -200,7 +226,7 @@ public sealed class EditorTabItem : IAsyncDisposable
         }
 
         transition.TrySetResult();
-        if (failures is null && published && !closeWonAfterPublication)
+        if (failures is null && accepted && !closeWonAfterPublication)
         {
             result.TrySetResult(true);
             return;
@@ -232,10 +258,31 @@ public sealed class EditorTabItem : IAsyncDisposable
             result.TrySetException(CreateFailure(failures));
     }
 
-    private bool PublishReplacementContext(IEditorContext replacement)
+    private (bool Published, bool Accepted) TryPublishReplacementContext(IEditorContext replacement)
     {
-        MutableContext.Value = replacement;
-        return true;
+        bool contextPublished = true;
+        bool itemPublished = false;
+        lock (_lifetimeGate)
+        {
+            if (_closing || _disposeTask is not null || MutableContext.Value is not null)
+                return (false, false);
+
+            if (replacement is IEditorContextPublicationGate gate)
+                contextPublished = gate.TryPublish(() =>
+                {
+                    MutableContext.Value = replacement;
+                    itemPublished = true;
+                });
+            else
+            {
+                MutableContext.Value = replacement;
+                itemPublished = true;
+            }
+
+            bool accepted = itemPublished && contextPublished && !_closing && _disposeTask is null
+                && ReferenceEquals(MutableContext.Value, replacement);
+            return (itemPublished, accepted);
+        }
     }
 
     private static void RecordFailure(ref List<Exception>? failures, Exception exception)
@@ -416,7 +463,18 @@ public sealed class EditorService : IOutputOperationLeaseProvider
 
     public ICoreReadOnlyList<EditorTabItem> TabItems => _tabItems;
 
-    internal void ClearTabItems() => _tabItems.Clear();
+    internal void ClearTabItems()
+    {
+        List<Exception>? failures = null;
+        foreach (EditorTabItem item in _tabItems.ToArray())
+        {
+            try { RemoveTabItem(item); }
+            catch (Exception ex) { (failures ??= []).Add(ex); }
+        }
+
+        if (failures is not null)
+            throw failures.Count == 1 ? failures[0] : new AggregateException(failures);
+    }
 
     internal void AddTabItem(EditorTabItem item)
     {
@@ -425,12 +483,43 @@ public sealed class EditorService : IOutputOperationLeaseProvider
     }
 
     internal bool TryAddTabItem(EditorTabItem item)
-    {
-        if (item.Context.Value is IEditorContextPublicationGate gate)
-            return gate.TryPublish(() => AddTabItemCore(item)) && ContainsTabItem(item);
+        => TryAddTabItem(item, select: false);
 
-        AddTabItemCore(item);
-        return true;
+    internal bool TryAddAndSelectTabItem(EditorTabItem item, Action? beforeSelection = null)
+        => TryAddTabItem(item, select: true, beforeSelection);
+
+    private bool TryAddTabItem(EditorTabItem item, bool select, Action? beforeSelection = null)
+    {
+        bool published = false;
+        void Publish()
+        {
+            void Mutate()
+            {
+                AddTabItemCore(item);
+                if (select && _tabItems.Contains(item))
+                {
+                    beforeSelection?.Invoke();
+                    if (!_tabItems.Contains(item) || item.Context.Value is null)
+                        return;
+
+                    item.IsSelected.Value = true;
+                    SelectedTabItem.Value = item;
+                }
+            }
+
+            bool contextPublished = true;
+            bool itemPublished = item.TryPublish(() =>
+            {
+                if (item.Context.Value is IEditorContextPublicationGate gate)
+                    contextPublished = gate.TryPublish(Mutate);
+                else
+                    Mutate();
+            });
+            published = itemPublished && contextPublished;
+        }
+
+        Publish();
+        return published && ContainsTabItem(item);
     }
 
     internal void AddTabItemCore(EditorTabItem item)
@@ -445,22 +534,29 @@ public sealed class EditorService : IOutputOperationLeaseProvider
     internal bool RemoveTabItem(EditorTabItem item)
     {
         List<Exception>? failures = null;
-        bool wasPresent = _tabItems.Contains(item);
         bool removed = false;
-        try
+        item.MutateLifetime(() =>
         {
-            removed = _tabItems.Remove(item);
-        }
-        catch (Exception ex)
-        {
-            failures = [ex];
-            removed = wasPresent && !_tabItems.Contains(item);
-        }
-        if (removed && ReferenceEquals(SelectedTabItem.Value, item))
-        {
-            try { SelectedTabItem.Value = null; }
+            bool wasPresent = _tabItems.Contains(item);
+            try
+            {
+                removed = _tabItems.Remove(item);
+            }
+            catch (Exception ex)
+            {
+                (failures ??= []).Add(ex);
+                removed = wasPresent && !_tabItems.Contains(item);
+            }
+            // Clear selection even when the collection removal lost a race with another remover.
+            // Otherwise a tab that is no longer live can be re-exposed as the selected item.
+            if (ReferenceEquals(SelectedTabItem.Value, item))
+            {
+                try { SelectedTabItem.Value = null; }
+                catch (Exception ex) { (failures ??= []).Add(ex); }
+            }
+            try { item.IsSelected.Value = false; }
             catch (Exception ex) { (failures ??= []).Add(ex); }
-        }
+        });
         if (failures is not null)
             throw failures.Count == 1 ? failures[0] : new AggregateException(failures);
         return removed;
@@ -867,8 +963,7 @@ public sealed class EditorService : IOutputOperationLeaseProvider
 
         if (TryGetTabItem(obj, out EditorTabItem? tabItem))
         {
-            tabItem.IsSelected.Value = true;
-            SelectedTabItem.Value = tabItem;
+            TrySelectTabItem(tabItem);
         }
         else
         {
@@ -877,12 +972,39 @@ public sealed class EditorService : IOutputOperationLeaseProvider
             if (ext?.TryCreateContext(obj, new EditorContextServices(this, _extensionProvider), out IEditorContext? context) == true)
             {
                 var tabItem2 = new EditorTabItem(context) { IsSelected = { Value = true } };
-                if (TryAddTabItem(tabItem2))
-                    SelectedTabItem.Value = tabItem2;
-                else
+                if (!TryAddAndSelectTabItem(tabItem2))
                     _ = tabItem2.DisposeAsync();
             }
         }
+    }
+
+    private bool TrySelectTabItem(EditorTabItem item)
+    {
+        bool selected = false;
+        void Publish()
+        {
+            void Mutate()
+            {
+                if (!_tabItems.Contains(item) || item.Context.Value is null)
+                    return;
+
+                item.IsSelected.Value = true;
+                SelectedTabItem.Value = item;
+            }
+
+            bool contextPublished = true;
+            bool itemPublished = item.TryPublish(() =>
+            {
+                if (item.Context.Value is IEditorContextPublicationGate gate)
+                    contextPublished = gate.TryPublish(Mutate);
+                else
+                    Mutate();
+            });
+            selected = itemPublished && contextPublished;
+        }
+
+        Publish();
+        return selected && ReferenceEquals(SelectedTabItem.Value, item);
     }
 
     public async ValueTask CloseTabItem(CoreObject obj)

--- a/src/Beutl/Services/PrimitiveImpls/SceneEditorExtension.cs
+++ b/src/Beutl/Services/PrimitiveImpls/SceneEditorExtension.cs
@@ -126,7 +126,7 @@ public sealed class SceneEditorExtension : EditorExtension
             && services.CloseService is { HostToken: not null } closeService
             && ReferenceEquals(editorService.HostToken, closeService.HostToken))
         {
-            var editViewModel = new EditViewModel(scene, editorService);
+            var editViewModel = new EditViewModel(scene, editorService, closeService);
             if (editViewModel.IsDisposeRequested)
             {
                 context = null;

--- a/src/Beutl/Services/PrimitiveImpls/SceneEditorExtension.cs
+++ b/src/Beutl/Services/PrimitiveImpls/SceneEditorExtension.cs
@@ -125,7 +125,11 @@ public sealed class SceneEditorExtension : EditorExtension
         if (obj is Scene scene
             && services.TryGetService<EditorService>(out EditorService? editorService))
         {
-            var editViewModel = new EditViewModel(scene, editorService.ExtensionProvider, editorService);
+            var editViewModel = new EditViewModel(
+                scene,
+                editorService.ExtensionProvider,
+                editorService,
+                services.CloseService);
             if (editViewModel.IsDisposeRequested)
             {
                 context = null;

--- a/src/Beutl/Services/PrimitiveImpls/SceneEditorExtension.cs
+++ b/src/Beutl/Services/PrimitiveImpls/SceneEditorExtension.cs
@@ -116,11 +116,11 @@ public sealed class SceneEditorExtension : EditorExtension
         }
     }
 
-    public override bool TryCreateContext(
-        CoreObject obj, IEditorContextServices services, [NotNullWhen(true)] out IEditorContext? context)
+    public override async ValueTask<IEditorContext?> CreateContextAsync(
+        CoreObject obj, IEditorContextServices services)
     {
-        // TryCreate* must not throw: when the host does not supply the services EditViewModel needs,
-        // fail (return false) rather than pushing nulls into EditViewModel.
+        // When the host does not supply the services EditViewModel needs, return null rather than
+        // pushing nulls into EditViewModel.
         if (obj is Scene scene
             && services.TryGetService<EditorService>(out EditorService? editorService)
             && services.CloseService is { HostToken: not null } closeService
@@ -129,20 +129,13 @@ public sealed class SceneEditorExtension : EditorExtension
             var editViewModel = new EditViewModel(scene, editorService, closeService);
             if (editViewModel.IsDisposeRequested)
             {
-                context = null;
-                _ = editViewModel.DisposeAsync().AsTask().ContinueWith(
-                    static task => _ = task.Exception,
-                    CancellationToken.None,
-                    TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
-                    TaskScheduler.Default);
-                return false;
+                await editViewModel.DisposeAsync();
+                return null;
             }
-            context = editViewModel;
-            return true;
+            return editViewModel;
         }
 
-        context = null;
-        return false;
+        return null;
     }
 
     public override IconSource? GetIcon()

--- a/src/Beutl/Services/PrimitiveImpls/SceneEditorExtension.cs
+++ b/src/Beutl/Services/PrimitiveImpls/SceneEditorExtension.cs
@@ -123,13 +123,15 @@ public sealed class SceneEditorExtension : EditorExtension
         // TryCreate* must not throw: when the host does not supply the services EditViewModel needs,
         // fail (return false) rather than pushing nulls into EditViewModel.
         if (obj is Scene scene
-            && services.TryGetService<EditorService>(out EditorService? editorService))
+            && services.TryGetService<EditorService>(out EditorService? editorService)
+            && services.CloseService is { HostToken: not null } closeService
+            && ReferenceEquals(editorService.HostToken, closeService.HostToken))
         {
             var editViewModel = new EditViewModel(
                 scene,
                 editorService.ExtensionProvider,
                 editorService,
-                services.CloseService);
+                closeService);
             if (editViewModel.IsDisposeRequested)
             {
                 context = null;

--- a/src/Beutl/Services/PrimitiveImpls/SceneEditorExtension.cs
+++ b/src/Beutl/Services/PrimitiveImpls/SceneEditorExtension.cs
@@ -2,7 +2,6 @@
 using System.Runtime.InteropServices;
 using Avalonia.Controls;
 using Avalonia.Platform.Storage;
-using Beutl.Api.Services;
 using Beutl.ProjectSystem;
 using Beutl.ViewModels;
 using Beutl.Views;
@@ -127,11 +126,7 @@ public sealed class SceneEditorExtension : EditorExtension
             && services.CloseService is { HostToken: not null } closeService
             && ReferenceEquals(editorService.HostToken, closeService.HostToken))
         {
-            var editViewModel = new EditViewModel(
-                scene,
-                editorService.ExtensionProvider,
-                editorService,
-                closeService);
+            var editViewModel = new EditViewModel(scene, editorService);
             if (editViewModel.IsDisposeRequested)
             {
                 context = null;

--- a/src/Beutl/Services/PrimitiveImpls/SceneEditorExtension.cs
+++ b/src/Beutl/Services/PrimitiveImpls/SceneEditorExtension.cs
@@ -125,7 +125,18 @@ public sealed class SceneEditorExtension : EditorExtension
         if (obj is Scene scene
             && services.TryGetService<EditorService>(out EditorService? editorService))
         {
-            context = new EditViewModel(scene, editorService.ExtensionProvider, editorService);
+            var editViewModel = new EditViewModel(scene, editorService.ExtensionProvider, editorService);
+            if (editViewModel.IsDisposeRequested)
+            {
+                context = null;
+                _ = editViewModel.DisposeAsync().AsTask().ContinueWith(
+                    static task => _ = task.Exception,
+                    CancellationToken.None,
+                    TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+                    TaskScheduler.Default);
+                return false;
+            }
+            context = editViewModel;
             return true;
         }
 

--- a/src/Beutl/Services/PrimitiveImpls/SceneEditorExtension.cs
+++ b/src/Beutl/Services/PrimitiveImpls/SceneEditorExtension.cs
@@ -127,6 +127,19 @@ public sealed class SceneEditorExtension : EditorExtension
             && ReferenceEquals(editorService.HostToken, closeService.HostToken))
         {
             var editViewModel = new EditViewModel(scene, editorService, closeService);
+            try
+            {
+                await editViewModel.Initialization;
+            }
+            catch (Exception initializationError)
+            {
+                try { await editViewModel.DisposeAsync(); }
+                catch (Exception disposalError)
+                {
+                    throw new AggregateException(initializationError, disposalError);
+                }
+                throw;
+            }
             if (editViewModel.IsDisposeRequested)
             {
                 await editViewModel.DisposeAsync();

--- a/src/Beutl/Services/ProjectService.Lifecycle.cs
+++ b/src/Beutl/Services/ProjectService.Lifecycle.cs
@@ -1,0 +1,415 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace Beutl.Services;
+
+public sealed partial class ProjectService
+{
+    private readonly Dictionary<ProjectTransitionContext, TaskCompletionSource> _transitionCompletions = [];
+    private readonly object _projectOperationGate = new();
+    private Task _projectOperationTask = Task.CompletedTask;
+    private bool _projectTransitionAdmissionClosed;
+    private TaskCompletionSource? _projectTransitionAdmission;
+    private readonly object _closeGate = new();
+    private Task? _activeCloseTask;
+    private Task? _activeCloseOperationTail;
+    private readonly object _projectNotificationGate = new();
+    private Task _projectNotificationTask = Task.CompletedTask;
+    private readonly object _projectChangeGate = new();
+    private IProjectChangeHandler? _projectChangeHandler;
+    private IProjectChangeHandler? _closingProjectChangeHandler;
+    private Task _lastProjectChangeTask = Task.CompletedTask;
+
+    internal Func<string, Task>? BeforeCreateProjectPreparation { get; set; }
+
+    internal Action<string>? AfterCreateProjectPreparation { get; set; }
+
+    internal Func<string, Task>? BeforeRecentProjectUpdate { get; set; }
+
+    internal Func<Task>? BeforeProjectChangeHandlerInitialization { get; set; }
+
+    internal ProjectChangeRegistration RegisterProjectChangeHandler(IProjectChangeHandler handler)
+    {
+        ArgumentNullException.ThrowIfNull(handler);
+        Task previous;
+        Project? current;
+        TaskCompletionSource? admission;
+        var initialization = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        lock (_projectOperationGate)
+        {
+            if (!_projectTransitionAdmissionClosed && !_projectOperationTask.IsCompleted)
+            {
+                throw new InvalidOperationException(
+                    "An editor host cannot be registered during a project transition.");
+            }
+
+            lock (_projectChangeGate)
+            {
+                if (_projectChangeHandler is not null || _closingProjectChangeHandler is not null)
+                {
+                    throw new InvalidOperationException(
+                        "An editor host is already registered or still completing shutdown.");
+                }
+
+                if (_projectTransitionAdmissionClosed
+                    && (_projectTransitionAdmission is null
+                        || _projectTransitionAdmission.Task.IsCompleted))
+                {
+                    _projectTransitionAdmission = new TaskCompletionSource(
+                        TaskCreationOptions.RunContinuationsAsynchronously);
+                }
+
+                _projectChangeHandler = handler;
+                current = _app.Project;
+                previous = _lastProjectChangeTask;
+                _lastProjectChangeTask = initialization.Task;
+                admission = _projectTransitionAdmissionClosed
+                    ? _projectTransitionAdmission
+                    : null;
+            }
+        }
+
+        _ = InitializeProjectChangeHandlerAsync(
+            previous,
+            handler,
+            current,
+            initialization,
+            admission);
+
+        return new ProjectChangeRegistration(this, handler);
+    }
+
+    private async Task InitializeProjectChangeHandlerAsync(
+        Task previous,
+        IProjectChangeHandler handler,
+        Project? current,
+        TaskCompletionSource completion,
+        TaskCompletionSource? admission)
+    {
+        try
+        {
+            await previous;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "A previous project change failed before editor-host initialization.");
+        }
+
+        try
+        {
+            if (BeforeProjectChangeHandlerInitialization is { } beforeInitialization)
+            {
+                await beforeInitialization();
+            }
+
+            await handler.ApplyProjectChangeAsync(current, null);
+            await handler.WaitForPendingProjectChangesAsync();
+            OpenProjectTransitionAdmission(admission);
+            completion.TrySetResult();
+        }
+        catch (Exception ex)
+        {
+            CloseProjectTransitionAdmission(admission, ex);
+            completion.TrySetException(ex);
+        }
+    }
+
+    private void OpenProjectTransitionAdmission(TaskCompletionSource? admission)
+    {
+        if (admission is null)
+            return;
+
+        lock (_projectOperationGate)
+        {
+            bool isCurrent = ReferenceEquals(_projectTransitionAdmission, admission);
+            if (isCurrent)
+                _projectTransitionAdmissionClosed = false;
+            admission.TrySetResult();
+        }
+    }
+
+    private void CloseProjectTransitionAdmission(
+        TaskCompletionSource? admission,
+        Exception exception)
+    {
+        if (admission is null)
+            return;
+
+        lock (_projectOperationGate)
+        {
+            admission.TrySetException(exception);
+        }
+    }
+
+    /// <summary>
+    /// Waits until every project transition accepted before this call, together with causally
+    /// queued project-item changes, has reached a stable editor state.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// A reentrant wait from an editor tab operation that project reconciliation would otherwise
+    /// have to drain was detected while causal execution context remained available.
+    /// </exception>
+    public async Task WaitForPendingProjectChangesAsync()
+    {
+        if (EditorService.IsTabLifecycleOperationActive)
+        {
+            throw new InvalidOperationException(
+                "Project changes cannot be awaited from an active editor tab operation.");
+        }
+
+        Task transition;
+        IProjectChangeHandler? handler;
+        Task lastPublished;
+        lock (_projectOperationGate)
+        {
+            transition = _projectOperationTask;
+        }
+
+        lock (_projectChangeGate)
+        {
+            handler = _projectChangeHandler;
+            lastPublished = _lastProjectChangeTask;
+        }
+
+        await transition;
+        await lastPublished;
+        if (handler is not null)
+        {
+            await handler.WaitForPendingProjectChangesAsync();
+        }
+    }
+
+    private async Task ApplyProjectChangeAsync(
+        Project? @new,
+        Project? old)
+    {
+        Task previous;
+        IProjectChangeHandler? handler;
+        var completion = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        lock (_projectChangeGate)
+        {
+            previous = _lastProjectChangeTask;
+            handler = _projectChangeHandler;
+            _lastProjectChangeTask = completion.Task;
+        }
+
+        _ = CompleteProjectChangeAsync(
+            previous,
+            handler,
+            @new,
+            old,
+            completion);
+        await completion.Task;
+    }
+
+    private async Task PublishProjectClosingAsync(ProjectCloseContext context)
+    {
+        Task previous;
+        IProjectChangeHandler? handler;
+        var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        lock (_projectChangeGate)
+        {
+            previous = _lastProjectChangeTask;
+            handler = _projectChangeHandler;
+            _lastProjectChangeTask = completion.Task;
+        }
+        try
+        {
+            await previous;
+            if (handler is not null)
+                await handler.ApplyProjectCloseAsync(context);
+        }
+        finally
+        {
+            completion.TrySetResult();
+        }
+    }
+
+    private async Task CompleteProjectChangeAsync(
+        Task previous,
+        IProjectChangeHandler? handler,
+        Project? @new,
+        Project? old,
+        TaskCompletionSource completion)
+    {
+        try
+        {
+            await previous;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "A previous project change failed before the next change could run.");
+        }
+
+        try
+        {
+            if (handler is not null)
+            {
+                await handler.ApplyProjectChangeAsync(@new, old);
+                await handler.WaitForPendingProjectChangesAsync();
+            }
+
+            completion.TrySetResult();
+        }
+        catch (Exception ex)
+        {
+            completion.TrySetException(ex);
+        }
+    }
+
+    private void QueueProjectNotification(Project? @new, Project? old, Task operationCompletion)
+    {
+        Task previous;
+        var completion = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        lock (_projectNotificationGate)
+        {
+            previous = _projectNotificationTask;
+            _projectNotificationTask = completion.Task;
+        }
+
+        _ = CompleteProjectNotificationAsync(previous, operationCompletion, @new, old, completion);
+    }
+
+    private async Task CompleteProjectNotificationAsync(
+        Task previous,
+        Task operationCompletion,
+        Project? @new,
+        Project? old,
+        TaskCompletionSource completion)
+    {
+        try
+        {
+            await previous;
+            await operationCompletion;
+            PublishProjectObservers((@new, old));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "A project observer failed after the editor reached a stable state.");
+        }
+        finally
+        {
+            completion.TrySetResult();
+        }
+    }
+
+    private async Task BeginUnregisterProjectChangeHandlerAsync(IProjectChangeHandler handler)
+    {
+        Task operation;
+        lock (_projectOperationGate)
+        {
+            operation = _projectOperationTask;
+            lock (_projectChangeGate)
+            {
+                if (!ReferenceEquals(_projectChangeHandler, handler))
+                    return;
+            }
+
+            _projectTransitionAdmissionClosed = true;
+            _projectTransitionAdmission = new TaskCompletionSource(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+        }
+
+        // Keep the handler installed while already-admitted transitions drain. An operation can
+        // be queued before unregister starts but reach PublishProjectChangeAsync afterwards.
+        await operation;
+
+        Task pending;
+        lock (_projectChangeGate)
+        {
+            if (ReferenceEquals(_projectChangeHandler, handler))
+            {
+                _projectChangeHandler = null;
+                _closingProjectChangeHandler = handler;
+            }
+
+            pending = _lastProjectChangeTask;
+        }
+
+        try
+        {
+            await pending;
+        }
+        finally
+        {
+            FailProjectTransitionAdmission();
+        }
+    }
+
+    private void FailProjectTransitionAdmission()
+    {
+        lock (_projectOperationGate)
+        {
+            if (_projectTransitionAdmissionClosed)
+            {
+                _projectTransitionAdmission?.TrySetException(new InvalidOperationException(
+                    "The editor host was unregistered before the project transition could be applied."));
+            }
+        }
+    }
+
+    private void CompleteUnregisterProjectChangeHandler(IProjectChangeHandler handler)
+    {
+        lock (_projectChangeGate)
+        {
+            if (ReferenceEquals(_closingProjectChangeHandler, handler))
+            {
+                _closingProjectChangeHandler = null;
+            }
+        }
+    }
+
+    internal sealed class ProjectChangeRegistration(
+        ProjectService owner,
+        IProjectChangeHandler handler) : IAsyncDisposable
+    {
+        private readonly object _gate = new();
+        private ProjectService? _owner = owner;
+        private Task? _beginDisposeTask;
+
+        internal Task BeginDisposeAsync()
+        {
+            lock (_gate)
+            {
+                return _beginDisposeTask ??= _owner is { } currentOwner
+                    ? currentOwner.BeginUnregisterProjectChangeHandlerAsync(handler)
+                    : Task.CompletedTask;
+            }
+        }
+
+        internal void CompleteDispose()
+        {
+            ProjectService? currentOwner;
+            lock (_gate)
+            {
+                currentOwner = _owner;
+                _owner = null;
+            }
+
+            currentOwner?.CompleteUnregisterProjectChangeHandler(handler);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            try
+            {
+                await BeginDisposeAsync();
+            }
+            finally
+            {
+                CompleteDispose();
+            }
+        }
+    }
+
+}
+
+internal interface IProjectChangeHandler
+{
+    Task ApplyProjectCloseAsync(ProjectService.ProjectCloseContext context)
+        => ApplyProjectChangeAsync(null, null);
+    Task ApplyProjectChangeAsync(Project? @new, Project? old);
+    Task WaitForPendingProjectChangesAsync();
+}

--- a/src/Beutl/Services/ProjectService.cs
+++ b/src/Beutl/Services/ProjectService.cs
@@ -558,22 +558,27 @@ public sealed partial class ProjectService
         activity?.SetTag(nameof(height), height);
         activity?.SetTag(nameof(framerate), framerate);
         activity?.SetTag(nameof(samplerate), samplerate);
-        Project? preparedProject = null;
-        var createdFiles = new List<string>();
-        var createdDirectories = new List<string>();
+        string? stagingDirectory = null;
         try
         {
+            ArgumentException.ThrowIfNullOrWhiteSpace(name);
+            if (name is "." or ".." || Path.GetFileName(name) != name)
+                throw new ArgumentException("The project name must be a single directory name.", nameof(name));
             if (BeforeCreateProjectPreparation is { } beforePreparation)
                 await beforePreparation(name);
+            string parentDirectory = location;
             location = Path.Combine(location, name);
+            if (Directory.Exists(location) || File.Exists(location))
+                throw new IOException("The project destination already exists.");
+            stagingDirectory = Path.Combine(parentDirectory, $".beutl-create-{Guid.NewGuid():N}.tmp");
             var scene = new Scene(width, height, name)
             {
-                Uri = UriHelper.CreateFromPath(Path.Combine(location, name, $"{name}.{EditorConstants.SceneFileExtension}")),
+                Uri = UriHelper.CreateFromPath(Path.Combine(stagingDirectory, name, $"{name}.{EditorConstants.SceneFileExtension}")),
             };
             var project = new Project()
             {
                 Items = { scene },
-                Uri = UriHelper.CreateFromPath(Path.Combine(location, $"{name}.{EditorConstants.ProjectFileExtension}")),
+                Uri = UriHelper.CreateFromPath(Path.Combine(stagingDirectory, $"{name}.{EditorConstants.ProjectFileExtension}")),
                 Variables =
                 {
                     [ProjectVariableKeys.FrameRate] = framerate.ToString(),
@@ -581,33 +586,17 @@ public sealed partial class ProjectService
                 }
             };
 
-            preparedProject = project;
-            foreach (string directory in new[] { Path.GetDirectoryName(scene.Uri.LocalPath)!, location })
-                if (!Directory.Exists(directory))
-                    createdDirectories.Add(directory);
-            foreach (string file in new[] { scene.Uri.LocalPath, project.Uri.LocalPath })
-                if (!File.Exists(file))
-                    createdFiles.Add(file);
             CoreSerializer.StoreToUri(scene, scene.Uri);
-            ProjectPersistence.PersistOrRollback(
-                () => CoreSerializer.StoreToUri(project, project.Uri),
-                () =>
-                {
-                    // The project write failed. Remove only a scene created by this attempt;
-                    // the outer failure path also removes its empty prepared directories.
-                    try
-                    {
-                        if (createdFiles.Contains(scene.Uri.LocalPath))
-                            File.Delete(scene.Uri.LocalPath);
-                    }
-                    catch (Exception deleteEx)
-                    {
-                        _logger.LogWarning(deleteEx, "Failed to delete orphaned scene file: {Uri}", scene.Uri);
-                    }
-                });
+            CoreSerializer.StoreToUri(project, project.Uri);
 
             AfterCreateProjectPreparation?.Invoke(name);
             await CloseProjectCoreAsync(transition, CancellationToken.None);
+            // Promote the complete bundle without overwriting a concurrently created destination.
+            // Serialized references stay relative because the bundle's internal layout is unchanged.
+            Directory.Move(stagingDirectory, location);
+            stagingDirectory = null;
+            scene.Uri = UriHelper.CreateFromPath(Path.Combine(location, name, $"{name}.{EditorConstants.SceneFileExtension}"));
+            project.Uri = UriHelper.CreateFromPath(Path.Combine(location, $"{name}.{EditorConstants.ProjectFileExtension}"));
             await ActivateProjectAsync(project);
 
             await TryAddToRecentProjectsAsync(project.Uri.LocalPath);
@@ -619,34 +608,26 @@ public sealed partial class ProjectService
         }
         catch (Exception ex)
         {
-            if (preparedProject is not null && !ReferenceEquals(_app.Project, preparedProject))
-            {
-                foreach (string file in createdFiles)
-                {
-                    try { File.Delete(file); }
-                    catch (Exception cleanupError)
-                    {
-                        _logger.LogWarning(cleanupError, "Failed to remove prepared project file {Path}.", file);
-                    }
-                }
-                foreach (string directory in createdDirectories)
-                {
-                    try
-                    {
-                        if (Directory.Exists(directory) && !Directory.EnumerateFileSystemEntries(directory).Any())
-                            Directory.Delete(directory);
-                    }
-                    catch (Exception cleanupError)
-                    {
-                        _logger.LogWarning(cleanupError, "Failed to remove empty prepared project directory {Path}.", directory);
-                    }
-                }
-            }
             activity?.SetStatus(ActivityStatusCode.Error);
             _logger.LogError(ex, "Unable to create the project. Name: {Name}, Location: {Location}", name, location);
             // Surface the actual failure (disk full, permission denied, ...) instead of a generic message.
             NotificationService.ShowError(Strings.Error, ex.Message);
             return null;
+        }
+        finally
+        {
+            if (stagingDirectory is not null)
+            {
+                try
+                {
+                    if (Directory.Exists(stagingDirectory))
+                        Directory.Delete(stagingDirectory, recursive: true);
+                }
+                catch (Exception cleanupError)
+                {
+                    _logger.LogWarning(cleanupError, "Failed to remove private project staging directory {Path}.", stagingDirectory);
+                }
+            }
         }
     }
 

--- a/src/Beutl/Services/ProjectService.cs
+++ b/src/Beutl/Services/ProjectService.cs
@@ -288,6 +288,7 @@ public sealed partial class ProjectService
 
         TaskCompletionSource completion;
         Task initialization;
+        Task predecessor;
         while (true)
         {
             Task? admission;
@@ -299,6 +300,7 @@ public sealed partial class ProjectService
                 if (admission is null)
                 {
                     completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                    predecessor = _projectOperationTask;
                     _projectOperationTask = _projectOperationTask.IsCompleted
                         ? completion.Task
                         : Task.WhenAll(_projectOperationTask, completion.Task);
@@ -314,6 +316,7 @@ public sealed partial class ProjectService
         CancelPendingOpenAttemptExcept(openAttemptOwner);
         try
         {
+            await predecessor.WaitAsync(cancellationToken);
             await initialization.WaitAsync(cancellationToken);
             await _transitionGate.WaitAsync(cancellationToken);
         }
@@ -555,6 +558,9 @@ public sealed partial class ProjectService
         activity?.SetTag(nameof(height), height);
         activity?.SetTag(nameof(framerate), framerate);
         activity?.SetTag(nameof(samplerate), samplerate);
+        Project? preparedProject = null;
+        var createdFiles = new List<string>();
+        var createdDirectories = new List<string>();
         try
         {
             if (BeforeCreateProjectPreparation is { } beforePreparation)
@@ -575,16 +581,24 @@ public sealed partial class ProjectService
                 }
             };
 
+            preparedProject = project;
+            foreach (string directory in new[] { Path.GetDirectoryName(scene.Uri.LocalPath)!, location })
+                if (!Directory.Exists(directory))
+                    createdDirectories.Add(directory);
+            foreach (string file in new[] { scene.Uri.LocalPath, project.Uri.LocalPath })
+                if (!File.Exists(file))
+                    createdFiles.Add(file);
             CoreSerializer.StoreToUri(scene, scene.Uri);
             ProjectPersistence.PersistOrRollback(
                 () => CoreSerializer.StoreToUri(project, project.Uri),
                 () =>
                 {
-                    // The project write failed, so the scene file just saved is orphaned. Delete it
-                    // (best-effort); any directories created are left in place.
+                    // The project write failed. Remove only a scene created by this attempt;
+                    // the outer failure path also removes its empty prepared directories.
                     try
                     {
-                        File.Delete(scene.Uri.LocalPath);
+                        if (createdFiles.Contains(scene.Uri.LocalPath))
+                            File.Delete(scene.Uri.LocalPath);
                     }
                     catch (Exception deleteEx)
                     {
@@ -605,6 +619,29 @@ public sealed partial class ProjectService
         }
         catch (Exception ex)
         {
+            if (preparedProject is not null && !ReferenceEquals(_app.Project, preparedProject))
+            {
+                foreach (string file in createdFiles)
+                {
+                    try { File.Delete(file); }
+                    catch (Exception cleanupError)
+                    {
+                        _logger.LogWarning(cleanupError, "Failed to remove prepared project file {Path}.", file);
+                    }
+                }
+                foreach (string directory in createdDirectories)
+                {
+                    try
+                    {
+                        if (Directory.Exists(directory) && !Directory.EnumerateFileSystemEntries(directory).Any())
+                            Directory.Delete(directory);
+                    }
+                    catch (Exception cleanupError)
+                    {
+                        _logger.LogWarning(cleanupError, "Failed to remove empty prepared project directory {Path}.", directory);
+                    }
+                }
+            }
             activity?.SetStatus(ActivityStatusCode.Error);
             _logger.LogError(ex, "Unable to create the project. Name: {Name}, Location: {Location}", name, location);
             // Surface the actual failure (disk full, permission denied, ...) instead of a generic message.

--- a/src/Beutl/Services/ProjectService.cs
+++ b/src/Beutl/Services/ProjectService.cs
@@ -15,7 +15,7 @@ using Reactive.Bindings;
 
 namespace Beutl.Services;
 
-public sealed class ProjectService
+public sealed partial class ProjectService
 {
     private readonly Subject<(Project? New, Project? Old)> _projectObservable = new();
     private readonly IObservable<(Project? New, Project? Old)> _safeProjectObservable;
@@ -104,6 +104,8 @@ public sealed class ProjectService
 
     public async Task OpenProject(string file)
     {
+        if (EditorService.IsTabLifecycleOperationActive)
+            throw new InvalidOperationException("A project transition cannot start from an active editor tab operation.");
         ArgumentException.ThrowIfNullOrWhiteSpace(file);
         ProjectOpenAttempt attempt = BeginOpenAttempt(file);
         try
@@ -192,40 +194,26 @@ public sealed class ProjectService
         }
     }
 
-    public void CloseProject()
+    public Task CloseProjectAsync()
     {
-        TryCloseProject();
-    }
-
-    internal bool TryCloseProject()
-    {
-        try
+        if (EditorService.IsTabLifecycleOperationActive)
+            return Task.FromException(new InvalidOperationException(
+                "A project transition cannot start from an active editor tab operation."));
+        lock (_closeGate)
         {
-            CloseProjectOrThrow();
-            return true;
-        }
-        catch (ProjectCloseAbortedException)
-        {
-            return false;
-        }
-    }
-
-    internal void CloseProjectOrThrow()
-    {
-        Task close = CloseProjectAsync();
-        if (Avalonia.Threading.Dispatcher.UIThread.CheckAccess())
-        {
-            while (!close.IsCompleted)
+            lock (_projectOperationGate)
             {
-                Avalonia.Threading.Dispatcher.UIThread.RunJobs();
-                Thread.Sleep(1);
+                if (_activeCloseTask is { IsCompleted: false }
+                    && ReferenceEquals(_activeCloseOperationTail, _projectOperationTask))
+                    return _activeCloseTask;
+                _activeCloseTask = CloseProjectAsync(CancellationToken.None);
+                _activeCloseOperationTail = _projectOperationTask;
+                return _activeCloseTask;
             }
         }
-
-        close.GetAwaiter().GetResult();
     }
 
-    internal async Task CloseProjectAsync(CancellationToken cancellationToken = default)
+    internal async Task CloseProjectAsync(CancellationToken cancellationToken)
     {
         await using ProjectTransitionScope transition = await BeginTransitionAsync(
             ProjectTransitionPurpose.Normal,
@@ -295,13 +283,50 @@ public sealed class ProjectService
         CancellationToken cancellationToken,
         ProjectOpenAttempt? preservedOpenAttempt = null)
     {
+        if (EditorService.IsTabLifecycleOperationActive)
+            throw new InvalidOperationException("A project transition cannot start from an active editor tab operation.");
+
+        TaskCompletionSource completion;
+        Task initialization;
+        while (true)
+        {
+            Task? admission;
+            lock (_projectOperationGate)
+            {
+                admission = _projectTransitionAdmissionClosed
+                    ? _projectTransitionAdmission?.Task
+                    : null;
+                if (admission is null)
+                {
+                    completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                    _projectOperationTask = _projectOperationTask.IsCompleted
+                        ? completion.Task
+                        : Task.WhenAll(_projectOperationTask, completion.Task);
+                    lock (_projectChangeGate)
+                        initialization = _lastProjectChangeTask;
+                    break;
+                }
+            }
+            await admission.WaitAsync(cancellationToken);
+        }
+
         object openAttemptOwner = preservedOpenAttempt ?? owner;
         CancelPendingOpenAttemptExcept(openAttemptOwner);
-        await _transitionGate.WaitAsync(cancellationToken);
+        try
+        {
+            await initialization.WaitAsync(cancellationToken);
+            await _transitionGate.WaitAsync(cancellationToken);
+        }
+        catch
+        {
+            completion.TrySetResult();
+            throw;
+        }
         CancelPendingOpenAttemptExcept(openAttemptOwner);
         if (cancellationToken.IsCancellationRequested)
         {
             _transitionGate.Release();
+            completion.TrySetResult();
             cancellationToken.ThrowIfCancellationRequested();
         }
 
@@ -312,6 +337,7 @@ public sealed class ProjectService
         lock (_transitionSync)
         {
             _currentTransition = context;
+            _transitionCompletions.Add(context, completion);
         }
 
         return new ProjectTransitionScope(this, context);
@@ -430,8 +456,6 @@ public sealed class ProjectService
                 return;
             }
 
-            await CloseProjectCoreAsync(transition, CancellationToken.None);
-
             (NuGetVersion appVersion, NuGetVersion minVersion) = await GetProjectVersion(file);
             activity?.SetTag(nameof(appVersion), appVersion.ToString());
             activity?.SetTag(nameof(minVersion), minVersion.ToString());
@@ -450,9 +474,10 @@ public sealed class ProjectService
 
             var project = CoreSerializer.RestoreFromUri<Project>(UriHelper.CreateFromPath(file));
 
+            await CloseProjectCoreAsync(transition, CancellationToken.None);
             await ActivateProjectAsync(project);
 
-            TryAddToRecentProjects(file);
+            await TryAddToRecentProjectsAsync(file);
             _logger.LogInformation("Opened project. File: {File}, AppVersion: {AppVersion}, MinVersion: {MinVersion}", file, appVersion, minVersion);
             PublishProjectChange((New: project, null));
             PublishTransitionCommitted(project);
@@ -473,6 +498,7 @@ public sealed class ProjectService
         VerifyTransition(transition);
         if (_app.Project is not { } closingProject)
         {
+            await ApplyProjectChangeAsync(null, null);
             return;
         }
 
@@ -531,8 +557,8 @@ public sealed class ProjectService
         activity?.SetTag(nameof(samplerate), samplerate);
         try
         {
-            await CloseProjectCoreAsync(transition, CancellationToken.None);
-
+            if (BeforeCreateProjectPreparation is { } beforePreparation)
+                await beforePreparation(name);
             location = Path.Combine(location, name);
             var scene = new Scene(width, height, name)
             {
@@ -566,10 +592,12 @@ public sealed class ProjectService
                     }
                 });
 
-            PublishProjectChange((New: project, null));
+            AfterCreateProjectPreparation?.Invoke(name);
+            await CloseProjectCoreAsync(transition, CancellationToken.None);
             await ActivateProjectAsync(project);
 
-            TryAddToRecentProjects(project.Uri.LocalPath);
+            await TryAddToRecentProjectsAsync(project.Uri.LocalPath);
+            PublishProjectChange((New: project, null));
             _logger.LogInformation("Created new project. Name: {Name}, Location: {Location}, Width: {Width}, Height: {Height}, Framerate: {Framerate}, Samplerate: {Samplerate}", name, location, width, height, framerate, samplerate);
             PublishTransitionCommitted(project);
 
@@ -585,10 +613,12 @@ public sealed class ProjectService
         }
     }
 
-    private void TryAddToRecentProjects(string file)
+    private async Task TryAddToRecentProjectsAsync(string file)
     {
         try
         {
+            if (BeforeRecentProjectUpdate is { } beforeUpdate)
+                await beforeUpdate(file);
             ViewConfig viewConfig = GlobalConfiguration.Instance.ViewConfig;
             viewConfig.UpdateRecentProject(file);
             viewConfig.UpdateRecentFile(file);
@@ -613,6 +643,7 @@ public sealed class ProjectService
 
     private async Task ActivateProjectAsync(Project project)
     {
+        await ApplyProjectChangeAsync(project, null);
         _app.Project = project;
         try
         {
@@ -676,6 +707,12 @@ public sealed class ProjectService
             }
         }
 
+        IProjectChangeHandler? editorHandler;
+        lock (_projectChangeGate)
+            editorHandler = _projectChangeHandler;
+        if (editorHandler is not null)
+            yield return (context, _) => editorHandler.ApplyProjectCloseAsync(context);
+
         if (Closing is { } closing)
         {
             foreach (Func<ProjectCloseContext, CancellationToken, Task> handler
@@ -704,6 +741,7 @@ public sealed class ProjectService
         ProjectCloseContext closeContext,
         CancellationToken cancellationToken)
     {
+        await PublishProjectClosingAsync(closeContext);
         if (Closing is { } closing)
         {
             foreach (Func<ProjectCloseContext, CancellationToken, Task> handler
@@ -734,6 +772,17 @@ public sealed class ProjectService
     }
 
     private void PublishProjectChange((Project? New, Project? Old) change)
+    {
+        Task completion;
+        lock (_transitionSync)
+            completion = _currentTransition is { } transition
+                         && _transitionCompletions.TryGetValue(transition, out TaskCompletionSource? source)
+                ? source.Task
+                : Task.CompletedTask;
+        QueueProjectNotification(change.New, change.Old, completion);
+    }
+
+    private void PublishProjectObservers((Project? New, Project? Old) change)
     {
         try
         {
@@ -780,6 +829,7 @@ public sealed class ProjectService
 
     private void EndTransition(ProjectTransitionContext transition)
     {
+        TaskCompletionSource? completion;
         lock (_transitionSync)
         {
             if (!ReferenceEquals(_currentTransition, transition))
@@ -788,9 +838,11 @@ public sealed class ProjectService
             }
 
             _currentTransition = null;
+            _transitionCompletions.Remove(transition, out completion);
         }
 
         _transitionGate.Release();
+        completion?.TrySetResult();
     }
 
     internal enum ProjectCloseIntent

--- a/src/Beutl/Services/Tutorials/TutorialHelpers.cs
+++ b/src/Beutl/Services/Tutorials/TutorialHelpers.cs
@@ -17,14 +17,13 @@ public static class TutorialHelpers
         return editorService.SelectedTabItem.Value?.Context.Value as EditViewModel;
     }
 
-    public static bool OpenLibraryTabIfNeeded(EditorService editorService)
+    public static async Task<bool> OpenLibraryTabIfNeeded(EditorService editorService)
     {
         var editVm = GetEditViewModel(editorService);
         if (editVm == null) return false;
 
         var tab = editVm.FindToolTab<LibraryTabViewModel>() ?? new LibraryTabViewModel(editVm);
-        editVm.OpenToolTab(tab);
-        return true;
+        return await editVm.OpenToolTabAsync(tab);
     }
 
     public static async Task<bool> EnsureProjectAsync(ProjectService projectService, EditorService editorService, string projectName = "Tutorial")

--- a/src/Beutl/Services/Tutorials/TutorialHelpers.cs
+++ b/src/Beutl/Services/Tutorials/TutorialHelpers.cs
@@ -55,16 +55,20 @@ public static class TutorialHelpers
             }
         }
 
-        Scene? scene = currentProject.Items.OfType<Scene>().FirstOrDefault();
-        if (scene != null)
+        await projectService.WaitForPendingProjectChangesAsync();
+        return await Dispatcher.UIThread.InvokeAsync(() =>
         {
-            editorService.ActivateTabItem(scene);
-        }
+            if (!ReferenceEquals(projectService.CurrentProject.Value, currentProject))
+                return false;
 
-        // UIの更新を待つ
-        await Task.Delay(200);
+            Scene? scene = currentProject.Items.OfType<Scene>().FirstOrDefault();
+            if (scene is not null)
+            {
+                editorService.ActivateTabItem(scene);
+            }
 
-        return GetEditViewModel(editorService) != null;
+            return GetEditViewModel(editorService) is not null;
+        });
     }
 
     public static IDisposable? SubscribeToElementSelection(EditViewModel? editVm, Action onSelected)

--- a/src/Beutl/Services/Tutorials/TutorialHelpers.cs
+++ b/src/Beutl/Services/Tutorials/TutorialHelpers.cs
@@ -56,7 +56,7 @@ public static class TutorialHelpers
         }
 
         await projectService.WaitForPendingProjectChangesAsync();
-        return await Dispatcher.UIThread.InvokeAsync(() =>
+        return await Dispatcher.UIThread.InvokeAsync(async () =>
         {
             if (!ReferenceEquals(projectService.CurrentProject.Value, currentProject))
                 return false;
@@ -64,7 +64,7 @@ public static class TutorialHelpers
             Scene? scene = currentProject.Items.OfType<Scene>().FirstOrDefault();
             if (scene is not null)
             {
-                editorService.ActivateTabItem(scene);
+                await editorService.ActivateTabItemAsync(scene);
             }
 
             return GetEditViewModel(editorService) is not null;

--- a/src/Beutl/Services/Tutorials/TutorialServiceHandler.cs
+++ b/src/Beutl/Services/Tutorials/TutorialServiceHandler.cs
@@ -48,17 +48,17 @@ public sealed class TutorialServiceHandler : ITutorialService
             return;
         }
 
-        // 前提条件の確認と自動満足
-        if (tutorial.CanStart != null && !tutorial.CanStart())
+        try
         {
-            if (!autoFulfillPrerequisites || tutorial.FulfillPrerequisites == null)
+            // 前提条件の確認と自動満足
+            if (tutorial.CanStart != null && !await tutorial.CanStart())
             {
-                _logger.LogInformation("Tutorial cannot start: {TutorialId}", tutorialId);
-                return;
-            }
+                if (!autoFulfillPrerequisites || tutorial.FulfillPrerequisites == null)
+                {
+                    _logger.LogInformation("Tutorial cannot start: {TutorialId}", tutorialId);
+                    return;
+                }
 
-            try
-            {
                 _logger.LogInformation("Fulfilling prerequisites for: {TutorialId}", tutorialId);
                 bool fulfilled = await tutorial.FulfillPrerequisites();
 
@@ -69,17 +69,17 @@ public sealed class TutorialServiceHandler : ITutorialService
                 }
 
                 // 前提条件が満たされたか再確認
-                if (!tutorial.CanStart())
+                if (!await tutorial.CanStart())
                 {
                     _logger.LogWarning("Prerequisites still not met after fulfillment for: {TutorialId}", tutorialId);
                     return;
                 }
             }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Exception during prerequisite fulfillment for: {TutorialId}", tutorialId);
-                return;
-            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Exception while checking tutorial prerequisites for: {TutorialId}", tutorialId);
+            return;
         }
 
         await Dispatcher.UIThread.InvokeAsync(async () =>

--- a/src/Beutl/ViewModels/Dialogs/CreateNewSceneViewModel.cs
+++ b/src/Beutl/ViewModels/Dialogs/CreateNewSceneViewModel.cs
@@ -88,7 +88,7 @@ public sealed class CreateNewSceneViewModel
 
             // Activation is not part of persistence, so a failure here must not be reported as a
             // save failure — kept outside the try above.
-            _editorService.ActivateTabItem(scene);
+            await _editorService.ActivateTabItemAsync(scene);
         });
     }
 

--- a/src/Beutl/ViewModels/Dock/BeutlDockFactory.cs
+++ b/src/Beutl/ViewModels/Dock/BeutlDockFactory.cs
@@ -6,8 +6,9 @@ using Dock.Model.Inpc;
 
 namespace Beutl.ViewModels.Dock;
 
-public class BeutlDockFactory(EditViewModel editViewModel) : Factory
+internal class BeutlDockFactory(EditViewModel editViewModel) : Factory
 {
+    internal Action<BeutlToolDockable>? DisposalTracker { get; set; }
     private readonly record struct AnchorDefinition(
         string Id,
         Alignment Alignment,
@@ -259,9 +260,9 @@ public class BeutlDockFactory(EditViewModel editViewModel) : Factory
         return EnumerateTools().Any(tool => tool.ToolContext.Extension == extension);
     }
 
-    internal bool OpenToolTab(ToolTabExtension extension, IToolDock target)
+    internal Task<bool> OpenToolTabAsync(ToolTabExtension extension, IToolDock target)
     {
-        return editViewModel.DockHost.OpenToolTabFromExtension(extension, target);
+        return editViewModel.DockHost.OpenToolTabFromExtensionAsync(extension, target);
     }
 
     internal void SetRootDock(IRootDock rootDock)
@@ -318,12 +319,36 @@ public class BeutlDockFactory(EditViewModel editViewModel) : Factory
     {
         _anchorCacheDirty = true;
         if (dockable is null) return;
-        base.CloseDockable(dockable);
+        DetachDockable(dockable);
 
         if (dockable is BeutlToolDockable beutlToolDockable)
         {
-            beutlToolDockable.Dispose();
+            TrackDisposal(beutlToolDockable);
         }
+    }
+
+    internal void DetachDockable(IDockable dockable)
+    {
+        _anchorCacheDirty = true;
+        base.CloseDockable(dockable);
+    }
+
+    internal Task DisposeDetachedDockable(IDockable dockable)
+    {
+        if (dockable is not BeutlToolDockable tool)
+            return Task.CompletedTask;
+        Task task = tool.GetDisposeTask();
+        return task;
+    }
+
+    private void TrackDisposal(BeutlToolDockable dockable)
+    {
+        if (DisposalTracker is { } tracker)
+            tracker(dockable);
+        else
+            _ = dockable.GetDisposeTask().ContinueWith(static t => _ = t.Exception, CancellationToken.None,
+                TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default);
     }
 
     public override void RemoveDockable(IDockable dockable, bool collapse)

--- a/src/Beutl/ViewModels/Dock/BeutlDockFactory.cs
+++ b/src/Beutl/ViewModels/Dock/BeutlDockFactory.cs
@@ -8,7 +8,9 @@ namespace Beutl.ViewModels.Dock;
 
 internal class BeutlDockFactory(EditViewModel editViewModel) : Factory
 {
-    internal Action<BeutlToolDockable>? DisposalTracker { get; set; }
+    internal Func<BeutlToolDockable, Task>? DisposalTracker { get; set; }
+    internal Action<BeutlToolDockable>? AfterToolAttach { get; set; }
+    internal Action? LayoutMutated { get; set; }
     private readonly record struct AnchorDefinition(
         string Id,
         Alignment Alignment,
@@ -172,8 +174,8 @@ internal class BeutlDockFactory(EditViewModel editViewModel) : Factory
             {
                 if (!string.IsNullOrEmpty(d.Id))
                 {
-                    var captured = d;
-                    DockableLocator[d.Id] = () => captured;
+                    var weak = new WeakReference<IDockable>(d);
+                    DockableLocator[d.Id] = () => weak.TryGetTarget(out IDockable? target) ? target : null;
                 }
             }
         }
@@ -228,6 +230,7 @@ internal class BeutlDockFactory(EditViewModel editViewModel) : Factory
 
         var dockable = new BeutlToolDockable(context, editViewModel);
         AddDockable(zone, dockable);
+        AfterToolAttach?.Invoke(dockable);
         if (activate)
         {
             SetActiveDockable(dockable);
@@ -318,19 +321,163 @@ internal class BeutlDockFactory(EditViewModel editViewModel) : Factory
     public override void CloseDockable(IDockable? dockable)
     {
         _anchorCacheDirty = true;
-        if (dockable is null) return;
-        DetachDockable(dockable);
-
-        if (dockable is BeutlToolDockable beutlToolDockable)
-        {
-            TrackDisposal(beutlToolDockable);
-        }
+        if (dockable is not null)
+            TryCloseDockable(dockable);
     }
 
     internal void DetachDockable(IDockable dockable)
     {
         _anchorCacheDirty = true;
-        base.CloseDockable(dockable);
+        try { ForceDetachDockable(dockable); }
+        catch (Exception ex) { System.Diagnostics.Trace.TraceWarning("Force-detach failed: {0}", ex.Message); }
+    }
+
+    internal bool TryCloseDockable(IDockable dockable)
+    {
+        if (dockable is null || dockable.Owner is null)
+            return false;
+        IDock owner = (IDock)dockable.Owner;
+        IRootDock? root = FindRoot(dockable, _ => true) ?? _rootDock;
+        try
+        {
+            base.CloseDockable(dockable);
+        }
+        catch
+        {
+        }
+        if (!IsAttached(dockable, owner, root))
+        {
+            CleanupDetachedState(dockable, owner, root);
+            TrackDisposalIfNeeded(dockable);
+            return true;
+        }
+        return false;
+    }
+
+    private void ForceDetachDockable(IDockable dockable)
+    {
+        IDock? owner = dockable.Owner as IDock;
+        IRootDock? root = FindRoot(dockable, _ => true) ?? _rootDock;
+        try
+        {
+            List<IDock> docks = root is null
+                ? []
+                : Traverse(root).OfType<IDock>()
+                    .ToList();
+            if (root is not null && !docks.Any(item => ReferenceEquals(item, root)))
+                docks.Add(root);
+            if (owner is not null && !docks.Any(item => ReferenceEquals(item, owner)))
+                docks.Add(owner);
+
+            if (root is not null)
+            {
+                TryCleanup(() => root.HiddenDockables?.Remove(dockable));
+                TryCleanup(() => root.LeftPinnedDockables?.Remove(dockable));
+                TryCleanup(() => root.RightPinnedDockables?.Remove(dockable));
+                TryCleanup(() => root.TopPinnedDockables?.Remove(dockable));
+                TryCleanup(() => root.BottomPinnedDockables?.Remove(dockable));
+            }
+            foreach (IDock dock in docks)
+            {
+                TryCleanup(() => dock.VisibleDockables?.Remove(dockable));
+                TryCleanup(() =>
+                {
+                    if (ReferenceEquals(dock.ActiveDockable, dockable))
+                    {
+                        dock.ActiveDockable = dock.VisibleDockables?.FirstOrDefault(
+                            static item => item is not ISplitter);
+                    }
+                });
+            }
+        }
+        finally
+        {
+            CleanupDetachedState(dockable, owner, root);
+            CleanupEmptyFloatingWindow(root);
+        }
+    }
+
+    private void CleanupEmptyFloatingWindow(IRootDock? root)
+    {
+        if (root?.Window is not { Owner: IRootDock } window
+            || Traverse(root).Any(static item => item is not IDock && item is not ISplitter))
+        {
+            return;
+        }
+
+        TryCleanup(() => RemoveWindow(window));
+        TryCleanup(() => (window.Owner as IRootDock)?.Windows?.Remove(window));
+        TryCleanup(() => root.Window = null);
+        TryCleanup(() => window.ParentWindow = null);
+        TryCleanup(() => window.Owner = null);
+        TryCleanup(() => window.Factory = null);
+        TryCleanup(() => window.Layout = null);
+    }
+
+    private static bool IsAttached(IDockable dockable, IDock owner, IRootDock? root)
+        => Contains(owner.VisibleDockables, dockable)
+            || Contains(root?.HiddenDockables, dockable)
+            || Contains(root?.LeftPinnedDockables, dockable)
+            || Contains(root?.RightPinnedDockables, dockable)
+            || Contains(root?.TopPinnedDockables, dockable)
+            || Contains(root?.BottomPinnedDockables, dockable);
+
+    private static bool Contains(IList<IDockable>? items, IDockable dockable)
+    {
+        try { return items?.Contains(dockable) == true; }
+        catch { return true; }
+    }
+
+    private void CleanupDetachedState(IDockable dockable, IDock? owner, IRootDock? root)
+    {
+        TryCleanup(() =>
+        {
+            if (owner?.ActiveDockable == dockable)
+                owner.ActiveDockable = owner.VisibleDockables?.FirstOrDefault();
+        });
+        TryCleanup(() =>
+        {
+            if (root?.FocusedDockable == dockable)
+                root.FocusedDockable = owner?.ActiveDockable;
+        });
+        TryCleanup(() =>
+        {
+            if (ReferenceEquals(CurrentDockable, dockable))
+                OnDockableDeactivated(dockable);
+        });
+        TryCleanup(() => ToolControls.Remove(dockable));
+        TryCleanup(() => DocumentControls.Remove(dockable));
+        TryCleanup(() => VisibleDockableControls.Remove(dockable));
+        TryCleanup(() => PinnedDockableControls.Remove(dockable));
+        TryCleanup(() => TabDockableControls.Remove(dockable));
+        TryCleanup(() =>
+        {
+            string? id = dockable.Id;
+            IDictionary<string, Func<IDockable?>>? locatorMap = DockableLocator;
+            if (!string.IsNullOrEmpty(id)
+                && locatorMap?.TryGetValue(id, out Func<IDockable?>? locate) == true
+                && locate is not null
+                && ReferenceEquals(locate(), dockable))
+            {
+                locatorMap.Remove(id);
+            }
+        });
+        TryCleanup(() => dockable.Context = null);
+        TryCleanup(() => dockable.Owner = null);
+        TryCleanup(() => dockable.OriginalOwner = null);
+        TryCleanup(() => dockable.Factory = null);
+    }
+
+    private static void TryCleanup(Action cleanup)
+    {
+        try { cleanup(); }
+        catch (Exception ex) { System.Diagnostics.Trace.TraceWarning("Dockable cleanup failed: {0}", ex.Message); }
+    }
+
+    private void TrackDisposalIfNeeded(IDockable dockable)
+    {
+        if (dockable is BeutlToolDockable tool)
+            TrackDisposal(tool);
     }
 
     internal Task DisposeDetachedDockable(IDockable dockable)
@@ -344,7 +491,9 @@ internal class BeutlDockFactory(EditViewModel editViewModel) : Factory
     private void TrackDisposal(BeutlToolDockable dockable)
     {
         if (DisposalTracker is { } tracker)
-            tracker(dockable);
+        {
+            _ = tracker(dockable);
+        }
         else
             _ = dockable.GetDisposeTask().ContinueWith(static t => _ = t.Exception, CancellationToken.None,
                 TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
@@ -355,5 +504,103 @@ internal class BeutlDockFactory(EditViewModel editViewModel) : Factory
     {
         _anchorCacheDirty = true;
         base.RemoveDockable(dockable, collapse);
+    }
+
+    public override void OnDockableAdded(IDockable? dockable)
+    {
+        base.OnDockableAdded(dockable);
+        LayoutMutated?.Invoke();
+    }
+
+    public override void OnActiveDockableChanged(IDockable? dockable)
+    {
+        base.OnActiveDockableChanged(dockable);
+        LayoutMutated?.Invoke();
+    }
+
+    public override void OnDockableRemoved(IDockable? dockable)
+    {
+        base.OnDockableRemoved(dockable);
+        LayoutMutated?.Invoke();
+    }
+
+    public override void OnDockableMoved(IDockable? dockable)
+    {
+        base.OnDockableMoved(dockable);
+        LayoutMutated?.Invoke();
+    }
+
+    public override void OnDockableDocked(IDockable? dockable, DockOperation operation)
+    {
+        base.OnDockableDocked(dockable, operation);
+        LayoutMutated?.Invoke();
+    }
+
+    public override void OnDockableUndocked(IDockable? dockable, DockOperation operation)
+    {
+        base.OnDockableUndocked(dockable, operation);
+        LayoutMutated?.Invoke();
+    }
+
+    public override void OnDockableSwapped(IDockable? dockable)
+    {
+        base.OnDockableSwapped(dockable);
+        LayoutMutated?.Invoke();
+    }
+
+    public override void OnDockablePinned(IDockable? dockable)
+    {
+        base.OnDockablePinned(dockable);
+        LayoutMutated?.Invoke();
+    }
+
+    public override void OnDockableUnpinned(IDockable? dockable)
+    {
+        base.OnDockableUnpinned(dockable);
+        LayoutMutated?.Invoke();
+    }
+
+    public override void OnDockableHidden(IDockable? dockable)
+    {
+        base.OnDockableHidden(dockable);
+        LayoutMutated?.Invoke();
+    }
+
+    public override void OnDockableRestored(IDockable? dockable)
+    {
+        base.OnDockableRestored(dockable);
+        LayoutMutated?.Invoke();
+    }
+
+    public override void OnWindowAdded(IDockWindow? window)
+    {
+        base.OnWindowAdded(window);
+        LayoutMutated?.Invoke();
+    }
+
+    public override void OnWindowRemoved(IDockWindow? window)
+    {
+        base.OnWindowRemoved(window);
+        LayoutMutated?.Invoke();
+    }
+
+    public override void OnWindowMoveDragEnd(IDockWindow? window)
+    {
+        base.OnWindowMoveDragEnd(window);
+        LayoutMutated?.Invoke();
+    }
+
+    public override bool OnWindowMoveDragBegin(IDockWindow? window)
+    {
+        bool accepted = base.OnWindowMoveDragBegin(window);
+        if (accepted)
+            LayoutMutated?.Invoke();
+        return accepted;
+    }
+
+    public override void OnWindowMoveDrag(IDockWindow? window)
+    {
+        base.OnWindowMoveDrag(window);
+        LayoutMutated?.Invoke();
     }
 }

--- a/src/Beutl/ViewModels/Dock/BeutlDockFactory.cs
+++ b/src/Beutl/ViewModels/Dock/BeutlDockFactory.cs
@@ -433,7 +433,7 @@ internal class BeutlDockFactory(EditViewModel editViewModel) : Factory
         TryCleanup(() =>
         {
             if (owner?.ActiveDockable == dockable)
-                owner.ActiveDockable = owner.VisibleDockables?.FirstOrDefault();
+                owner.ActiveDockable = owner.VisibleDockables?.FirstOrDefault(static item => item is not ISplitter);
         });
         TryCleanup(() =>
         {

--- a/src/Beutl/ViewModels/Dock/BeutlToolDockable.cs
+++ b/src/Beutl/ViewModels/Dock/BeutlToolDockable.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using Avalonia.Controls;
 using Dock.Model.Inpc.Controls;
 using FluentAvalonia.UI.Controls;
@@ -7,20 +8,23 @@ namespace Beutl.ViewModels.Dock;
 
 internal static class ToolContextDisposal
 {
-    private static readonly AsyncLocal<IToolContext?> s_current = new();
+    private static readonly AsyncLocal<WeakReference<IToolContext>?> s_current = new();
 
     public static bool IsCurrent(IToolContext context)
-        => ReferenceEquals(s_current.Value, context);
+        => s_current.Value is { } current
+            && current.TryGetTarget(out IToolContext? target)
+            && ReferenceEquals(target, context);
 
-    public static bool IsActive => s_current.Value is not null;
+    public static bool IsActive
+        => s_current.Value is { } current && current.TryGetTarget(out _);
 
     public static async ValueTask DisposeAsync(IToolContext context)
     {
         if (IsCurrent(context))
             return;
 
-        IToolContext? previous = s_current.Value;
-        s_current.Value = context;
+        WeakReference<IToolContext>? previous = s_current.Value;
+        s_current.Value = new WeakReference<IToolContext>(context);
         try
         {
             await context.DisposeAsync();
@@ -34,15 +38,16 @@ internal static class ToolContextDisposal
 
 internal class BeutlToolDockable : Tool, IAsyncDisposable
 {
-    private readonly IDisposable _isSelectedSubscription;
-    private readonly IDisposable _headerSubscription;
+    private IDisposable? _isSelectedSubscription;
+    private IDisposable? _headerSubscription;
     private readonly object _disposeGate = new();
+    private IToolContext? _toolContext;
     private Task? _disposeTask;
     private bool _isDisposed;
 
     public BeutlToolDockable(IToolContext context, EditViewModel editViewModel)
     {
-        ToolContext = context;
+        _toolContext = context;
         EditViewModel = editViewModel;
 
         Id = CreateId(context);
@@ -75,7 +80,23 @@ internal class BeutlToolDockable : Tool, IAsyncDisposable
         PropertyChanged += OnPropertyChanged;
     }
 
-    public IToolContext ToolContext { get; }
+    public IToolContext ToolContext
+    {
+        get
+        {
+            lock (_disposeGate)
+                return _toolContext ?? throw new ObjectDisposedException(nameof(BeutlToolDockable));
+        }
+    }
+
+    internal bool TryGetToolContext([NotNullWhen(true)] out IToolContext? context)
+    {
+        lock (_disposeGate)
+        {
+            context = _toolContext;
+            return context is not null;
+        }
+    }
 
     public EditViewModel EditViewModel { get; }
 
@@ -138,12 +159,36 @@ internal class BeutlToolDockable : Tool, IAsyncDisposable
 
     private async Task DisposeCoreAsync()
     {
-        PropertyChanged -= OnPropertyChanged;
-        _headerSubscription.Dispose();
-        _isSelectedSubscription.Dispose();
-        ToolContent = null;
-
-        await ToolContextDisposal.DisposeAsync(ToolContext);
+        IToolContext? context;
+        lock (_disposeGate)
+            context = _toolContext;
+        List<Exception>? errors = null;
+        try
+        {
+            try { PropertyChanged -= OnPropertyChanged; }
+            catch (Exception ex) { (errors ??= []).Add(ex); }
+            try { Interlocked.Exchange(ref _headerSubscription, null)?.Dispose(); }
+            catch (Exception ex) { (errors ??= []).Add(ex); }
+            try { Interlocked.Exchange(ref _isSelectedSubscription, null)?.Dispose(); }
+            catch (Exception ex) { (errors ??= []).Add(ex); }
+            try { ToolContent = null; }
+            catch (Exception ex) { (errors ??= []).Add(ex); }
+            try { Context = null; }
+            catch (Exception ex) { (errors ??= []).Add(ex); }
+            try
+            {
+                if (context is not null)
+                    await ToolContextDisposal.DisposeAsync(context);
+            }
+            catch (Exception ex) { (errors ??= []).Add(ex); }
+        }
+        finally
+        {
+            lock (_disposeGate)
+                _toolContext = null;
+        }
+        if (errors is { Count: > 0 })
+            throw new AggregateException(errors);
     }
 
     // Resolve empty per-instance/menu headers to a readable display or extension name.

--- a/src/Beutl/ViewModels/Dock/BeutlToolDockable.cs
+++ b/src/Beutl/ViewModels/Dock/BeutlToolDockable.cs
@@ -5,10 +5,39 @@ using FluentAvalonia.UI.Controls;
 
 namespace Beutl.ViewModels.Dock;
 
-public class BeutlToolDockable : Tool, IDisposable
+internal static class ToolContextDisposal
+{
+    private static readonly AsyncLocal<IToolContext?> s_current = new();
+
+    public static bool IsCurrent(IToolContext context)
+        => ReferenceEquals(s_current.Value, context);
+
+    public static bool IsActive => s_current.Value is not null;
+
+    public static async ValueTask DisposeAsync(IToolContext context)
+    {
+        if (IsCurrent(context))
+            return;
+
+        IToolContext? previous = s_current.Value;
+        s_current.Value = context;
+        try
+        {
+            await context.DisposeAsync();
+        }
+        finally
+        {
+            s_current.Value = previous;
+        }
+    }
+}
+
+internal class BeutlToolDockable : Tool, IAsyncDisposable
 {
     private readonly IDisposable _isSelectedSubscription;
     private readonly IDisposable _headerSubscription;
+    private readonly object _disposeGate = new();
+    private Task? _disposeTask;
     private bool _isDisposed;
 
     public BeutlToolDockable(IToolContext context, EditViewModel editViewModel)
@@ -61,15 +90,60 @@ public class BeutlToolDockable : Tool, IDisposable
             ToolContext.IsSelected.Value = IsSelected;
     }
 
-    public void Dispose()
+    /// <summary>Disposes this dockable and its owned tool context exactly once.</summary>
+    /// <remarks>The returned task completes only after the context's asynchronous disposal completes.</remarks>
+    public ValueTask DisposeAsync() => new(GetDisposeTask());
+
+    internal Task GetDisposeTask()
     {
-        if (_isDisposed) return;
-        _isDisposed = true;
+        TaskCompletionSource? completion = null;
+        Task task;
+        lock (_disposeGate)
+        {
+            if (_disposeTask is not null)
+                return _disposeTask;
+
+            _isDisposed = true;
+            completion = new TaskCompletionSource(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            _disposeTask = completion.Task;
+            task = completion.Task;
+        }
+
+        _ = CompleteDisposeAsync(completion);
+        return task;
+    }
+
+    private async Task CompleteDisposeAsync(TaskCompletionSource completion)
+    {
+        try
+        {
+            await DisposeCoreAsync();
+            completion.TrySetResult();
+        }
+        catch (Exception ex)
+        {
+            completion.TrySetException(ex);
+        }
+    }
+
+    internal Task PendingDisposeTask
+    {
+        get
+        {
+            lock (_disposeGate)
+                return _disposeTask ?? Task.CompletedTask;
+        }
+    }
+
+    private async Task DisposeCoreAsync()
+    {
         PropertyChanged -= OnPropertyChanged;
         _headerSubscription.Dispose();
         _isSelectedSubscription.Dispose();
-        ToolContext.Dispose();
         ToolContent = null;
+
+        await ToolContextDisposal.DisposeAsync(ToolContext);
     }
 
     // Resolve empty per-instance/menu headers to a readable display or extension name.

--- a/src/Beutl/ViewModels/Dock/BeutlToolDockable.cs
+++ b/src/Beutl/ViewModels/Dock/BeutlToolDockable.cs
@@ -44,6 +44,7 @@ internal class BeutlToolDockable : Tool, IAsyncDisposable
     private IToolContext? _toolContext;
     private Task? _disposeTask;
     private bool _isDisposed;
+    private Action<IToolContext>? _contextDisposed;
 
     public BeutlToolDockable(IToolContext context, EditViewModel editViewModel)
     {
@@ -101,6 +102,11 @@ internal class BeutlToolDockable : Tool, IAsyncDisposable
     public EditViewModel EditViewModel { get; }
 
     internal Control? ToolContent { get; set; }
+
+    internal Action<IToolContext>? ContextDisposed
+    {
+        set => _contextDisposed = value;
+    }
 
     private void OnPropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
@@ -186,6 +192,11 @@ internal class BeutlToolDockable : Tool, IAsyncDisposable
         {
             lock (_disposeGate)
                 _toolContext = null;
+            if (context is not null)
+            {
+                try { Interlocked.Exchange(ref _contextDisposed, null)?.Invoke(context); }
+                catch (Exception ex) { (errors ??= []).Add(ex); }
+            }
         }
         if (errors is { Count: > 0 })
             throw new AggregateException(errors);

--- a/src/Beutl/ViewModels/DockHostViewModel.cs
+++ b/src/Beutl/ViewModels/DockHostViewModel.cs
@@ -26,6 +26,8 @@ internal class DockHostViewModel : IAsyncDisposable
     private bool _layoutTransitioning;
     private readonly Dictionary<IToolContext, ToolDisposalRegistration> _toolDisposals =
         new(ReferenceEqualityComparer.Instance);
+    private readonly HashSet<IToolContext> _deferredOwnerCloses =
+        new(ReferenceEqualityComparer.Instance);
     private readonly ConditionalWeakTable<IToolContext, object> _disposedToolContexts = new();
     private readonly List<Task> _pendingDockableDisposals = [];
     private bool _layoutInitialized;
@@ -45,10 +47,10 @@ internal class DockHostViewModel : IAsyncDisposable
     // omits tool state, so handing it to IToolContext.ReadFromJson would feed every reader a
     // document missing the fields its writer produces.
     private bool _restoringArrangementOnly;
-    private static readonly AsyncLocal<DockHostViewModel?> s_materializingDefaults = new();
+    private static readonly AsyncLocal<OwnerCallbackScope?> s_ownerCallbackScope = new();
 
-    internal bool IsMaterializingDefaultPluginCallback
-        => ReferenceEquals(s_materializingDefaults.Value, this);
+    internal bool IsOwnerCallbackScope
+        => s_ownerCallbackScope.Value?.IsActiveFor(this) == true;
 
     internal void RequestOwnerShutdown()
     {
@@ -221,14 +223,33 @@ internal class DockHostViewModel : IAsyncDisposable
         }
     }
 
-    public async Task CloseToolTabAsync(IToolContext item)
+    public Task CloseToolTabAsync(IToolContext item)
+        => CloseToolTabCoreAsync(
+            item,
+            allowDuringTransition: false,
+            allowOwnerShutdown: false,
+            honorOwnerScope: true);
+
+    private async Task CloseToolTabCoreAsync(
+        IToolContext item,
+        bool allowDuringTransition,
+        bool allowOwnerShutdown,
+        bool honorOwnerScope)
     {
         ArgumentNullException.ThrowIfNull(item);
-        bool ownerCallbackReentrant = IsMaterializingDefaultPluginCallback;
+        OwnerCallbackScope? ownerScope = honorOwnerScope ? s_ownerCallbackScope.Value : null;
+        bool ownerCallbackReentrant = ownerScope?.IsActiveFor(this) == true;
+        if (ownerCallbackReentrant)
+        {
+            if (TryQueueOwnerScopedClose(item, ownerScope!))
+                return;
+            ownerCallbackReentrant = false;
+        }
         bool reentrantToolTeardown = ToolContextDisposal.IsActive || ownerCallbackReentrant;
         await _layoutGate.WaitAsync();
         BeutlToolDockable? dockable = null;
         bool rejected;
+        bool existingDisposal = false;
         Task? owningTransition = null;
         ToolDisposalRegistration? disposal = null;
         try
@@ -238,12 +259,13 @@ internal class DockHostViewModel : IAsyncDisposable
                 if (_toolDisposals.TryGetValue(item, out disposal))
                 {
                     rejected = true;
+                    existingDisposal = true;
                     owningTransition = disposal.Completion.Task;
                     goto Release;
                 }
-                rejected = _ownerShutdownRequested
+                rejected = (_ownerShutdownRequested && !allowOwnerShutdown)
                     || _disposing
-                    || (_layoutTransitioning && !ownerCallbackReentrant);
+                    || (_layoutTransitioning && !allowDuringTransition);
                 if (rejected)
                 {
                     owningTransition = _disposing
@@ -284,7 +306,9 @@ internal class DockHostViewModel : IAsyncDisposable
         }
         if (rejected)
         {
-            if (!reentrantToolTeardown && owningTransition is not null)
+            if (!reentrantToolTeardown
+                && owningTransition is not null
+                && (existingDisposal || !allowDuringTransition))
                 await owningTransition;
             return;
         }
@@ -296,6 +320,64 @@ internal class DockHostViewModel : IAsyncDisposable
         }
         if (!reentrantToolTeardown)
             await DrainPendingDockableDisposalsAsync();
+    }
+
+    private bool TryQueueOwnerScopedClose(IToolContext item, OwnerCallbackScope scope)
+    {
+        lock (_disposeGate)
+        {
+            if (!scope.IsActiveFor(this))
+                return false;
+            if (_toolDisposals.ContainsKey(item) || _disposedToolContexts.TryGetValue(item, out _))
+                return true;
+            _deferredOwnerCloses.Add(item);
+            return true;
+        }
+    }
+
+    private async Task ExitOwnerCallbackScopeAsync(
+        OwnerCallbackScope scope,
+        OwnerCallbackScope? previous)
+    {
+        IToolContext[] pending;
+        lock (_disposeGate)
+        {
+            scope.Deactivate();
+            pending = _deferredOwnerCloses.ToArray();
+            _deferredOwnerCloses.Clear();
+        }
+        s_ownerCallbackScope.Value = previous;
+        await DrainDeferredOwnerClosesAsync(pending);
+    }
+
+    private async Task DrainDeferredOwnerClosesAsync()
+    {
+        IToolContext[] pending;
+        lock (_disposeGate)
+        {
+            pending = _deferredOwnerCloses.ToArray();
+            _deferredOwnerCloses.Clear();
+        }
+        await DrainDeferredOwnerClosesAsync(pending);
+    }
+
+    private async Task DrainDeferredOwnerClosesAsync(IToolContext[] pending)
+    {
+        foreach (IToolContext item in pending)
+        {
+            try
+            {
+                await CloseToolTabCoreAsync(
+                    item,
+                    allowDuringTransition: true,
+                    allowOwnerShutdown: true,
+                    honorOwnerScope: false).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to drain a deferred owner close ({SceneId})", _sceneId);
+            }
+        }
     }
 
     public Task OpenDefaultTabsAsync() => OpenDefaultTabsCoreAsync(allowDuringTransition: false);
@@ -396,57 +478,60 @@ internal class DockHostViewModel : IAsyncDisposable
 
         IToolContext? tab = null;
         bool created = false;
-        DockHostViewModel? previousMaterializer = s_materializingDefaults.Value;
+        OwnerCallbackScope? previousOwnerScope = s_ownerCallbackScope.Value;
+        OwnerCallbackScope? currentOwnerScope = null;
         if (ownerCallbackScope)
-            s_materializingDefaults.Value = this;
+        {
+            currentOwnerScope = new OwnerCallbackScope(this);
+            s_ownerCallbackScope.Value = currentOwnerScope;
+        }
         try
         {
             created = !rejected && ext.TryCreateContext(_editViewModel, out tab) && tab is not null;
+            if (!created || tab is null)
+            {
+                // [NotNullWhen(true)] permits an extension to return false while
+                // still handing us a context. Consume that context on the refusal
+                // path as well; otherwise a contract-violating extension leaks its
+                // subscriptions until the editor itself is torn down.
+                if (tab is not null)
+                    await DisposeContextOnceAsync(tab);
+                return false;
+            }
+
+            if (allowDuringTransition)
+            {
+                bool opened;
+                await _layoutGate.WaitAsync();
+                try
+                {
+                    lock (_disposeGate)
+                    {
+                        opened = !_ownerShutdownRequested && !_disposing && OpenToolTabCore(tab, target);
+                        if (opened)
+                            _layoutEpoch++;
+                    }
+                }
+                finally
+                {
+                    _layoutGate.Release();
+                }
+                if (!opened)
+                    await DisposeContextOnceAsync(tab);
+                await DrainPendingDockableDisposalsAsync();
+                return opened;
+            }
+
+            return await OpenToolTabAsync(tab, target);
         }
         finally
         {
             if (ownerCallbackScope)
             {
-                s_materializingDefaults.Value = previousMaterializer;
+                await ExitOwnerCallbackScopeAsync(currentOwnerScope!, previousOwnerScope);
                 await DrainPendingDockableDisposalsAsync();
             }
         }
-
-        if (!created || tab is null)
-        {
-            // [NotNullWhen(true)] permits an extension to return false while
-            // still handing us a context. Consume that context on the refusal
-            // path as well; otherwise a contract-violating extension leaks its
-            // subscriptions until the editor itself is torn down.
-            if (tab is not null)
-                await DisposeContextOnceAsync(tab);
-            return false;
-        }
-
-        if (allowDuringTransition)
-        {
-            bool opened;
-            await _layoutGate.WaitAsync();
-            try
-            {
-                lock (_disposeGate)
-                {
-                    opened = !_ownerShutdownRequested && !_disposing && OpenToolTabCore(tab, target);
-                    if (opened)
-                        _layoutEpoch++;
-                }
-            }
-            finally
-            {
-                _layoutGate.Release();
-            }
-            if (!opened)
-                await DisposeContextOnceAsync(tab);
-            await DrainPendingDockableDisposalsAsync();
-            return opened;
-        }
-
-        return await OpenToolTabAsync(tab, target);
     }
 
     private void EnsureDefaultLayout()
@@ -516,6 +601,12 @@ internal class DockHostViewModel : IAsyncDisposable
         if (transition is not null)
             await transition;
 
+        IToolContext[] deferredCloses;
+        lock (_disposeGate)
+        {
+            deferredCloses = _deferredOwnerCloses.ToArray();
+            _deferredOwnerCloses.Clear();
+        }
         BeutlToolDockable[] dockables;
         ToolDisposalRegistration[] disposals;
         await _layoutGate.WaitAsync();
@@ -523,13 +614,34 @@ internal class DockHostViewModel : IAsyncDisposable
         {
             _logger.LogInformation("Disposing DockHostViewModel ({SceneId})", _sceneId);
             dockables = Factory.EnumerateTools().ToArray();
-            var prepared = new List<ToolDisposalRegistration>(dockables.Length);
+            var prepared = new List<ToolDisposalRegistration>(dockables.Length + deferredCloses.Length);
+            var hostedContexts = new HashSet<IToolContext>(ReferenceEqualityComparer.Instance);
             foreach (BeutlToolDockable dockable in dockables)
             {
-                try { prepared.Add(PrepareDockableDisposal(dockable)); }
+                try
+                {
+                    if (dockable.TryGetToolContext(out IToolContext? context))
+                        hostedContexts.Add(context);
+                    prepared.Add(PrepareDockableDisposal(dockable));
+                }
                 catch (Exception ex)
                 {
                     _logger.LogWarning(ex, "Failed to prepare a tool for editor disposal ({SceneId})", _sceneId);
+                }
+            }
+            foreach (IToolContext context in deferredCloses)
+            {
+                if (hostedContexts.Contains(context))
+                    continue;
+                try
+                {
+                    prepared.Add(PrepareContextDisposal(
+                        context,
+                        () => ToolContextDisposal.DisposeAsync(context)));
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to prepare a deferred tool for editor disposal ({SceneId})", _sceneId);
                 }
             }
             disposals = prepared.ToArray();
@@ -620,7 +732,7 @@ internal class DockHostViewModel : IAsyncDisposable
         {
             lock (_disposeGate)
             {
-                if (_disposing || _layoutTransitioning)
+                if (_ownerShutdownRequested || _disposing || _layoutTransitioning)
                     return;
                 _layoutTransitioning = true;
                 _layoutEpoch++;
@@ -737,12 +849,15 @@ internal class DockHostViewModel : IAsyncDisposable
         bool transitionActive = false;
         bool restoredPublished = false;
         TaskCompletionSource? transitionCompletion = null;
+        OwnerCallbackScope? previousOwnerScope = null;
+        OwnerCallbackScope? currentOwnerScope = null;
+        bool ownerCallbackScopeActive = false;
         await _layoutGate.WaitAsync();
         try
         {
             lock (_disposeGate)
             {
-                if (_disposing || _layoutTransitioning)
+                if (_ownerShutdownRequested || _disposing || _layoutTransitioning)
                     return false;
                 _layoutTransitioning = true;
                 _layoutEpoch++;
@@ -790,6 +905,10 @@ internal class DockHostViewModel : IAsyncDisposable
             if (preparationFailure is not null)
                 ExceptionDispatchInfo.Capture(preparationFailure).Throw();
 
+            previousOwnerScope = s_ownerCallbackScope.Value;
+            currentOwnerScope = new OwnerCallbackScope(this);
+            s_ownerCallbackScope.Value = currentOwnerScope;
+            ownerCallbackScopeActive = true;
             restored = await TryRestoreLayoutAsync(plan!, restoreToolState);
             if (restored is null)
             {
@@ -799,24 +918,45 @@ internal class DockHostViewModel : IAsyncDisposable
                 return false;
             }
 
-            bool openDefaults;
             await _layoutGate.WaitAsync();
             try
             {
+                lock (_disposeGate)
+                {
+                    if (_ownerShutdownRequested || _disposing)
+                        throw new InvalidOperationException("Editor shutdown was requested during layout restoration.");
+                }
                 BeforeLayoutPublication?.Invoke(restored!);
+                if (BeutlDockFactory.Traverse(restored!)
+                    .OfType<BeutlToolDockable>()
+                    .Any(tool => IsContextDisposingOrDisposed(tool.ToolContext)))
+                {
+                    throw new InvalidOperationException("A restored tool was disposed during layout publication.");
+                }
                 Factory.SetRootDock(restored!);
                 Factory.InitLayout(restored!);
                 Layout.Value = restored!;
                 _layoutInitialized = true;
                 restoredPublished = true;
                 _layoutEpoch++;
-                openDefaults = !Factory.EnumerateTools().Any();
             }
             finally
             {
                 _layoutGate.Release();
             }
-            if (openDefaults)
+            await ExitOwnerCallbackScopeAsync(currentOwnerScope, previousOwnerScope);
+            ownerCallbackScopeActive = false;
+            bool defaultsAfterDeferredClose;
+            await _layoutGate.WaitAsync();
+            try
+            {
+                defaultsAfterDeferredClose = !Factory.EnumerateTools().Any();
+            }
+            finally
+            {
+                _layoutGate.Release();
+            }
+            if (defaultsAfterDeferredClose)
                 await OpenDefaultTabsCoreAsync(allowDuringTransition: true);
             EndLayoutTransition(transitionCompletion!);
             transitionActive = false;
@@ -827,6 +967,15 @@ internal class DockHostViewModel : IAsyncDisposable
             Exception? recoveryError = null;
             try
             {
+                if (ownerCallbackScopeActive)
+                {
+                    await ExitOwnerCallbackScopeAsync(currentOwnerScope!, previousOwnerScope);
+                    ownerCallbackScopeActive = false;
+                }
+                else
+                {
+                    await DrainDeferredOwnerClosesAsync();
+                }
                 if (restored is not null)
                 {
                     BeutlToolDockable[] restoredTools = BeutlDockFactory.Traverse(restored)
@@ -863,11 +1012,22 @@ internal class DockHostViewModel : IAsyncDisposable
             }
             if (recoveryError is not null)
                 throw new AggregateException(publicationError, recoveryError);
+            lock (_disposeGate)
+            {
+                if (_ownerShutdownRequested
+                    || publicationError is InvalidOperationException { Message: "A restored tool was disposed during layout publication." })
+                    return false;
+            }
             ExceptionDispatchInfo.Capture(publicationError).Throw();
             throw;
         }
         finally
         {
+            if (ownerCallbackScopeActive)
+            {
+                await ExitOwnerCallbackScopeAsync(currentOwnerScope!, previousOwnerScope);
+                ownerCallbackScopeActive = false;
+            }
             if (transitionActive)
                 EndLayoutTransition(transitionCompletion!);
         }
@@ -1092,6 +1252,17 @@ internal class DockHostViewModel : IAsyncDisposable
                 await AwaitAllToolDisposalsAsync();
             }
         }
+    }
+
+    private sealed class OwnerCallbackScope(DockHostViewModel owner)
+    {
+        private int _active = 1;
+
+        public bool IsActiveFor(DockHostViewModel candidate)
+            => Volatile.Read(ref _active) != 0 && ReferenceEquals(owner, candidate);
+
+        public void Deactivate()
+            => Volatile.Write(ref _active, 0);
     }
 
     private sealed record LayoutPlan(JsonObject Snapshot);
@@ -1586,6 +1757,12 @@ internal class DockHostViewModel : IAsyncDisposable
             return null;
         }
 
+        if (IsContextDisposingOrDisposed(ctx))
+        {
+            _ = DisposeContextOnceAsync(ctx);
+            return null;
+        }
+
         BeutlToolDockable? dockable = null;
         try
         {
@@ -1605,6 +1782,12 @@ internal class DockHostViewModel : IAsyncDisposable
                 }
             }
 
+            if (IsContextDisposingOrDisposed(ctx))
+            {
+                _ = DisposeContextOnceAsync(ctx);
+                return null;
+            }
+
             dockable = new BeutlToolDockable(ctx, _editViewModel);
             // Registered before anything that can throw — including the id parse just below — so a
             // failure anywhere after construction can still dispose it.
@@ -1617,6 +1800,12 @@ internal class DockHostViewModel : IAsyncDisposable
                 dockable.Id = savedId;
             }
 
+            if (IsContextDisposingOrDisposed(ctx))
+            {
+                _ = dockable.DisposeAsync().AsTask();
+                return null;
+            }
+
             return dockable;
         }
         catch
@@ -1625,6 +1814,13 @@ internal class DockHostViewModel : IAsyncDisposable
                 _ = DisposeContextOnceAsync(ctx);
             throw;
         }
+    }
+
+    private bool IsContextDisposingOrDisposed(IToolContext context)
+    {
+        lock (_disposeGate)
+            return _toolDisposals.ContainsKey(context)
+                || _disposedToolContexts.TryGetValue(context, out _);
     }
 
     private PlayerToolDockable? RestorePlayerDockable()

--- a/src/Beutl/ViewModels/DockHostViewModel.cs
+++ b/src/Beutl/ViewModels/DockHostViewModel.cs
@@ -1,4 +1,7 @@
-﻿using System.Text.Json.Nodes;
+﻿using System.Runtime.CompilerServices;
+using System.Runtime.ExceptionServices;
+using System.Text.Json.Nodes;
+using Avalonia.Threading;
 using Beutl.Api.Services;
 using Beutl.Logging;
 using Beutl.ViewModels.Dock;
@@ -23,8 +26,15 @@ internal class DockHostViewModel : IAsyncDisposable
     private bool _layoutTransitioning;
     private readonly Dictionary<IToolContext, ToolDisposalRegistration> _toolDisposals =
         new(ReferenceEqualityComparer.Instance);
+    private readonly ConditionalWeakTable<IToolContext, object> _disposedToolContexts = new();
     private readonly List<Task> _pendingDockableDisposals = [];
     private bool _layoutInitialized;
+    private long _layoutEpoch;
+    internal IReadOnlyList<ToolTabExtension>? DefaultExtensionsOverride { get; set; }
+    internal Func<Task>? BeforeDefaultTabMaterializationAsync { get; set; }
+    internal Action<BeutlToolDockable>? BeforePrepareDockableDisposal { get; set; }
+    internal Action<IRootDock>? BeforeLayoutPublication { get; set; }
+
 
     // Set only while ApplyLayout is walking a restore, so a failure mid-walk can dispose the tools
     // built so far. Null at every other time.
@@ -41,6 +51,7 @@ internal class DockHostViewModel : IAsyncDisposable
         _editViewModel = editViewModel;
         Factory = new BeutlDockFactory(editViewModel);
         Factory.DisposalTracker = TrackDockableDisposal;
+        Factory.LayoutMutated = () => Interlocked.Increment(ref _layoutEpoch);
 
         var placeholder = Factory.CreateRootDock();
         placeholder.Id = DockIds.Root;
@@ -75,21 +86,49 @@ internal class DockHostViewModel : IAsyncDisposable
     public async Task<bool> OpenToolTabAsync(IToolContext item, IToolDock? target = null)
     {
         ArgumentNullException.ThrowIfNull(item);
+        bool teardownReentrant = ToolContextDisposal.IsActive;
         await _layoutGate.WaitAsync();
         bool opened = false;
         bool rejected = false;
+        bool hostedOrRegistered = false;
+        bool alreadyDisposed = false;
         try
         {
             lock (_disposeGate)
             {
-                rejected = _disposing || _layoutTransitioning;
+                alreadyDisposed = _disposedToolContexts.TryGetValue(item, out _);
+                hostedOrRegistered = _toolDisposals.ContainsKey(item)
+                    || Factory.EnumerateTools().Any(tool =>
+                        tool.TryGetToolContext(out IToolContext? context)
+                        && ReferenceEquals(context, item));
+                rejected = teardownReentrant || _disposing || _layoutTransitioning;
                 if (!rejected)
                     opened = OpenToolTabCore(item, target);
+                if (opened)
+                    _layoutEpoch++;
             }
         }
         finally
         {
             _layoutGate.Release();
+        }
+        if (teardownReentrant)
+        {
+            if (!ToolContextDisposal.IsCurrent(item) && !alreadyDisposed)
+            {
+                Task deferred = hostedOrRegistered
+                    ? CloseToolTabAsync(item)
+                    : DisposeContextOnceAsync(item);
+                _ = deferred.ContinueWith(
+                    t => _logger.LogWarning(
+                        t.Exception,
+                        "Deferred reentrant tool disposal failed ({SceneId})",
+                        _sceneId),
+                    CancellationToken.None,
+                    TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+                    TaskScheduler.Default);
+            }
+            return false;
         }
         if (rejected || !opened)
             await DisposeContextOnceAsync(item);
@@ -102,6 +141,12 @@ internal class DockHostViewModel : IAsyncDisposable
         _logger.LogInformation("Attempting to open tool tab '{ToolTabName}' ({SceneId})", item.Extension.Name, _sceneId);
         try
         {
+            lock (_disposeGate)
+            {
+                if (_toolDisposals.ContainsKey(item)
+                    || _disposedToolContexts.TryGetValue(item, out _))
+                    return false;
+            }
             EnsureDefaultLayout();
 
             var existing = Factory.EnumerateTools().FirstOrDefault(t => t.ToolContext == item);
@@ -118,7 +163,35 @@ internal class DockHostViewModel : IAsyncDisposable
                 return false;
             }
 
-            var dockable = Factory.AddTool(item, target);
+            // A target captured before a layout transition may belong to a detached root.
+            // Resolve it against the current root before attaching anything.
+            if (target is not null && !BeutlDockFactory.Traverse(Layout.Value).Contains(target))
+                target = null;
+
+            BeutlToolDockable? dockable = null;
+            try
+            {
+                dockable = Factory.AddTool(item, target);
+            }
+            catch
+            {
+                // AddTool activates/focuses after attaching. If either callback throws, roll the
+                // dockable back out of the live tree before the caller observes failure.
+                if (dockable is not null)
+                    Factory.DetachDockable(dockable);
+                else
+                {
+                    dockable = Factory.EnumerateTools().FirstOrDefault(t => t.ToolContext == item);
+                    if (dockable is not null)
+                        Factory.DetachDockable(dockable);
+                }
+                if (dockable is not null)
+                {
+                    ToolDisposalRegistration rollback = PrepareDockableDisposal(dockable);
+                    rollback.Start.TrySetResult();
+                }
+                throw;
+            }
             if (dockable is null)
             {
                 _logger.LogWarning("No dock zone found for tool '{ToolTabName}'. ({SceneId})", item.Extension.Name, _sceneId);
@@ -171,6 +244,7 @@ internal class DockHostViewModel : IAsyncDisposable
                     {
                         disposal = PrepareDockableDisposal(dockable);
                         Factory.DetachDockable(dockable);
+                        _layoutEpoch++;
                     }
                     else
                     {
@@ -207,7 +281,9 @@ internal class DockHostViewModel : IAsyncDisposable
             await DrainPendingDockableDisposalsAsync();
     }
 
-    public async Task OpenDefaultTabsAsync()
+    public Task OpenDefaultTabsAsync() => OpenDefaultTabsCoreAsync(allowDuringTransition: false);
+
+    private async Task OpenDefaultTabsCoreAsync(bool allowDuringTransition)
     {
         ToolTabExtension[] extensions;
         await _layoutGate.WaitAsync();
@@ -215,11 +291,12 @@ internal class DockHostViewModel : IAsyncDisposable
         {
             lock (_disposeGate)
             {
-                if (_disposing || _layoutTransitioning)
+                if (_disposing || (_layoutTransitioning && !allowDuringTransition))
                     return;
                 EnsureDefaultLayout();
-                extensions = _editViewModel.ExtensionProvider.AllExtensions
-                    .OfType<ToolTabExtension>()
+                IEnumerable<ToolTabExtension> availableExtensions = DefaultExtensionsOverride
+                    ?? _editViewModel.ExtensionProvider.AllExtensions.OfType<ToolTabExtension>();
+                extensions = availableExtensions
                     .Where(e => e.OpenByDefault)
                     .OrderBy(e => (int)e.DefaultAnchor)
                     .ThenBy(e => e.DefaultOrder)
@@ -232,6 +309,8 @@ internal class DockHostViewModel : IAsyncDisposable
         }
 
         _logger.LogInformation("Opening default tabs ({SceneId})", _sceneId);
+        if (allowDuringTransition && BeforeDefaultTabMaterializationAsync is { } beforeMaterialization)
+            await beforeMaterialization();
         foreach (var ext in extensions)
         {
             IToolDock? target;
@@ -246,7 +325,7 @@ internal class DockHostViewModel : IAsyncDisposable
             {
                 _layoutGate.Release();
             }
-            await OpenToolTabFromExtensionAsync(ext, target);
+            await OpenToolTabFromExtensionCoreAsync(ext, target, allowDuringTransition);
         }
 
         await _layoutGate.WaitAsync();
@@ -266,16 +345,19 @@ internal class DockHostViewModel : IAsyncDisposable
     }
 
     internal Task<bool> OpenToolTabFromExtensionAsync(ToolTabExtension ext, IToolDock? target)
-        => OpenToolTabFromExtensionCoreAsync(ext, target);
+        => OpenToolTabFromExtensionCoreAsync(ext, target, allowDuringTransition: false);
 
-    private async Task<bool> OpenToolTabFromExtensionCoreAsync(ToolTabExtension ext, IToolDock? target)
+    private async Task<bool> OpenToolTabFromExtensionCoreAsync(
+        ToolTabExtension ext,
+        IToolDock? target,
+        bool allowDuringTransition)
     {
         bool rejected;
         await _layoutGate.WaitAsync();
         try
         {
             lock (_disposeGate)
-                rejected = _disposing || _layoutTransitioning;
+                rejected = _disposing || (_layoutTransitioning && !allowDuringTransition);
         }
         finally
         {
@@ -289,6 +371,29 @@ internal class DockHostViewModel : IAsyncDisposable
             return false;
         }
 
+        if (allowDuringTransition)
+        {
+            bool opened;
+            await _layoutGate.WaitAsync();
+            try
+            {
+                lock (_disposeGate)
+                {
+                    opened = !_disposing && OpenToolTabCore(tab, target);
+                    if (opened)
+                        _layoutEpoch++;
+                }
+            }
+            finally
+            {
+                _layoutGate.Release();
+            }
+            if (!opened)
+                await DisposeContextOnceAsync(tab);
+            await DrainPendingDockableDisposalsAsync();
+            return opened;
+        }
+
         return await OpenToolTabAsync(tab, target);
     }
 
@@ -299,9 +404,23 @@ internal class DockHostViewModel : IAsyncDisposable
         Factory.InitLayout(layout);
         Layout.Value = layout;
         _layoutInitialized = true;
+        _layoutEpoch++;
     }
 
     public ValueTask DisposeAsync() => new(GetDisposeTask());
+
+    internal async Task WaitForLayoutTransitionAsync()
+    {
+        for (; ; )
+        {
+            Task? transition;
+            lock (_disposeGate)
+                transition = _layoutTransitionCompletion?.Task;
+            if (transition is null)
+                return;
+            await transition.ConfigureAwait(false);
+        }
+    }
 
     internal Task GetDisposeTask()
     {
@@ -352,7 +471,16 @@ internal class DockHostViewModel : IAsyncDisposable
         {
             _logger.LogInformation("Disposing DockHostViewModel ({SceneId})", _sceneId);
             dockables = Factory.EnumerateTools().ToArray();
-            disposals = dockables.Select(PrepareDockableDisposal).ToArray();
+            var prepared = new List<ToolDisposalRegistration>(dockables.Length);
+            foreach (BeutlToolDockable dockable in dockables)
+            {
+                try { prepared.Add(PrepareDockableDisposal(dockable)); }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to prepare a tool for editor disposal ({SceneId})", _sceneId);
+                }
+            }
+            disposals = prepared.ToArray();
             foreach (BeutlToolDockable dockable in dockables)
             {
                 Factory.DetachDockable(dockable);
@@ -365,25 +493,42 @@ internal class DockHostViewModel : IAsyncDisposable
 
         foreach (ToolDisposalRegistration disposal in disposals)
             disposal.Start.TrySetResult();
-        for (int i = 0; i < dockables.Length; i++)
-        {
-            try
-            {
-                await disposals[i].Completion.Task;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Failed to dispose tool tab '{ToolName}'. ({SceneId})", dockables[i].ToolContext.Extension.Name, _sceneId);
-            }
-        }
+        await DisposeDockablesAsync(dockables, "editor disposal");
         await AwaitAllToolDisposalsAsync();
     }
 
     public void WriteToJson(JsonObject json)
     {
+        if (!Dispatcher.UIThread.CheckAccess())
+        {
+            Dispatcher.UIThread.Invoke(() => WriteToJson(json));
+            return;
+        }
         _logger.LogInformation("Writing DockHostViewModel to JSON ({SceneId})", _sceneId);
-        json["_dockVersion"] = DockVersion;
-        json["DockLayout"] = SaveNode(Layout.Value);
+        IRootDock layout;
+        long epoch;
+        lock (_disposeGate)
+        {
+            ObjectDisposedException.ThrowIf(_disposing, this);
+            if (_layoutTransitioning)
+                throw new InvalidOperationException("Dock layout transition is in progress.");
+            layout = Layout.Value;
+            epoch = _layoutEpoch;
+        }
+        var snapshot = new JsonObject
+        {
+            ["_dockVersion"] = DockVersion,
+            ["DockLayout"] = SaveNode(layout),
+        };
+        lock (_disposeGate)
+        {
+            ObjectDisposedException.ThrowIf(_disposing, this);
+            if (_layoutTransitioning || epoch != _layoutEpoch)
+                throw new InvalidOperationException("Dock layout changed while it was being serialized.");
+        }
+        json.Clear();
+        foreach ((string key, JsonNode? value) in snapshot)
+            json[key] = value?.DeepClone();
     }
 
     public async Task<bool> ReadFromJsonAsync(JsonObject json)
@@ -416,6 +561,7 @@ internal class DockHostViewModel : IAsyncDisposable
     {
         BeutlToolDockable[] previousTools;
         ToolDisposalRegistration[] disposals;
+        Exception? preparationFailure = null;
         TaskCompletionSource transitionCompletion;
         await _layoutGate.WaitAsync();
         try
@@ -425,15 +571,34 @@ internal class DockHostViewModel : IAsyncDisposable
                 if (_disposing || _layoutTransitioning)
                     return;
                 _layoutTransitioning = true;
+                _layoutEpoch++;
                 transitionCompletion = new TaskCompletionSource(
                     TaskCreationOptions.RunContinuationsAsynchronously);
                 _layoutTransitionCompletion = transitionCompletion;
             }
 
-            previousTools = Factory.EnumerateTools().ToArray();
-            disposals = previousTools.Select(PrepareDockableDisposal).ToArray();
-            foreach (BeutlToolDockable tool in previousTools)
-                Factory.DetachDockable(tool);
+            try
+            {
+                previousTools = Factory.EnumerateTools().ToArray();
+                var prepared = new List<ToolDisposalRegistration>(previousTools.Length);
+                foreach (BeutlToolDockable tool in previousTools)
+                {
+                    try { prepared.Add(PrepareDockableDisposal(tool)); }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning(ex, "Failed to prepare a tool for layout reset ({SceneId})", _sceneId);
+                        preparationFailure ??= ex;
+                    }
+                }
+                disposals = prepared.ToArray();
+                foreach (BeutlToolDockable tool in previousTools)
+                    Factory.DetachDockable(tool);
+            }
+            catch
+            {
+                EndLayoutTransition(transitionCompletion);
+                throw;
+            }
         }
         finally
         {
@@ -446,6 +611,8 @@ internal class DockHostViewModel : IAsyncDisposable
                 disposal.Start.TrySetResult();
             await DisposeDockablesAsync(previousTools, "reset");
             await AwaitAllToolDisposalsAsync();
+            if (preparationFailure is not null)
+                ExceptionDispatchInfo.Capture(preparationFailure).Throw();
             await CompleteTransitionWithDefaultLayoutAsync("user requested");
         }
         finally
@@ -464,16 +631,32 @@ internal class DockHostViewModel : IAsyncDisposable
     /// </remarks>
     public JsonObject CaptureLayout()
     {
+        if (!Dispatcher.UIThread.CheckAccess())
+            return Dispatcher.UIThread.Invoke(CaptureLayout);
+        if (!_layoutInitialized)
+            EnsureDefaultLayout();
+        IRootDock layout;
+        long epoch;
         lock (_disposeGate)
         {
             ObjectDisposedException.ThrowIf(_disposing, this);
-            EnsureDefaultLayout();
-            return new JsonObject
-            {
-                ["_dockVersion"] = DockVersion,
-                ["DockLayout"] = SaveNode(Layout.Value, includeToolState: false),
-            };
+            if (_layoutTransitioning)
+                throw new InvalidOperationException("Dock layout transition is in progress.");
+            layout = Layout.Value;
+            epoch = _layoutEpoch;
         }
+        var snapshot = new JsonObject
+        {
+            ["_dockVersion"] = DockVersion,
+            ["DockLayout"] = SaveNode(layout, includeToolState: false),
+        };
+        lock (_disposeGate)
+        {
+            ObjectDisposedException.ThrowIf(_disposing, this);
+            if (_layoutTransitioning || epoch != _layoutEpoch)
+                throw new InvalidOperationException("Dock layout changed while it was being captured.");
+        }
+        return snapshot;
     }
 
     /// <summary>
@@ -498,7 +681,9 @@ internal class DockHostViewModel : IAsyncDisposable
         IRootDock? restored = null;
         List<BeutlToolDockable>? previousTools = null;
         ToolDisposalRegistration[]? previousDisposals = null;
+        Exception? preparationFailure = null;
         bool transitionActive = false;
+        bool restoredPublished = false;
         TaskCompletionSource? transitionCompletion = null;
         await _layoutGate.WaitAsync();
         try
@@ -508,16 +693,36 @@ internal class DockHostViewModel : IAsyncDisposable
                 if (_disposing || _layoutTransitioning)
                     return false;
                 _layoutTransitioning = true;
+                _layoutEpoch++;
                 transitionActive = true;
                 transitionCompletion = new TaskCompletionSource(
                     TaskCreationOptions.RunContinuationsAsynchronously);
                 _layoutTransitionCompletion = transitionCompletion;
             }
 
-            previousTools = Factory.EnumerateTools().ToList();
-            previousDisposals = previousTools.Select(PrepareDockableDisposal).ToArray();
-            foreach (BeutlToolDockable tool in previousTools)
-                Factory.DetachDockable(tool);
+            try
+            {
+                previousTools = Factory.EnumerateTools().ToList();
+                var prepared = new List<ToolDisposalRegistration>(previousTools.Count);
+                foreach (BeutlToolDockable tool in previousTools)
+                {
+                    try { prepared.Add(PrepareDockableDisposal(tool)); }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning(ex, "Failed to prepare a tool for layout replacement ({SceneId})", _sceneId);
+                        preparationFailure ??= ex;
+                    }
+                }
+                previousDisposals = prepared.ToArray();
+                foreach (BeutlToolDockable tool in previousTools)
+                    Factory.DetachDockable(tool);
+            }
+            catch
+            {
+                EndLayoutTransition(transitionCompletion);
+                transitionActive = false;
+                throw;
+            }
         }
         finally
         {
@@ -530,6 +735,8 @@ internal class DockHostViewModel : IAsyncDisposable
                 disposal.Start.TrySetResult();
             await DisposeDockablesAsync(previousTools!, "layout replacement");
             await AwaitAllToolDisposalsAsync();
+            if (preparationFailure is not null)
+                ExceptionDispatchInfo.Capture(preparationFailure).Throw();
 
             restored = await TryRestoreLayoutAsync(plan!, restoreToolState);
             if (restored is null)
@@ -544,23 +751,68 @@ internal class DockHostViewModel : IAsyncDisposable
             await _layoutGate.WaitAsync();
             try
             {
+                BeforeLayoutPublication?.Invoke(restored!);
                 Factory.SetRootDock(restored!);
                 Factory.InitLayout(restored!);
                 Layout.Value = restored!;
                 _layoutInitialized = true;
+                restoredPublished = true;
+                _layoutEpoch++;
                 openDefaults = !Factory.EnumerateTools().Any();
-                lock (_disposeGate)
-                    _layoutTransitioning = false;
             }
             finally
             {
                 _layoutGate.Release();
             }
             if (openDefaults)
-                await OpenDefaultTabsAsync();
+                await OpenDefaultTabsCoreAsync(allowDuringTransition: true);
             EndLayoutTransition(transitionCompletion!);
             transitionActive = false;
             return true;
+        }
+        catch (Exception publicationError)
+        {
+            Exception? recoveryError = null;
+            try
+            {
+                if (restored is not null)
+                {
+                    BeutlToolDockable[] restoredTools = BeutlDockFactory.Traverse(restored)
+                        .OfType<BeutlToolDockable>()
+                        .Distinct()
+                        .ToArray();
+                    ToolDisposalRegistration[] restoredDisposals = restoredTools
+                        .Select(PrepareDockableDisposal)
+                        .ToArray();
+                    foreach (BeutlToolDockable tool in restoredTools)
+                        Factory.DetachDockable(tool);
+                    foreach (ToolDisposalRegistration disposal in restoredDisposals)
+                        disposal.Start.TrySetResult();
+                    await DisposeDockablesAsync(restoredTools, "failed layout publication");
+                    await AwaitAllToolDisposalsAsync();
+                }
+
+                await _layoutGate.WaitAsync();
+                try
+                {
+                    _layoutInitialized = false;
+                    ResetToDefaultLayout(restoredPublished
+                        ? "saved layout publication failed"
+                        : "saved layout restoration failed");
+                }
+                finally
+                {
+                    _layoutGate.Release();
+                }
+            }
+            catch (Exception ex)
+            {
+                recoveryError = ex;
+            }
+            if (recoveryError is not null)
+                throw new AggregateException(publicationError, recoveryError);
+            ExceptionDispatchInfo.Capture(publicationError).Throw();
+            throw;
         }
         finally
         {
@@ -573,9 +825,11 @@ internal class DockHostViewModel : IAsyncDisposable
     {
         lock (_disposeGate)
         {
-            _layoutTransitioning = false;
             if (ReferenceEquals(_layoutTransitionCompletion, completion))
+            {
+                _layoutTransitioning = false;
                 _layoutTransitionCompletion = null;
+            }
         }
         completion.TrySetResult();
     }
@@ -586,14 +840,14 @@ internal class DockHostViewModel : IAsyncDisposable
         try
         {
             ResetToDefaultLayout(reason);
-            lock (_disposeGate)
-                _layoutTransitioning = false;
         }
         finally
         {
             _layoutGate.Release();
         }
-        await OpenDefaultTabsAsync();
+        // Keep the transition flag set while default tabs materialize. Internal opens are
+        // explicitly admitted, while concurrent external opens continue to be rejected.
+        await OpenDefaultTabsCoreAsync(allowDuringTransition: true);
     }
 
     private async Task DisposeDockablesAsync(
@@ -602,9 +856,11 @@ internal class DockHostViewModel : IAsyncDisposable
     {
         foreach (BeutlToolDockable tool in dockables)
         {
+            IToolContext? context = null;
+            tool.TryGetToolContext(out context);
             try
             {
-                await DisposeDockableOnceAsync(tool);
+                await tool.GetDisposeTask();
             }
             catch (Exception ex)
             {
@@ -613,6 +869,11 @@ internal class DockHostViewModel : IAsyncDisposable
                     "Failed to dispose a tool during {Operation} ({SceneId})",
                     operation,
                     _sceneId);
+            }
+            if (context is not null)
+            {
+                lock (_disposeGate)
+                    _disposedToolContexts.GetValue(context, static _ => new object());
             }
         }
     }
@@ -822,9 +1083,20 @@ internal class DockHostViewModel : IAsyncDisposable
         }
     }
 
-    private void TrackDockableDisposal(BeutlToolDockable dockable)
+    private Task TrackDockableDisposal(BeutlToolDockable dockable)
     {
-        _ = DisposeDockableOnceAsync(dockable);
+        lock (_disposeGate)
+            _layoutEpoch++;
+        Task disposal = DisposeDockableOnceAsync(dockable);
+        _ = disposal.ContinueWith(
+            t => _logger.LogWarning(
+                t.Exception,
+                "User-closed tool disposal failed ({SceneId})",
+                _sceneId),
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+        return disposal;
     }
 
     private Task DisposeDockableOnceAsync(BeutlToolDockable dockable)
@@ -844,7 +1116,12 @@ internal class DockHostViewModel : IAsyncDisposable
     }
 
     private ToolDisposalRegistration PrepareDockableDisposal(BeutlToolDockable dockable)
-        => PrepareContextDisposal(dockable.ToolContext, dockable.DisposeAsync);
+    {
+        BeforePrepareDockableDisposal?.Invoke(dockable);
+        return dockable.TryGetToolContext(out IToolContext? context)
+            ? PrepareContextDisposal(context, dockable.DisposeAsync)
+            : ToolDisposalRegistration.Completed;
+    }
 
     private ToolDisposalRegistration PrepareContextDisposal(
         IToolContext context,
@@ -854,31 +1131,55 @@ internal class DockHostViewModel : IAsyncDisposable
         {
             if (_toolDisposals.TryGetValue(context, out ToolDisposalRegistration? existing))
                 return existing;
+            if (_disposedToolContexts.TryGetValue(context, out _))
+                return ToolDisposalRegistration.Completed;
             var registration = new ToolDisposalRegistration(dispose);
             _toolDisposals.Add(context, registration);
             _pendingDockableDisposals.Add(registration.Completion.Task);
-            _ = CompleteToolDisposalAsync(registration);
+            _ = CompleteToolDisposalAsync(context, registration);
             return registration;
         }
     }
 
-    private static async Task CompleteToolDisposalAsync(
+    private async Task CompleteToolDisposalAsync(
+        IToolContext context,
         ToolDisposalRegistration registration)
     {
         await registration.Start.Task.ConfigureAwait(false);
+        Exception? failure = null;
         try
         {
             await registration.Dispose();
-            registration.Completion.TrySetResult();
         }
         catch (Exception ex)
         {
-            registration.Completion.TrySetException(ex);
+            failure = ex;
+        }
+
+        // Remove every strong reference before waking callers. Otherwise a caller can observe a
+        // completed close while the registration still retains the context and its dockable.
+        OnDisposalCompleted(context, registration);
+        if (failure is null)
+            registration.Completion.TrySetResult();
+        else
+            registration.Completion.TrySetException(failure);
+    }
+
+    private void OnDisposalCompleted(IToolContext context, ToolDisposalRegistration registration)
+    {
+        lock (_disposeGate)
+        {
+            if (ReferenceEquals(_toolDisposals.GetValueOrDefault(context), registration))
+                _toolDisposals.Remove(context);
+            _disposedToolContexts.GetValue(context, static _ => new object());
+            _pendingDockableDisposals.Remove(registration.Completion.Task);
         }
     }
 
     private sealed class ToolDisposalRegistration(Func<ValueTask> dispose)
     {
+        public static readonly ToolDisposalRegistration Completed = CreateCompleted();
+
         public Func<ValueTask> Dispose { get; } = dispose;
 
         public TaskCompletionSource Start { get; } = new(
@@ -886,6 +1187,14 @@ internal class DockHostViewModel : IAsyncDisposable
 
         public TaskCompletionSource Completion { get; } = new(
             TaskCreationOptions.RunContinuationsAsynchronously);
+
+        private static ToolDisposalRegistration CreateCompleted()
+        {
+            var registration = new ToolDisposalRegistration(static () => ValueTask.CompletedTask);
+            registration.Start.TrySetResult();
+            registration.Completion.TrySetResult();
+            return registration;
+        }
     }
 
     private static bool IsCurrentVersion(JsonObject json)

--- a/src/Beutl/ViewModels/DockHostViewModel.cs
+++ b/src/Beutl/ViewModels/DockHostViewModel.cs
@@ -30,6 +30,7 @@ internal class DockHostViewModel : IAsyncDisposable
     private readonly List<Task> _pendingDockableDisposals = [];
     private bool _layoutInitialized;
     private long _layoutEpoch;
+    private bool _ownerShutdownRequested;
     internal IReadOnlyList<ToolTabExtension>? DefaultExtensionsOverride { get; set; }
     internal Func<Task>? BeforeDefaultTabMaterializationAsync { get; set; }
     internal Action<BeutlToolDockable>? BeforePrepareDockableDisposal { get; set; }
@@ -44,6 +45,16 @@ internal class DockHostViewModel : IAsyncDisposable
     // omits tool state, so handing it to IToolContext.ReadFromJson would feed every reader a
     // document missing the fields its writer produces.
     private bool _restoringArrangementOnly;
+    private static readonly AsyncLocal<DockHostViewModel?> s_materializingDefaults = new();
+
+    internal bool IsMaterializingDefaultPluginCallback
+        => ReferenceEquals(s_materializingDefaults.Value, this);
+
+    internal void RequestOwnerShutdown()
+    {
+        lock (_disposeGate)
+            _ownerShutdownRequested = true;
+    }
 
     public DockHostViewModel(string sceneId, EditViewModel editViewModel)
     {
@@ -101,7 +112,10 @@ internal class DockHostViewModel : IAsyncDisposable
                     || Factory.EnumerateTools().Any(tool =>
                         tool.TryGetToolContext(out IToolContext? context)
                         && ReferenceEquals(context, item));
-                rejected = teardownReentrant || _disposing || _layoutTransitioning;
+                rejected = teardownReentrant
+                    || _ownerShutdownRequested
+                    || _disposing
+                    || _layoutTransitioning;
                 if (!rejected)
                     opened = OpenToolTabCore(item, target);
                 if (opened)
@@ -210,7 +224,8 @@ internal class DockHostViewModel : IAsyncDisposable
     public async Task CloseToolTabAsync(IToolContext item)
     {
         ArgumentNullException.ThrowIfNull(item);
-        bool reentrantToolTeardown = ToolContextDisposal.IsActive;
+        bool ownerCallbackReentrant = IsMaterializingDefaultPluginCallback;
+        bool reentrantToolTeardown = ToolContextDisposal.IsActive || ownerCallbackReentrant;
         await _layoutGate.WaitAsync();
         BeutlToolDockable? dockable = null;
         bool rejected;
@@ -226,7 +241,9 @@ internal class DockHostViewModel : IAsyncDisposable
                     owningTransition = disposal.Completion.Task;
                     goto Release;
                 }
-                rejected = _disposing || _layoutTransitioning;
+                rejected = _ownerShutdownRequested
+                    || _disposing
+                    || (_layoutTransitioning && !ownerCallbackReentrant);
                 if (rejected)
                 {
                     owningTransition = _disposing
@@ -291,7 +308,9 @@ internal class DockHostViewModel : IAsyncDisposable
         {
             lock (_disposeGate)
             {
-                if (_disposing || (_layoutTransitioning && !allowDuringTransition))
+                if (_ownerShutdownRequested
+                    || _disposing
+                    || (_layoutTransitioning && !allowDuringTransition))
                     return;
                 EnsureDefaultLayout();
                 IEnumerable<ToolTabExtension> availableExtensions = DefaultExtensionsOverride
@@ -325,7 +344,11 @@ internal class DockHostViewModel : IAsyncDisposable
             {
                 _layoutGate.Release();
             }
-            await OpenToolTabFromExtensionCoreAsync(ext, target, allowDuringTransition);
+            await OpenToolTabFromExtensionCoreAsync(
+                ext,
+                target,
+                allowDuringTransition,
+                ownerCallbackScope: true);
         }
 
         await _layoutGate.WaitAsync();
@@ -345,29 +368,58 @@ internal class DockHostViewModel : IAsyncDisposable
     }
 
     internal Task<bool> OpenToolTabFromExtensionAsync(ToolTabExtension ext, IToolDock? target)
-        => OpenToolTabFromExtensionCoreAsync(ext, target, allowDuringTransition: false);
+        => OpenToolTabFromExtensionCoreAsync(
+            ext,
+            target,
+            allowDuringTransition: false,
+            ownerCallbackScope: false);
 
     private async Task<bool> OpenToolTabFromExtensionCoreAsync(
         ToolTabExtension ext,
         IToolDock? target,
-        bool allowDuringTransition)
+        bool allowDuringTransition,
+        bool ownerCallbackScope)
     {
         bool rejected;
         await _layoutGate.WaitAsync();
         try
         {
             lock (_disposeGate)
-                rejected = _disposing || (_layoutTransitioning && !allowDuringTransition);
+                rejected = _ownerShutdownRequested
+                    || _disposing
+                    || (_layoutTransitioning && !allowDuringTransition);
         }
         finally
         {
             _layoutGate.Release();
         }
 
-        if (rejected
-            || !ext.TryCreateContext(_editViewModel, out IToolContext? tab)
-            || tab is null)
+        IToolContext? tab = null;
+        bool created = false;
+        DockHostViewModel? previousMaterializer = s_materializingDefaults.Value;
+        if (ownerCallbackScope)
+            s_materializingDefaults.Value = this;
+        try
         {
+            created = !rejected && ext.TryCreateContext(_editViewModel, out tab) && tab is not null;
+        }
+        finally
+        {
+            if (ownerCallbackScope)
+            {
+                s_materializingDefaults.Value = previousMaterializer;
+                await DrainPendingDockableDisposalsAsync();
+            }
+        }
+
+        if (!created || tab is null)
+        {
+            // [NotNullWhen(true)] permits an extension to return false while
+            // still handing us a context. Consume that context on the refusal
+            // path as well; otherwise a contract-violating extension leaks its
+            // subscriptions until the editor itself is torn down.
+            if (tab is not null)
+                await DisposeContextOnceAsync(tab);
             return false;
         }
 
@@ -379,7 +431,7 @@ internal class DockHostViewModel : IAsyncDisposable
             {
                 lock (_disposeGate)
                 {
-                    opened = !_disposing && OpenToolTabCore(tab, target);
+                    opened = !_ownerShutdownRequested && !_disposing && OpenToolTabCore(tab, target);
                     if (opened)
                         _layoutEpoch++;
                 }
@@ -1023,6 +1075,10 @@ internal class DockHostViewModel : IAsyncDisposable
         {
             _restoredTools = null;
             _restoringArrangementOnly = false;
+            // A malformed extension may return false with a non-null context.
+            // Drain that compensating disposal before the restored layout is
+            // published so no rejected context survives the transition.
+            await DrainPendingDockableDisposalsAsync();
             if (result is null)
             {
                 try
@@ -1522,7 +1578,13 @@ internal class DockHostViewModel : IAsyncDisposable
             .FirstOrDefault(x => x.GetType() == extType) as ToolTabExtension;
         if (extension is null) return null;
 
-        if (!extension.TryCreateContext(_editViewModel, out IToolContext? ctx) || ctx is null) return null;
+        bool created = extension.TryCreateContext(_editViewModel, out IToolContext? ctx);
+        if (!created || ctx is null)
+        {
+            if (ctx is not null)
+                _ = DisposeContextOnceAsync(ctx);
+            return null;
+        }
 
         BeutlToolDockable? dockable = null;
         try

--- a/src/Beutl/ViewModels/DockHostViewModel.cs
+++ b/src/Beutl/ViewModels/DockHostViewModel.cs
@@ -9,12 +9,21 @@ using Reactive.Bindings;
 
 namespace Beutl.ViewModels;
 
-public class DockHostViewModel : IDisposable, IJsonSerializable
+internal class DockHostViewModel : IAsyncDisposable
 {
     private const int DockVersion = 2;
     private readonly string _sceneId;
     private readonly EditViewModel _editViewModel;
     private readonly ILogger _logger = Log.CreateLogger<DockHostViewModel>();
+    private readonly object _disposeGate = new();
+    private readonly SemaphoreSlim _layoutGate = new(1, 1);
+    private Task? _disposeTask;
+    private TaskCompletionSource? _layoutTransitionCompletion;
+    private bool _disposing;
+    private bool _layoutTransitioning;
+    private readonly Dictionary<IToolContext, ToolDisposalRegistration> _toolDisposals =
+        new(ReferenceEqualityComparer.Instance);
+    private readonly List<Task> _pendingDockableDisposals = [];
     private bool _layoutInitialized;
 
     // Set only while ApplyLayout is walking a restore, so a failure mid-walk can dispose the tools
@@ -31,6 +40,7 @@ public class DockHostViewModel : IDisposable, IJsonSerializable
         _sceneId = sceneId;
         _editViewModel = editViewModel;
         Factory = new BeutlDockFactory(editViewModel);
+        Factory.DisposalTracker = TrackDockableDisposal;
 
         var placeholder = Factory.CreateRootDock();
         placeholder.Id = DockIds.Root;
@@ -38,9 +48,9 @@ public class DockHostViewModel : IDisposable, IJsonSerializable
         Layout = new ReactivePropertySlim<IRootDock>(placeholder);
     }
 
-    public BeutlDockFactory Factory { get; }
+    internal BeutlDockFactory Factory { get; }
 
-    public ReactivePropertySlim<IRootDock> Layout { get; }
+    internal ReactivePropertySlim<IRootDock> Layout { get; }
 
     public T? FindToolTab<T>(Func<T, bool> condition) where T : IToolContext
     {
@@ -62,12 +72,32 @@ public class DockHostViewModel : IDisposable, IJsonSerializable
             .FirstOrDefault(ctx => ctx.Extension.GetType() == extensionType);
     }
 
-    public bool OpenToolTab(IToolContext item)
+    public async Task<bool> OpenToolTabAsync(IToolContext item, IToolDock? target = null)
     {
-        return OpenToolTab(item, target: null);
+        ArgumentNullException.ThrowIfNull(item);
+        await _layoutGate.WaitAsync();
+        bool opened = false;
+        bool rejected = false;
+        try
+        {
+            lock (_disposeGate)
+            {
+                rejected = _disposing || _layoutTransitioning;
+                if (!rejected)
+                    opened = OpenToolTabCore(item, target);
+            }
+        }
+        finally
+        {
+            _layoutGate.Release();
+        }
+        if (rejected || !opened)
+            await DisposeContextOnceAsync(item);
+        await DrainPendingDockableDisposalsAsync();
+        return opened && !rejected;
     }
 
-    public bool OpenToolTab(IToolContext item, IToolDock? target)
+    private bool OpenToolTabCore(IToolContext item, IToolDock? target)
     {
         _logger.LogInformation("Attempting to open tool tab '{ToolTabName}' ({SceneId})", item.Extension.Name, _sceneId);
         try
@@ -104,71 +134,162 @@ public class DockHostViewModel : IDisposable, IJsonSerializable
         }
     }
 
-    public void CloseToolTab(IToolContext item)
+    public async Task CloseToolTabAsync(IToolContext item)
     {
-        _logger.LogInformation("Attempting to close tool tab '{ToolName}' ({SceneId})", item.Extension.Name, _sceneId);
+        ArgumentNullException.ThrowIfNull(item);
+        bool reentrantToolTeardown = ToolContextDisposal.IsActive;
+        await _layoutGate.WaitAsync();
+        BeutlToolDockable? dockable = null;
+        bool rejected;
+        Task? owningTransition = null;
+        ToolDisposalRegistration? disposal = null;
         try
         {
-            var dockable = Factory.EnumerateTools().FirstOrDefault(t => t.ToolContext == item);
-            if (dockable is null)
+            lock (_disposeGate)
             {
-                item.Dispose();
-                return;
-            }
+                if (_toolDisposals.TryGetValue(item, out disposal))
+                {
+                    rejected = true;
+                    owningTransition = disposal.Completion.Task;
+                    goto Release;
+                }
+                rejected = _disposing || _layoutTransitioning;
+                if (rejected)
+                {
+                    owningTransition = _disposing
+                        ? _disposeTask
+                        : _layoutTransitionCompletion?.Task;
+                }
+                if (rejected)
+                    goto Release;
 
-            Factory.CloseDockable(dockable);
+                _logger.LogInformation("Attempting to close tool tab '{ToolName}' ({SceneId})", item.Extension.Name, _sceneId);
+                try
+                {
+                    dockable = Factory.EnumerateTools().FirstOrDefault(t => t.ToolContext == item);
+                    if (dockable is not null)
+                    {
+                        disposal = PrepareDockableDisposal(dockable);
+                        Factory.DetachDockable(dockable);
+                    }
+                    else
+                    {
+                        disposal = PrepareContextDisposal(
+                            item,
+                            () => ToolContextDisposal.DisposeAsync(item));
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to close tool tab '{ToolName}'. ({SceneId})", item.Extension.Name, _sceneId);
+                }
+            }
+        Release:
+            ;
         }
-        catch (Exception ex)
+        finally
         {
-            _logger.LogError(ex, "Failed to close tool tab '{ToolName}'. ({SceneId})", item.Extension.Name, _sceneId);
+            _layoutGate.Release();
         }
+        if (rejected)
+        {
+            if (!reentrantToolTeardown && owningTransition is not null)
+                await owningTransition;
+            return;
+        }
+        if (disposal is not null)
+        {
+            disposal.Start.TrySetResult();
+            if (!reentrantToolTeardown)
+                await disposal.Completion.Task;
+        }
+        if (!reentrantToolTeardown)
+            await DrainPendingDockableDisposalsAsync();
     }
 
-    public void OpenDefaultTabs()
+    public async Task OpenDefaultTabsAsync()
     {
+        ToolTabExtension[] extensions;
+        await _layoutGate.WaitAsync();
+        try
+        {
+            lock (_disposeGate)
+            {
+                if (_disposing || _layoutTransitioning)
+                    return;
+                EnsureDefaultLayout();
+                extensions = _editViewModel.ExtensionProvider.AllExtensions
+                    .OfType<ToolTabExtension>()
+                    .Where(e => e.OpenByDefault)
+                    .OrderBy(e => (int)e.DefaultAnchor)
+                    .ThenBy(e => e.DefaultOrder)
+                    .ToArray();
+            }
+        }
+        finally
+        {
+            _layoutGate.Release();
+        }
+
         _logger.LogInformation("Opening default tabs ({SceneId})", _sceneId);
-
-        EnsureDefaultLayout();
-
-        var fallback = Factory.GetAnchoredDock(DockAnchor.Left) ?? Factory.FindFirstToolDock();
-
-        var extensions = _editViewModel.ExtensionProvider.AllExtensions
-            .OfType<ToolTabExtension>()
-            .Where(e => e.OpenByDefault)
-            .OrderBy(e => (int)e.DefaultAnchor)
-            .ThenBy(e => e.DefaultOrder);
-
         foreach (var ext in extensions)
         {
-            var target = Factory.GetAnchoredDock(ext.DefaultAnchor) ?? fallback;
-            OpenToolTabFromExtension(ext, target);
+            IToolDock? target;
+            await _layoutGate.WaitAsync();
+            try
+            {
+                target = Factory.GetAnchoredDock(ext.DefaultAnchor)
+                    ?? Factory.GetAnchoredDock(DockAnchor.Left)
+                    ?? Factory.FindFirstToolDock();
+            }
+            finally
+            {
+                _layoutGate.Release();
+            }
+            await OpenToolTabFromExtensionAsync(ext, target);
         }
 
-        if (Factory.GetAnchoredDock(DockAnchor.Bottom) is { } bottomDock)
-            bottomDock.ActiveDockable = bottomDock.VisibleDockables?.FirstOrDefault();
-
-        if (Factory.GetAnchoredDock(DockAnchor.Left) is { } leftDock)
-            leftDock.ActiveDockable = leftDock.VisibleDockables?.FirstOrDefault();
-
-        if (Factory.GetAnchoredDock(DockAnchor.Right) is { } rightDock)
-            rightDock.ActiveDockable = rightDock.VisibleDockables?.FirstOrDefault();
+        await _layoutGate.WaitAsync();
+        try
+        {
+            if (Factory.GetAnchoredDock(DockAnchor.Bottom) is { } bottomDock)
+                bottomDock.ActiveDockable = bottomDock.VisibleDockables?.FirstOrDefault();
+            if (Factory.GetAnchoredDock(DockAnchor.Left) is { } leftDock)
+                leftDock.ActiveDockable = leftDock.VisibleDockables?.FirstOrDefault();
+            if (Factory.GetAnchoredDock(DockAnchor.Right) is { } rightDock)
+                rightDock.ActiveDockable = rightDock.VisibleDockables?.FirstOrDefault();
+        }
+        finally
+        {
+            _layoutGate.Release();
+        }
     }
 
-    internal bool OpenToolTabFromExtension(ToolTabExtension ext, IToolDock? target)
+    internal Task<bool> OpenToolTabFromExtensionAsync(ToolTabExtension ext, IToolDock? target)
+        => OpenToolTabFromExtensionCoreAsync(ext, target);
+
+    private async Task<bool> OpenToolTabFromExtensionCoreAsync(ToolTabExtension ext, IToolDock? target)
     {
-        if (!ext.TryCreateContext(_editViewModel, out IToolContext? tab)
+        bool rejected;
+        await _layoutGate.WaitAsync();
+        try
+        {
+            lock (_disposeGate)
+                rejected = _disposing || _layoutTransitioning;
+        }
+        finally
+        {
+            _layoutGate.Release();
+        }
+
+        if (rejected
+            || !ext.TryCreateContext(_editViewModel, out IToolContext? tab)
             || tab is null)
         {
             return false;
         }
 
-        if (OpenToolTab(tab, target))
-        {
-            return true;
-        }
-
-        tab.Dispose();
-        return false;
+        return await OpenToolTabAsync(tab, target);
     }
 
     private void EnsureDefaultLayout()
@@ -180,13 +301,82 @@ public class DockHostViewModel : IDisposable, IJsonSerializable
         _layoutInitialized = true;
     }
 
-    public void Dispose()
+    public ValueTask DisposeAsync() => new(GetDisposeTask());
+
+    internal Task GetDisposeTask()
     {
-        _logger.LogInformation("Disposing DockHostViewModel ({SceneId})", _sceneId);
-        foreach (var dockable in Factory.EnumerateTools().ToList())
+        TaskCompletionSource? completion = null;
+        Task task;
+        lock (_disposeGate)
         {
-            Factory.CloseDockable(dockable);
+            if (_disposeTask is not null)
+                return _disposeTask;
+
+            _disposing = true;
+            completion = new TaskCompletionSource(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            _disposeTask = completion.Task;
+            task = completion.Task;
         }
+
+        _ = CompleteDisposeAsync(completion);
+        return task;
+    }
+
+    private async Task CompleteDisposeAsync(TaskCompletionSource completion)
+    {
+        try
+        {
+            await DisposeCoreAsync();
+            completion.TrySetResult();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Dock host disposal failed ({SceneId})", _sceneId);
+            completion.TrySetException(ex);
+        }
+    }
+
+    private async Task DisposeCoreAsync()
+    {
+        Task? transition;
+        lock (_disposeGate)
+            transition = _layoutTransitionCompletion?.Task;
+        if (transition is not null)
+            await transition;
+
+        BeutlToolDockable[] dockables;
+        ToolDisposalRegistration[] disposals;
+        await _layoutGate.WaitAsync();
+        try
+        {
+            _logger.LogInformation("Disposing DockHostViewModel ({SceneId})", _sceneId);
+            dockables = Factory.EnumerateTools().ToArray();
+            disposals = dockables.Select(PrepareDockableDisposal).ToArray();
+            foreach (BeutlToolDockable dockable in dockables)
+            {
+                Factory.DetachDockable(dockable);
+            }
+        }
+        finally
+        {
+            _layoutGate.Release();
+        }
+
+        foreach (ToolDisposalRegistration disposal in disposals)
+            disposal.Start.TrySetResult();
+        for (int i = 0; i < dockables.Length; i++)
+        {
+            try
+            {
+                await disposals[i].Completion.Task;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to dispose tool tab '{ToolName}'. ({SceneId})", dockables[i].ToolContext.Extension.Name, _sceneId);
+            }
+        }
+        await AwaitAllToolDisposalsAsync();
     }
 
     public void WriteToJson(JsonObject json)
@@ -196,57 +386,77 @@ public class DockHostViewModel : IDisposable, IJsonSerializable
         json["DockLayout"] = SaveNode(Layout.Value);
     }
 
-    public void ReadFromJson(JsonObject json)
+    public async Task<bool> ReadFromJsonAsync(JsonObject json)
     {
-        _logger.LogInformation("Reading DockHostViewModel from JSON ({SceneId})", _sceneId);
+        bool applied = await ApplyLayoutCoreAsync(json, restoreToolState: true);
+        if (applied)
+            return true;
 
-        if (IsCurrentVersion(json) &&
-            json.TryGetPropertyValue("DockLayout", out var layoutNode) &&
-            layoutNode is JsonObject layoutObj)
+        bool needsDefaults;
+        await _layoutGate.WaitAsync();
+        try
         {
-            try
-            {
-                var restored = RestoreNode(layoutObj);
-                if (restored is IRootDock rootDock)
-                {
-                    Factory.SetRootDock(rootDock);
-                    Factory.InitLayout(rootDock);
-                    Layout.Value = rootDock;
-                    _layoutInitialized = true;
-                }
-                else
-                {
-                    ResetToDefaultLayout("restored root dock was not an IRootDock");
-                }
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Failed to restore dock layout, using defaults ({SceneId})", _sceneId);
-                ResetToDefaultLayout("restore threw an exception");
-            }
+            needsDefaults = !Factory.EnumerateTools().Any();
         }
-        else
+        finally
         {
-            _logger.LogInformation(
-                "Dock layout version missing or mismatched, initializing defaults ({SceneId})",
-                _sceneId);
+            _layoutGate.Release();
         }
-
-        if (!Factory.EnumerateTools().Any())
-        {
-            OpenDefaultTabs();
-        }
+        if (needsDefaults)
+            await OpenDefaultTabsAsync();
+        return false;
     }
 
-    public void ResetLayout()
+    public Task ResetLayoutAsync()
     {
-        ResetToDefaultLayout("user requested");
-        OpenDefaultTabs();
+        return ResetLayoutCoreAsync();
+    }
+
+    private async Task ResetLayoutCoreAsync()
+    {
+        BeutlToolDockable[] previousTools;
+        ToolDisposalRegistration[] disposals;
+        TaskCompletionSource transitionCompletion;
+        await _layoutGate.WaitAsync();
+        try
+        {
+            lock (_disposeGate)
+            {
+                if (_disposing || _layoutTransitioning)
+                    return;
+                _layoutTransitioning = true;
+                transitionCompletion = new TaskCompletionSource(
+                    TaskCreationOptions.RunContinuationsAsynchronously);
+                _layoutTransitionCompletion = transitionCompletion;
+            }
+
+            previousTools = Factory.EnumerateTools().ToArray();
+            disposals = previousTools.Select(PrepareDockableDisposal).ToArray();
+            foreach (BeutlToolDockable tool in previousTools)
+                Factory.DetachDockable(tool);
+        }
+        finally
+        {
+            _layoutGate.Release();
+        }
+
+        try
+        {
+            foreach (ToolDisposalRegistration disposal in disposals)
+                disposal.Start.TrySetResult();
+            await DisposeDockablesAsync(previousTools, "reset");
+            await AwaitAllToolDisposalsAsync();
+            await CompleteTransitionWithDefaultLayoutAsync("user requested");
+        }
+        finally
+        {
+            EndLayoutTransition(transitionCompletion);
+        }
     }
 
     /// <summary>
     /// Captures the current layout in the same shape <see cref="WriteToJson"/> writes, for
-    /// <see cref="ApplyLayout"/> to restore later.
+    /// <see cref="ApplyLayoutAsync"/> to restore later.
     /// </summary>
     /// <remarks>
     /// Per-tool state (selected element ids, search text, ...) is dropped; it belongs to the scene
@@ -254,12 +464,16 @@ public class DockHostViewModel : IDisposable, IJsonSerializable
     /// </remarks>
     public JsonObject CaptureLayout()
     {
-        EnsureDefaultLayout();
-        return new JsonObject
+        lock (_disposeGate)
         {
-            ["_dockVersion"] = DockVersion,
-            ["DockLayout"] = SaveNode(Layout.Value, includeToolState: false),
-        };
+            ObjectDisposedException.ThrowIf(_disposing, this);
+            EnsureDefaultLayout();
+            return new JsonObject
+            {
+                ["_dockVersion"] = DockVersion,
+                ["DockLayout"] = SaveNode(Layout.Value, includeToolState: false),
+            };
+        }
     }
 
     /// <summary>
@@ -269,85 +483,409 @@ public class DockHostViewModel : IDisposable, IJsonSerializable
     /// The outgoing tool contexts are disposed and the incoming layout builds fresh ones against
     /// this editor, so a layout captured elsewhere restores the arrangement only.
     /// </remarks>
-    public bool ApplyLayout(JsonObject layout)
+    public Task<bool> ApplyLayoutAsync(JsonObject layout)
     {
-        _logger.LogInformation("Applying a saved dock layout ({SceneId})", _sceneId);
+        return ApplyLayoutCoreAsync(layout, restoreToolState: false);
+    }
 
-        // Restore first: a malformed preset must not leave the editor without a layout.
-        IRootDock restored;
-        // Collects every tool built during the walk, so a mid-walk failure can dispose them.
-        var built = new List<BeutlToolDockable>();
-        _restoredTools = built;
-        // A saved layout carries no tool state (see CaptureLayout), so the readers must be skipped.
-        _restoringArrangementOnly = true;
+    private async Task<bool> ApplyLayoutCoreAsync(
+        JsonObject layout,
+        bool restoreToolState)
+    {
+        if (!TryCreateLayoutPlan(layout, out LayoutPlan? plan))
+            return false;
+
+        IRootDock? restored = null;
+        List<BeutlToolDockable>? previousTools = null;
+        ToolDisposalRegistration[]? previousDisposals = null;
+        bool transitionActive = false;
+        TaskCompletionSource? transitionCompletion = null;
+        await _layoutGate.WaitAsync();
         try
         {
-            if (!IsCurrentVersion(layout))
+            lock (_disposeGate)
+            {
+                if (_disposing || _layoutTransitioning)
+                    return false;
+                _layoutTransitioning = true;
+                transitionActive = true;
+                transitionCompletion = new TaskCompletionSource(
+                    TaskCreationOptions.RunContinuationsAsynchronously);
+                _layoutTransitionCompletion = transitionCompletion;
+            }
+
+            previousTools = Factory.EnumerateTools().ToList();
+            previousDisposals = previousTools.Select(PrepareDockableDisposal).ToArray();
+            foreach (BeutlToolDockable tool in previousTools)
+                Factory.DetachDockable(tool);
+        }
+        finally
+        {
+            _layoutGate.Release();
+        }
+
+        try
+        {
+            foreach (ToolDisposalRegistration disposal in previousDisposals!)
+                disposal.Start.TrySetResult();
+            await DisposeDockablesAsync(previousTools!, "layout replacement");
+            await AwaitAllToolDisposalsAsync();
+
+            restored = await TryRestoreLayoutAsync(plan!, restoreToolState);
+            if (restored is null)
+            {
+                await CompleteTransitionWithDefaultLayoutAsync("saved layout materialization failed");
+                EndLayoutTransition(transitionCompletion!);
+                transitionActive = false;
+                return false;
+            }
+
+            bool openDefaults;
+            await _layoutGate.WaitAsync();
+            try
+            {
+                Factory.SetRootDock(restored!);
+                Factory.InitLayout(restored!);
+                Layout.Value = restored!;
+                _layoutInitialized = true;
+                openDefaults = !Factory.EnumerateTools().Any();
+                lock (_disposeGate)
+                    _layoutTransitioning = false;
+            }
+            finally
+            {
+                _layoutGate.Release();
+            }
+            if (openDefaults)
+                await OpenDefaultTabsAsync();
+            EndLayoutTransition(transitionCompletion!);
+            transitionActive = false;
+            return true;
+        }
+        finally
+        {
+            if (transitionActive)
+                EndLayoutTransition(transitionCompletion!);
+        }
+    }
+
+    private void EndLayoutTransition(TaskCompletionSource completion)
+    {
+        lock (_disposeGate)
+        {
+            _layoutTransitioning = false;
+            if (ReferenceEquals(_layoutTransitionCompletion, completion))
+                _layoutTransitionCompletion = null;
+        }
+        completion.TrySetResult();
+    }
+
+    private async Task CompleteTransitionWithDefaultLayoutAsync(string reason)
+    {
+        await _layoutGate.WaitAsync();
+        try
+        {
+            ResetToDefaultLayout(reason);
+            lock (_disposeGate)
+                _layoutTransitioning = false;
+        }
+        finally
+        {
+            _layoutGate.Release();
+        }
+        await OpenDefaultTabsAsync();
+    }
+
+    private async Task DisposeDockablesAsync(
+        IEnumerable<BeutlToolDockable> dockables,
+        string operation)
+    {
+        foreach (BeutlToolDockable tool in dockables)
+        {
+            try
+            {
+                await DisposeDockableOnceAsync(tool);
+            }
+            catch (Exception ex)
             {
                 _logger.LogWarning(
-                    "Saved dock layout was written by an incompatible version ({SceneId})", _sceneId);
-                return false;
+                    ex,
+                    "Failed to dispose a tool during {Operation} ({SceneId})",
+                    operation,
+                    _sceneId);
             }
+        }
+    }
 
-            if (!layout.TryGetPropertyValue("DockLayout", out JsonNode? layoutNode)
-                || layoutNode is not JsonObject layoutObj)
+    private bool TryCreateLayoutPlan(JsonObject layout, out LayoutPlan? plan)
+    {
+        plan = null;
+        JsonObject snapshot = (JsonObject)layout.DeepClone();
+        if (!IsCurrentVersion(snapshot)
+            || !snapshot.TryGetPropertyValue("DockLayout", out JsonNode? node)
+            || node is not JsonObject root
+            || !root.TryGetPropertyValueAsJsonValue("$type", out string? rootType)
+            || rootType != "root")
+            return false;
+        if (!ValidateNode(root))
+            return false;
+        plan = new LayoutPlan(snapshot);
+        return true;
+
+        bool ValidateNode(JsonObject obj)
+        {
+            if (!obj.TryGetPropertyValueAsJsonValue("$type", out string? type))
+                return false;
+            return type switch
             {
-                _logger.LogWarning("Saved dock layout has no DockLayout node ({SceneId})", _sceneId);
-                return false;
-            }
+                "splitter" or "player" => true,
+                "tool" => obj["extension"] is JsonObject ext
+                    && ext.TryGetDiscriminator(out Type? extensionType)
+                    && extensionType is not null
+                    && _editViewModel.ExtensionProvider.AllExtensions
+                        .OfType<ToolTabExtension>()
+                        .Any(candidate => candidate.GetType() == extensionType)
+                    && ValidateOptionalString(obj, "id"),
+                "root" => ValidateOptionalString(obj, "id")
+                    && ValidateChildren(obj, "children")
+                    && ValidateChildren(obj, "hidden")
+                    && ValidateChildren(obj, "leftPinned")
+                    && ValidateChildren(obj, "rightPinned")
+                    && ValidateChildren(obj, "topPinned")
+                    && ValidateChildren(obj, "bottomPinned")
+                    && ValidateWindows(obj),
+                "proportional" => ValidateOptionalString(obj, "id")
+                    && ValidateOptionalEnumString(obj, "orientation", "horizontal", "vertical")
+                    && ValidateOptionalDouble(obj, "proportion", nonNegative: true)
+                    && ValidateChildren(obj, "children"),
+                "tool_dock" => ValidateOptionalString(obj, "id")
+                    && ValidateOptionalString(obj, "alignment")
+                    && ValidateOptionalDouble(obj, "proportion", nonNegative: true)
+                    && ValidateOptionalDouble(obj, "minWidth", nonNegative: true)
+                    && ValidateOptionalDouble(obj, "minHeight", nonNegative: true)
+                    && ValidateOptionalInt32(obj, "activeDockableIndex")
+                    && ValidateChildren(obj, "tools"),
+                _ => false,
+            };
+        }
 
-            if (RestoreNode(layoutObj) is not IRootDock rootDock)
-            {
-                _logger.LogWarning("Saved dock layout did not restore to an IRootDock ({SceneId})", _sceneId);
-                DisposeAll(built, "partially restored");
-                return false;
-            }
+        bool ValidateChildren(JsonObject obj, string key)
+        {
+            if (!obj.TryGetPropertyValue(key, out JsonNode? node))
+                return true;
+            return node is null
+                || node is JsonArray array
+                    && array.All(x => x is JsonObject child && ValidateNode(child));
+        }
 
-            restored = rootDock;
+        bool ValidateWindows(JsonObject obj)
+        {
+            if (!obj.TryGetPropertyValue("windows", out JsonNode? node) || node is null)
+                return true;
+            return node is JsonArray windows && windows.All(item =>
+                item is JsonObject window
+                && window["layout"] is JsonObject windowLayout
+                && ValidateNode(windowLayout)
+                && ValidateOptionalDouble(window, "x", nonNegative: false)
+                && ValidateOptionalDouble(window, "y", nonNegative: false)
+                && ValidateOptionalDouble(window, "width", nonNegative: true)
+                && ValidateOptionalDouble(window, "height", nonNegative: true)
+                && ValidateOptionalBoolean(window, "topmost")
+                && ValidateOptionalString(window, "title"));
+        }
+
+        static bool ValidateOptionalString(JsonObject obj, string key)
+            => !obj.TryGetPropertyValue(key, out JsonNode? node)
+                || node is null
+                || node is JsonValue value && value.TryGetValue(out string? _);
+
+        static bool ValidateOptionalEnumString(
+            JsonObject obj,
+            string key,
+            params string[] values)
+        {
+            if (!obj.TryGetPropertyValue(key, out JsonNode? node) || node is null)
+                return true;
+            return node is JsonValue value
+                && value.TryGetValue(out string? text)
+                && text is not null
+                && values.Contains(text, StringComparer.Ordinal);
+        }
+
+        static bool ValidateOptionalDouble(
+            JsonObject obj,
+            string key,
+            bool nonNegative)
+        {
+            if (!obj.TryGetPropertyValue(key, out JsonNode? node) || node is null)
+                return true;
+            return node is JsonValue value
+                && value.TryGetValue(out double number)
+                && double.IsFinite(number)
+                && (!nonNegative || number >= 0);
+        }
+
+        static bool ValidateOptionalInt32(JsonObject obj, string key)
+            => !obj.TryGetPropertyValue(key, out JsonNode? node)
+                || node is null
+                || node is JsonValue value && value.TryGetValue(out int _);
+
+        static bool ValidateOptionalBoolean(JsonObject obj, string key)
+            => !obj.TryGetPropertyValue(key, out JsonNode? node)
+                || node is null
+                || node is JsonValue value && value.TryGetValue(out bool _);
+    }
+
+    private async Task<IRootDock?> TryRestoreLayoutAsync(
+        LayoutPlan plan,
+        bool restoreToolState)
+    {
+        var built = new List<BeutlToolDockable>();
+        IRootDock? result = null;
+        _restoredTools = built;
+        _restoringArrangementOnly = !restoreToolState;
+        try
+        {
+            JsonObject layout = plan.Snapshot;
+            if (!layout.TryGetPropertyValue("DockLayout", out JsonNode? node)
+                || node is not JsonObject obj)
+                return null;
+            result = RestoreNode(obj) as IRootDock;
+            return result;
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to restore a saved dock layout ({SceneId})", _sceneId);
-            DisposeAll(built, "partially restored");
-            return false;
+            _logger.LogWarning(ex, "Failed to materialize saved dock layout ({SceneId})", _sceneId);
+            return null;
         }
         finally
         {
             _restoredTools = null;
             _restoringArrangementOnly = false;
+            if (result is null)
+            {
+                try
+                {
+                    await Task.WhenAll(built.Select(static t => t.DisposeAsync().AsTask()));
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to dispose partially restored tools ({SceneId})", _sceneId);
+                }
+                await AwaitAllToolDisposalsAsync();
+            }
         }
-
-        // Dispose after the swap, and directly — CloseDockable would walk the old tree.
-        var previousTools = Factory.EnumerateTools().ToList();
-
-        Factory.SetRootDock(restored);
-        Factory.InitLayout(restored);
-        Layout.Value = restored;
-        _layoutInitialized = true;
-
-        DisposeAll(previousTools, "replaced");
-
-        if (!Factory.EnumerateTools().Any())
-        {
-            OpenDefaultTabs();
-        }
-
-        return true;
     }
 
-    private void DisposeAll(IEnumerable<BeutlToolDockable> tools, string what)
+    private sealed record LayoutPlan(JsonObject Snapshot);
+
+    private async Task DrainPendingDockableDisposalsAsync()
     {
-        foreach (BeutlToolDockable tool in tools)
+        for (; ; )
         {
+            Task[] pending;
+            lock (_disposeGate)
+            {
+                pending = _pendingDockableDisposals.ToArray();
+                _pendingDockableDisposals.Clear();
+            }
+            if (pending.Length == 0)
+                return;
             try
             {
-                tool.Dispose();
+                await Task.WhenAll(pending);
             }
             catch (Exception ex)
             {
-                _logger.LogWarning(ex, "Failed to dispose a {What} tool tab ({SceneId})", what, _sceneId);
+                _logger.LogWarning(ex, "One or more pending dockable disposals failed ({SceneId})", _sceneId);
             }
         }
+    }
+
+    private async Task AwaitAllToolDisposalsAsync()
+    {
+        Task[] disposals;
+        lock (_disposeGate)
+            disposals = _toolDisposals.Values
+                .Select(static registration => registration.Completion.Task)
+                .Distinct()
+                .ToArray();
+        if (disposals.Length == 0)
+            return;
+        try
+        {
+            await Task.WhenAll(disposals);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "One or more tool disposals failed ({SceneId})", _sceneId);
+        }
+    }
+
+    private void TrackDockableDisposal(BeutlToolDockable dockable)
+    {
+        _ = DisposeDockableOnceAsync(dockable);
+    }
+
+    private Task DisposeDockableOnceAsync(BeutlToolDockable dockable)
+    {
+        ToolDisposalRegistration registration = PrepareDockableDisposal(dockable);
+        registration.Start.TrySetResult();
+        return registration.Completion.Task;
+    }
+
+    private Task DisposeContextOnceAsync(IToolContext context)
+    {
+        ToolDisposalRegistration registration = PrepareContextDisposal(
+            context,
+            () => ToolContextDisposal.DisposeAsync(context));
+        registration.Start.TrySetResult();
+        return registration.Completion.Task;
+    }
+
+    private ToolDisposalRegistration PrepareDockableDisposal(BeutlToolDockable dockable)
+        => PrepareContextDisposal(dockable.ToolContext, dockable.DisposeAsync);
+
+    private ToolDisposalRegistration PrepareContextDisposal(
+        IToolContext context,
+        Func<ValueTask> dispose)
+    {
+        lock (_disposeGate)
+        {
+            if (_toolDisposals.TryGetValue(context, out ToolDisposalRegistration? existing))
+                return existing;
+            var registration = new ToolDisposalRegistration(dispose);
+            _toolDisposals.Add(context, registration);
+            _pendingDockableDisposals.Add(registration.Completion.Task);
+            _ = CompleteToolDisposalAsync(registration);
+            return registration;
+        }
+    }
+
+    private static async Task CompleteToolDisposalAsync(
+        ToolDisposalRegistration registration)
+    {
+        await registration.Start.Task.ConfigureAwait(false);
+        try
+        {
+            await registration.Dispose();
+            registration.Completion.TrySetResult();
+        }
+        catch (Exception ex)
+        {
+            registration.Completion.TrySetException(ex);
+        }
+    }
+
+    private sealed class ToolDisposalRegistration(Func<ValueTask> dispose)
+    {
+        public Func<ValueTask> Dispose { get; } = dispose;
+
+        public TaskCompletionSource Start { get; } = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource Completion { get; } = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
     }
 
     private static bool IsCurrentVersion(JsonObject json)
@@ -361,17 +899,6 @@ public class DockHostViewModel : IDisposable, IJsonSerializable
     private void ResetToDefaultLayout(string reason)
     {
         _logger.LogWarning("Resetting dock layout to defaults ({Reason}, {SceneId})", reason, _sceneId);
-        foreach (var tool in Factory.EnumerateTools().ToList())
-        {
-            try
-            {
-                Factory.CloseDockable(tool);
-            }
-            catch
-            {
-            }
-        }
-
         _layoutInitialized = false;
         EnsureDefaultLayout();
     }
@@ -686,37 +1213,47 @@ public class DockHostViewModel : IDisposable, IJsonSerializable
             .FirstOrDefault(x => x.GetType() == extType) as ToolTabExtension;
         if (extension is null) return null;
 
-        if (!extension.TryCreateContext(_editViewModel, out IToolContext? ctx)) return null;
+        if (!extension.TryCreateContext(_editViewModel, out IToolContext? ctx) || ctx is null) return null;
 
-        if (!_restoringArrangementOnly)
+        BeutlToolDockable? dockable = null;
+        try
         {
-            try
+            if (!_restoringArrangementOnly)
             {
-                ctx.ReadFromJson(obj);
+                try
+                {
+                    ctx.ReadFromJson(obj);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(
+                        ex,
+                        "Failed to restore tool state for '{ToolType}' ({SceneId})",
+                        extType.FullName,
+                        _sceneId);
+                }
             }
-            catch (Exception ex)
+
+            dockable = new BeutlToolDockable(ctx, _editViewModel);
+            // Registered before anything that can throw — including the id parse just below — so a
+            // failure anywhere after construction can still dispose it.
+            _restoredTools?.Add(dockable);
+
+            if (obj["id"] is JsonValue idValue
+                && idValue.TryGetValue(out string? savedId)
+                && savedId is { Length: > 0 })
             {
-                _logger.LogWarning(
-                    ex,
-                    "Failed to restore tool state for '{ToolType}' ({SceneId})",
-                    extType.FullName,
-                    _sceneId);
+                dockable.Id = savedId;
             }
+
+            return dockable;
         }
-
-        var dockable = new BeutlToolDockable(ctx, _editViewModel);
-        // Registered before anything that can throw — including the id parse just below — so a
-        // failure anywhere after construction can still dispose it.
-        _restoredTools?.Add(dockable);
-
-        if (obj["id"] is JsonValue idValue
-            && idValue.TryGetValue(out string? savedId)
-            && savedId.Length > 0)
+        catch
         {
-            dockable.Id = savedId;
+            if (dockable is null)
+                _ = DisposeContextOnceAsync(ctx);
+            throw;
         }
-
-        return dockable;
     }
 
     private PlayerToolDockable? RestorePlayerDockable()

--- a/src/Beutl/ViewModels/DockHostViewModel.cs
+++ b/src/Beutl/ViewModels/DockHostViewModel.cs
@@ -124,7 +124,7 @@ internal class DockHostViewModel : IAsyncDisposable
                 if (!rejected)
                     opened = OpenToolTabCore(item, target);
                 if (opened)
-                    _layoutEpoch++;
+                    Interlocked.Increment(ref _layoutEpoch);
             }
         }
         finally
@@ -295,7 +295,7 @@ internal class DockHostViewModel : IAsyncDisposable
                     {
                         disposal = PrepareDockableDisposal(dockable);
                         Factory.DetachDockable(dockable);
-                        _layoutEpoch++;
+                        Interlocked.Increment(ref _layoutEpoch);
                     }
                 }
                 catch (Exception ex)
@@ -515,7 +515,7 @@ internal class DockHostViewModel : IAsyncDisposable
                     {
                         opened = !_ownerShutdownRequested && !_disposing && OpenToolTabCore(tab, target);
                         if (opened)
-                            _layoutEpoch++;
+                            Interlocked.Increment(ref _layoutEpoch);
                     }
                 }
                 finally
@@ -547,7 +547,7 @@ internal class DockHostViewModel : IAsyncDisposable
         Factory.InitLayout(layout);
         Layout.Value = layout;
         _layoutInitialized = true;
-        _layoutEpoch++;
+        Interlocked.Increment(ref _layoutEpoch);
     }
 
     public ValueTask DisposeAsync() => new(GetDisposeTask());
@@ -683,7 +683,7 @@ internal class DockHostViewModel : IAsyncDisposable
             if (_layoutTransitioning)
                 throw new InvalidOperationException("Dock layout transition is in progress.");
             layout = Layout.Value;
-            epoch = _layoutEpoch;
+            epoch = Interlocked.Read(ref _layoutEpoch);
         }
         var snapshot = new JsonObject
         {
@@ -693,10 +693,9 @@ internal class DockHostViewModel : IAsyncDisposable
         lock (_disposeGate)
         {
             ObjectDisposedException.ThrowIf(_disposing, this);
-            if (_layoutTransitioning || epoch != _layoutEpoch)
+            if (_layoutTransitioning || epoch != Interlocked.Read(ref _layoutEpoch))
                 throw new InvalidOperationException("Dock layout changed while it was being serialized.");
         }
-        json.Clear();
         foreach ((string key, JsonNode? value) in snapshot)
             json[key] = value?.DeepClone();
     }
@@ -741,7 +740,7 @@ internal class DockHostViewModel : IAsyncDisposable
                 if (_ownerShutdownRequested || _disposing || _layoutTransitioning)
                     return;
                 _layoutTransitioning = true;
-                _layoutEpoch++;
+                Interlocked.Increment(ref _layoutEpoch);
                 transitionCompletion = new TaskCompletionSource(
                     TaskCreationOptions.RunContinuationsAsynchronously);
                 _layoutTransitionCompletion = transitionCompletion;
@@ -813,7 +812,7 @@ internal class DockHostViewModel : IAsyncDisposable
             if (_layoutTransitioning)
                 throw new InvalidOperationException("Dock layout transition is in progress.");
             layout = Layout.Value;
-            epoch = _layoutEpoch;
+            epoch = Interlocked.Read(ref _layoutEpoch);
         }
         var snapshot = new JsonObject
         {
@@ -823,7 +822,7 @@ internal class DockHostViewModel : IAsyncDisposable
         lock (_disposeGate)
         {
             ObjectDisposedException.ThrowIf(_disposing, this);
-            if (_layoutTransitioning || epoch != _layoutEpoch)
+            if (_layoutTransitioning || epoch != Interlocked.Read(ref _layoutEpoch))
                 throw new InvalidOperationException("Dock layout changed while it was being captured.");
         }
         return snapshot;
@@ -866,7 +865,7 @@ internal class DockHostViewModel : IAsyncDisposable
                 if (_ownerShutdownRequested || _disposing || _layoutTransitioning)
                     return false;
                 _layoutTransitioning = true;
-                _layoutEpoch++;
+                Interlocked.Increment(ref _layoutEpoch);
                 transitionActive = true;
                 transitionCompletion = new TaskCompletionSource(
                     TaskCreationOptions.RunContinuationsAsynchronously);
@@ -944,7 +943,7 @@ internal class DockHostViewModel : IAsyncDisposable
                 Layout.Value = restored!;
                 _layoutInitialized = true;
                 restoredPublished = true;
-                _layoutEpoch++;
+                Interlocked.Increment(ref _layoutEpoch);
             }
             finally
             {
@@ -1099,6 +1098,25 @@ internal class DockHostViewModel : IAsyncDisposable
     private bool TryCreateLayoutPlan(JsonObject layout, out LayoutPlan? plan)
     {
         plan = null;
+        var pending = new Stack<(JsonNode Node, int Depth)>();
+        pending.Push((layout, 0));
+        while (pending.TryPop(out var entry))
+        {
+            if (entry.Depth >= 64)
+                return false;
+            if (entry.Node is JsonObject obj)
+            {
+                foreach (JsonNode? child in obj.Select(static pair => pair.Value))
+                    if (child is not null)
+                        pending.Push((child, entry.Depth + 1));
+            }
+            else if (entry.Node is JsonArray array)
+            {
+                foreach (JsonNode? child in array)
+                    if (child is not null)
+                        pending.Push((child, entry.Depth + 1));
+            }
+        }
         JsonObject snapshot = (JsonObject)layout.DeepClone();
         if (!IsCurrentVersion(snapshot)
             || !snapshot.TryGetPropertyValue("DockLayout", out JsonNode? node)
@@ -1319,7 +1337,7 @@ internal class DockHostViewModel : IAsyncDisposable
     private Task TrackDockableDisposal(BeutlToolDockable dockable)
     {
         lock (_disposeGate)
-            _layoutEpoch++;
+            Interlocked.Increment(ref _layoutEpoch);
         Task disposal = DisposeDockableOnceAsync(dockable);
         _ = disposal.ContinueWith(
             t => _logger.LogWarning(

--- a/src/Beutl/ViewModels/DockHostViewModel.cs
+++ b/src/Beutl/ViewModels/DockHostViewModel.cs
@@ -26,6 +26,9 @@ internal class DockHostViewModel : IAsyncDisposable
     private bool _layoutTransitioning;
     private readonly Dictionary<IToolContext, ToolDisposalRegistration> _toolDisposals =
         new(ReferenceEqualityComparer.Instance);
+    private readonly ToolContextHostToken _toolHostToken = new();
+    private readonly Dictionary<IToolContext, ToolContextOwnershipLease> _toolOwnershipLeases =
+        new(ReferenceEqualityComparer.Instance);
     private readonly HashSet<IToolContext> _deferredOwnerCloses =
         new(ReferenceEqualityComparer.Instance);
     private readonly ConditionalWeakTable<IToolContext, object> _disposedToolContexts = new();
@@ -132,17 +135,22 @@ internal class DockHostViewModel : IAsyncDisposable
         {
             if (!ToolContextDisposal.IsCurrent(item) && !alreadyDisposed)
             {
-                Task deferred = hostedOrRegistered
-                    ? CloseToolTabAsync(item)
-                    : DisposeContextOnceAsync(item);
-                _ = deferred.ContinueWith(
-                    t => _logger.LogWarning(
-                        t.Exception,
-                        "Deferred reentrant tool disposal failed ({SceneId})",
-                        _sceneId),
-                    CancellationToken.None,
-                    TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
-                    TaskScheduler.Default);
+                if (hostedOrRegistered)
+                {
+                    Task deferred = CloseToolTabAsync(item);
+                    _ = deferred.ContinueWith(
+                        t => _logger.LogWarning(
+                            t.Exception,
+                            "Deferred reentrant tool disposal failed ({SceneId})",
+                            _sceneId),
+                        CancellationToken.None,
+                        TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+                        TaskScheduler.Default);
+                }
+                else
+                {
+                    await DisposeContextOnceAsync(item);
+                }
             }
             return false;
         }
@@ -163,6 +171,8 @@ internal class DockHostViewModel : IAsyncDisposable
                     || _disposedToolContexts.TryGetValue(item, out _))
                     return false;
             }
+            if (!TryAcquireToolContext(item))
+                return false;
             EnsureDefaultLayout();
 
             var existing = Factory.EnumerateTools().FirstOrDefault(t => t.ToolContext == item);
@@ -188,6 +198,8 @@ internal class DockHostViewModel : IAsyncDisposable
             try
             {
                 dockable = Factory.AddTool(item, target);
+                if (dockable is not null)
+                    dockable.ContextDisposed = OnUntrackedDockableContextDisposed;
             }
             catch
             {
@@ -284,12 +296,6 @@ internal class DockHostViewModel : IAsyncDisposable
                         disposal = PrepareDockableDisposal(dockable);
                         Factory.DetachDockable(dockable);
                         _layoutEpoch++;
-                    }
-                    else
-                    {
-                        disposal = PrepareContextDisposal(
-                            item,
-                            () => ToolContextDisposal.DisposeAsync(item));
                     }
                 }
                 catch (Exception ex)
@@ -1354,6 +1360,9 @@ internal class DockHostViewModel : IAsyncDisposable
         IToolContext context,
         Func<ValueTask> dispose)
     {
+        if (!TryAcquireToolContext(context))
+            return ToolDisposalRegistration.Completed;
+
         lock (_disposeGate)
         {
             if (_toolDisposals.TryGetValue(context, out ToolDisposalRegistration? existing))
@@ -1394,12 +1403,48 @@ internal class DockHostViewModel : IAsyncDisposable
 
     private void OnDisposalCompleted(IToolContext context, ToolDisposalRegistration registration)
     {
+        ToolContextOwnershipLease? ownershipLease = null;
         lock (_disposeGate)
         {
             if (ReferenceEquals(_toolDisposals.GetValueOrDefault(context), registration))
                 _toolDisposals.Remove(context);
             _disposedToolContexts.GetValue(context, static _ => new object());
             _pendingDockableDisposals.Remove(registration.Completion.Task);
+            if (_toolOwnershipLeases.Remove(context, out ToolContextOwnershipLease? lease))
+                ownershipLease = lease;
+        }
+        ownershipLease?.Dispose();
+    }
+
+    private void OnUntrackedDockableContextDisposed(IToolContext context)
+    {
+        ToolContextOwnershipLease? ownershipLease = null;
+        lock (_disposeGate)
+        {
+            if (_toolDisposals.ContainsKey(context))
+                return;
+
+            _disposedToolContexts.GetValue(context, static _ => new object());
+            if (_toolOwnershipLeases.Remove(context, out ToolContextOwnershipLease? lease))
+                ownershipLease = lease;
+        }
+        ownershipLease?.Dispose();
+    }
+
+    private bool TryAcquireToolContext(IToolContext context)
+    {
+        lock (_disposeGate)
+        {
+            if (_toolOwnershipLeases.ContainsKey(context))
+                return true;
+            if (_disposedToolContexts.TryGetValue(context, out _))
+                return false;
+
+            if (!_toolHostToken.TryAcquireContext(context, out ToolContextOwnershipLease? lease))
+                return false;
+
+            _toolOwnershipLeases.Add(context, lease);
+            return true;
         }
     }
 
@@ -1763,6 +1808,9 @@ internal class DockHostViewModel : IAsyncDisposable
             return null;
         }
 
+        if (!TryAcquireToolContext(ctx))
+            return null;
+
         BeutlToolDockable? dockable = null;
         try
         {
@@ -1789,6 +1837,7 @@ internal class DockHostViewModel : IAsyncDisposable
             }
 
             dockable = new BeutlToolDockable(ctx, _editViewModel);
+            dockable.ContextDisposed = OnUntrackedDockableContextDisposed;
             // Registered before anything that can throw — including the id parse just below — so a
             // failure anywhere after construction can still dispose it.
             _restoredTools?.Add(dockable);

--- a/src/Beutl/ViewModels/EditViewModel.cs
+++ b/src/Beutl/ViewModels/EditViewModel.cs
@@ -69,7 +69,10 @@ public sealed partial class EditViewModel : IEditorContext, IAiJobResultEditorCo
     private volatile bool _disposed;
     private readonly object _disposeGate = new();
     private Task? _disposeTask;
+    private int _disposeFaultObserverAttached;
     private readonly Task _restoreTask;
+    private readonly TaskCompletionSource _constructionCompleted = new(
+        TaskCreationOptions.RunContinuationsAsynchronously);
 
     internal bool IsDisposingOrDisposed => _disposed;
 
@@ -191,6 +194,7 @@ public sealed partial class EditViewModel : IEditorContext, IAiJobResultEditorCo
         _autoSaveService.DisposeWith(_disposables);
 
         _restoreTask = RestoreStateAsync();
+        _constructionCompleted.TrySetResult();
 
         _logger.LogInformation("Initialized EditViewModel for Scene ({SceneId}).", SceneId);
     }
@@ -622,28 +626,61 @@ public sealed partial class EditViewModel : IEditorContext, IAiJobResultEditorCo
 
     internal DockHostViewModel DockHost { get; }
 
+    internal bool IsDisposeRequested
+    {
+        get
+        {
+            lock (_disposeGate)
+                return _disposeTask is not null;
+        }
+    }
+
     public ValueTask DisposeAsync()
     {
         TaskCompletionSource<object?>? completion = null;
         Task task;
-        bool reentrantToolTeardown = ToolContextDisposal.IsActive;
+        bool startDisposal = false;
+        bool reentrantOwnerCallback = ToolContextDisposal.IsActive
+            || DockHost.IsMaterializingDefaultPluginCallback;
         lock (_disposeGate)
         {
             if (_disposeTask is not null)
             {
-                return reentrantToolTeardown
-                    ? ValueTask.CompletedTask
-                    : new ValueTask(_disposeTask);
+                task = _disposeTask;
             }
-
-            completion = new TaskCompletionSource<object?>(
-                TaskCreationOptions.RunContinuationsAsynchronously);
-            _disposeTask = completion.Task;
-            task = completion.Task;
+            else
+            {
+                completion = new TaskCompletionSource<object?>(
+                    TaskCreationOptions.RunContinuationsAsynchronously);
+                _disposeTask = completion.Task;
+                task = completion.Task;
+                startDisposal = true;
+            }
         }
 
-        _ = DisposeCoreAsync(completion);
-        return reentrantToolTeardown ? ValueTask.CompletedTask : new ValueTask(task);
+        if (startDisposal)
+        {
+            DockHost.RequestOwnerShutdown();
+            EditorService.RequestContextShutdown(this);
+            _ = DisposeCoreAsync(completion!);
+        }
+        if (reentrantOwnerCallback)
+        {
+            ObserveReentrantDisposalFailure(task);
+            return ValueTask.CompletedTask;
+        }
+        return new ValueTask(task);
+    }
+
+    private void ObserveReentrantDisposalFailure(Task task)
+    {
+        if (Interlocked.CompareExchange(ref _disposeFaultObserverAttached, 1, 0) != 0)
+            return;
+        _ = task.ContinueWith(
+            t => _logger.LogError(t.Exception, "Reentrant editor disposal failed ({SceneId}).", SceneId),
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
     }
 
     private async Task DisposeCoreAsync(TaskCompletionSource<object?> completion)
@@ -657,6 +694,7 @@ public sealed partial class EditViewModel : IEditorContext, IAiJobResultEditorCo
         _disposed = true;
         Try(() => GlobalConfiguration.Instance.EditorConfig.PropertyChanged -= OnEditorConfigPropertyChanged);
 
+        await TryAsync(async () => await _constructionCompleted.Task.ConfigureAwait(false));
         await TryAsync(async () => await _restoreTask.ConfigureAwait(false));
         await TryAsync(async () => await DockHost.WaitForLayoutTransitionAsync().ConfigureAwait(false));
         if (scene.Uri is not null)

--- a/src/Beutl/ViewModels/EditViewModel.cs
+++ b/src/Beutl/ViewModels/EditViewModel.cs
@@ -769,9 +769,6 @@ public sealed partial class EditViewModel : IEditorContext, IAiJobResultEditorCo
         // Tool contexts can own asynchronous operations that still publish through the editor.
         // Cancel and drain them before retiring element handlers and the player.
         await TryAsync(async () => await DockHost.DisposeAsync());
-        // Retire and cancel UI-initiated element operations before waiting for handler leases.
-        // Awaiting yields the UI thread so cancellation continuations can release those leases.
-        await TryAsync(async () => await _elementAdder.DisposeAsync());
         await TryAsync(async () => await Player.DisposeAsync());
         Try(() => _elementNudgeService?.Dispose());
         Try(() => _historyMutationPlaybackGuard.Dispose());
@@ -780,9 +777,6 @@ public sealed partial class EditViewModel : IEditorContext, IAiJobResultEditorCo
         Player = null!;
         BufferStatus = null!;
 
-        // History can retain an undone unsaved element across a save. Once the editor closes and
-        // history is about to be discarded, no live or redoable item may still own this directory.
-        Try(() => UnsavedSceneStorage.Cleanup(scene.Id));
         Scene = null!;
         Commands = null!;
         Try(HistoryManager.Clear);

--- a/src/Beutl/ViewModels/EditViewModel.cs
+++ b/src/Beutl/ViewModels/EditViewModel.cs
@@ -1130,9 +1130,6 @@ public sealed partial class EditViewModel : IEditorContext, IAiJobResultEditorCo
         if (serviceType.IsAssignableTo(typeof(IEditorContext)))
             return this;
 
-        if (serviceType == typeof(IEditorContextCloseService))
-            return _contextCloseService;
-
         if (serviceType == typeof(HistoryManager))
             return HistoryManager;
 

--- a/src/Beutl/ViewModels/EditViewModel.cs
+++ b/src/Beutl/ViewModels/EditViewModel.cs
@@ -83,17 +83,25 @@ public sealed partial class EditViewModel : IEditorContext, IAiJobResultEditorCo
     /// </summary>
     internal EditViewModel(
         Scene scene,
-        EditorService editorService)
+        EditorService editorService,
+        IEditorContextCloseService closeService)
     {
         ArgumentNullException.ThrowIfNull(scene);
         ArgumentNullException.ThrowIfNull(editorService);
+        ArgumentNullException.ThrowIfNull(closeService);
+        if (!ReferenceEquals(editorService.HostToken, closeService.HostToken))
+        {
+            throw new ArgumentException(
+                "The close service must belong to the same editor host as the editor service.",
+                nameof(closeService));
+        }
 
         _logger.LogInformation("Initializing EditViewModel for Scene ({SceneId}).", scene.Id);
 
         Scene = scene;
         ExtensionProvider = editorService.ExtensionProvider;
         EditorService = editorService;
-        _contextCloseService = new BoundContextCloseService(this, editorService);
+        _contextCloseService = new BoundContextCloseService(this, closeService);
         SceneId = scene.Id.ToString();
 
         _timelineOptionsProvider = new TimelineOptionsProviderImpl(scene)
@@ -1083,9 +1091,9 @@ public sealed partial class EditViewModel : IEditorContext, IAiJobResultEditorCo
 
     private sealed class BoundContextCloseService(
         EditViewModel owner,
-        EditorService editorService) : IEditorContextCloseService
+        IEditorContextCloseService closeService) : IEditorContextCloseService
     {
-        public EditorContextHostToken HostToken => editorService.HostToken;
+        public EditorContextHostToken HostToken => closeService.HostToken;
 
         public EditorContextCloseRequest RequestClose(IEditorContext context)
         {
@@ -1096,13 +1104,13 @@ public sealed partial class EditViewModel : IEditorContext, IAiJobResultEditorCo
                     Task.CompletedTask);
             }
 
-            EditorContextCloseRequest request = editorService.RequestClose(owner);
+            EditorContextCloseRequest request = closeService.RequestClose(owner);
             if (request.Status != EditorContextCloseRequestStatus.NotOwned)
                 return request;
 
             owner.BeforePreOwnershipCloseStart?.Invoke();
             (bool started, Task completion) = owner.GetOrStartDisposal();
-            EditorContextCloseRequest attachedRequest = editorService.RequestClose(owner);
+            EditorContextCloseRequest attachedRequest = closeService.RequestClose(owner);
             if (attachedRequest.Status != EditorContextCloseRequestStatus.NotOwned)
                 return attachedRequest;
             _ = completion.ContinueWith(

--- a/src/Beutl/ViewModels/EditViewModel.cs
+++ b/src/Beutl/ViewModels/EditViewModel.cs
@@ -648,50 +648,63 @@ public sealed partial class EditViewModel : IEditorContext, IAiJobResultEditorCo
 
     private async Task DisposeCoreAsync(TaskCompletionSource<object?> completion)
     {
-        try
-        {
-            _logger.LogInformation("Disposing EditViewModel ({SceneId}).", SceneId);
-            Scene scene = Scene;
+        List<Exception>? failures = null;
+        _logger.LogInformation("Disposing EditViewModel ({SceneId}).", SceneId);
+        Scene scene = Scene;
 
-            // Block any proxy-invalidation flush already posted to the UI thread from running after this
-            // nulls Scene / disposes FrameCacheManager below.
-            _disposed = true;
-            GlobalConfiguration.Instance.EditorConfig.PropertyChanged -= OnEditorConfigPropertyChanged;
-            if (scene.Uri is not null)
-                SaveState();
-            _editorSelection.SelectedObject.Value = null;
-            // Player を破棄する前にイベント購読を外し、Subject 破棄後の OnNext を抑止する。
-            DisposeCommandStateNotifier();
-            // Tool contexts can own asynchronous operations that still publish through the editor.
-            // Cancel and drain them before retiring element handlers and the player.
-            await _restoreTask.ConfigureAwait(false);
-            await DockHost.DisposeAsync();
-            // Retire and cancel UI-initiated element operations before waiting for handler leases.
-            // Awaiting yields the UI thread so cancellation continuations can release those leases.
-            await _elementAdder.DisposeAsync();
-            await Player.DisposeAsync();
-            _elementNudgeService?.Dispose();
-            _historyMutationPlaybackGuard.Dispose();
-            _disposables.Dispose();
-            IsEnabled.Dispose();
-            Player = null!;
-            BufferStatus = null!;
+        // Block any proxy-invalidation flush already posted to the UI thread from running after this
+        // nulls Scene / disposes FrameCacheManager below.
+        _disposed = true;
+        Try(() => GlobalConfiguration.Instance.EditorConfig.PropertyChanged -= OnEditorConfigPropertyChanged);
 
-            // History can retain an undone unsaved element across a save. Once the editor closes and
-            // history is about to be discarded, no live or redoable item may still own this directory.
-            UnsavedSceneStorage.Cleanup(scene.Id);
-            Scene = null!;
-            Commands = null!;
-            HistoryManager.Clear();
-            FrameCacheManager.Value.Dispose();
-            FrameCacheManager.Dispose();
+        await TryAsync(async () => await _restoreTask.ConfigureAwait(false));
+        await TryAsync(async () => await DockHost.WaitForLayoutTransitionAsync().ConfigureAwait(false));
+        if (scene.Uri is not null)
+            Try(() => SaveState());
+        Try(() => _editorSelection.SelectedObject.Value = null);
+        // Player を破棄する前にイベント購読を外し、Subject 破棄後の OnNext を抑止する。
+        Try(DisposeCommandStateNotifier);
+        // Tool contexts can own asynchronous operations that still publish through the editor.
+        // Cancel and drain them before retiring element handlers and the player.
+        await TryAsync(async () => await DockHost.DisposeAsync());
+        // Retire and cancel UI-initiated element operations before waiting for handler leases.
+        // Awaiting yields the UI thread so cancellation continuations can release those leases.
+        await TryAsync(async () => await _elementAdder.DisposeAsync());
+        await TryAsync(async () => await Player.DisposeAsync());
+        Try(() => _elementNudgeService?.Dispose());
+        Try(() => _historyMutationPlaybackGuard.Dispose());
+        Try(() => _disposables.Dispose());
+        Try(() => IsEnabled.Dispose());
+        Player = null!;
+        BufferStatus = null!;
 
-            _logger.LogInformation("Disposed EditViewModel ({SceneId}).", SceneId);
+        // History can retain an undone unsaved element across a save. Once the editor closes and
+        // history is about to be discarded, no live or redoable item may still own this directory.
+        Try(() => UnsavedSceneStorage.Cleanup(scene.Id));
+        Scene = null!;
+        Commands = null!;
+        Try(HistoryManager.Clear);
+        Try(() => FrameCacheManager.Value.Dispose());
+        Try(() => FrameCacheManager.Dispose());
+
+        _logger.LogInformation("Disposed EditViewModel ({SceneId}).", SceneId);
+        if (failures is null)
             completion.TrySetResult(null);
-        }
-        catch (Exception ex)
+        else
+            completion.TrySetException(
+                failures.Count == 1 ? failures[0] : new AggregateException(failures));
+        return;
+
+        void Try(Action action)
         {
-            completion.TrySetException(ex);
+            try { action(); }
+            catch (Exception ex) { (failures ??= []).Add(ex); }
+        }
+
+        async Task TryAsync(Func<Task> action)
+        {
+            try { await action().ConfigureAwait(false); }
+            catch (Exception ex) { (failures ??= []).Add(ex); }
         }
     }
 

--- a/src/Beutl/ViewModels/EditViewModel.cs
+++ b/src/Beutl/ViewModels/EditViewModel.cs
@@ -756,13 +756,19 @@ public sealed partial class EditViewModel : IEditorContext, IAiJobResultEditorCo
         // Block any proxy-invalidation flush already posted to the UI thread from running after this
         // nulls Scene / disposes FrameCacheManager below.
         _disposed = true;
+        Try(_autoSaveCancellation.Cancel);
         Try(() => GlobalConfiguration.Instance.EditorConfig.PropertyChanged -= OnEditorConfigPropertyChanged);
 
         await TryAsync(async () => await _constructionCompleted.Task.ConfigureAwait(false));
         await TryAsync(async () => await _restoreTask.ConfigureAwait(false));
         await TryAsync(async () => await DockHost.WaitForLayoutTransitionAsync().ConfigureAwait(false));
         if (scene.Uri is not null)
-            Try(() => SaveState());
+            await TryAsync(async () =>
+            {
+                using IDisposable? write = await EditorService.BeginFinalProjectFileWriteAsync();
+                if (write is not null)
+                    SaveState();
+            });
         Try(() => _editorSelection.SelectedObject.Value = null);
         // Player を破棄する前にイベント購読を外し、Subject 破棄後の OnNext を抑止する。
         Try(DisposeCommandStateNotifier);

--- a/src/Beutl/ViewModels/EditViewModel.cs
+++ b/src/Beutl/ViewModels/EditViewModel.cs
@@ -1086,6 +1086,8 @@ public sealed partial class EditViewModel : IEditorContext, IAiJobResultEditorCo
         EditViewModel owner,
         IEditorContextCloseService closeService) : IEditorContextCloseService
     {
+        public EditorContextHostToken HostToken => closeService.HostToken;
+
         public EditorContextCloseRequest RequestClose(IEditorContext context)
         {
             if (!ReferenceEquals(context, owner))

--- a/src/Beutl/ViewModels/EditViewModel.cs
+++ b/src/Beutl/ViewModels/EditViewModel.cs
@@ -68,7 +68,10 @@ public sealed partial class EditViewModel : IEditorContext, IAiJobResultEditorCo
     private bool _proxyInvalidationScheduled;
     private volatile bool _disposed;
     private readonly object _disposeGate = new();
+    private static readonly AsyncLocal<PublicationScope?> s_publicationScope = new();
     private Task? _disposeTask;
+    private TaskCompletionSource? _publicationDrain;
+    private int _activePublications;
     private int _disposeFaultObserverAttached;
     private readonly Task _restoreTask;
     private readonly TaskCompletionSource _constructionCompleted = new(
@@ -635,8 +638,8 @@ public sealed partial class EditViewModel : IEditorContext, IAiJobResultEditorCo
         }
     }
 
-    // Publish under the same lifetime gate used by DisposeAsync, so shutdown cannot race
-    // publication even when the context was constructed directly (without a reservation token).
+    // Admission and completion are serialized with DisposeAsync, while observer callbacks run
+    // outside the gate. Teardown drains admitted callbacks after closing further admission.
     internal bool TryPublish(Action publish)
     {
         ArgumentNullException.ThrowIfNull(publish);
@@ -644,23 +647,79 @@ public sealed partial class EditViewModel : IEditorContext, IAiJobResultEditorCo
         {
             if (_disposeTask is not null)
                 return false;
+
+            if (_activePublications++ == 0)
+            {
+                _publicationDrain = new TaskCompletionSource(
+                    TaskCreationOptions.RunContinuationsAsynchronously);
+            }
+        }
+
+        PublicationScope? previous = s_publicationScope.Value;
+        var scope = new PublicationScope(this, previous);
+        s_publicationScope.Value = scope;
+        try
+        {
             publish();
-            return _disposeTask is null;
+            lock (_disposeGate)
+                return _disposeTask is null;
+        }
+        finally
+        {
+            TaskCompletionSource? drained = null;
+            lock (_disposeGate)
+            {
+                scope.Deactivate();
+                _activePublications--;
+                if (_activePublications == 0)
+                {
+                    drained = _publicationDrain;
+                    _publicationDrain = null;
+                }
+            }
+            s_publicationScope.Value = previous;
+            drained?.TrySetResult();
         }
     }
 
     bool IEditorContextPublicationGate.TryPublish(Action publish)
         => TryPublish(publish);
 
+    private static bool IsActivePublicationScope(EditViewModel owner)
+    {
+        for (PublicationScope? scope = s_publicationScope.Value; scope is not null; scope = scope.Parent)
+        {
+            if (scope.IsActive && ReferenceEquals(scope.Owner, owner))
+                return true;
+        }
+
+        return false;
+    }
+
+    private sealed class PublicationScope(EditViewModel owner, PublicationScope? parent)
+    {
+        private int _active = 1;
+
+        public EditViewModel Owner { get; } = owner;
+
+        public PublicationScope? Parent { get; } = parent;
+
+        public bool IsActive => Volatile.Read(ref _active) != 0;
+
+        public void Deactivate() => Interlocked.Exchange(ref _active, 0);
+    }
+
     public ValueTask DisposeAsync()
     {
         TaskCompletionSource<object?>? completion = null;
         Task task;
+        Task publicationDrain = Task.CompletedTask;
         bool startDisposal = false;
         bool reentrantOwnerCallback = ToolContextDisposal.IsActive
             || DockHost.IsOwnerCallbackScope;
         lock (_disposeGate)
         {
+            reentrantOwnerCallback |= IsActivePublicationScope(this);
             if (_disposeTask is not null)
             {
                 task = _disposeTask;
@@ -671,6 +730,7 @@ public sealed partial class EditViewModel : IEditorContext, IAiJobResultEditorCo
                     TaskCreationOptions.RunContinuationsAsynchronously);
                 _disposeTask = completion.Task;
                 task = completion.Task;
+                publicationDrain = _publicationDrain?.Task ?? Task.CompletedTask;
                 startDisposal = true;
             }
         }
@@ -679,7 +739,7 @@ public sealed partial class EditViewModel : IEditorContext, IAiJobResultEditorCo
         {
             DockHost.RequestOwnerShutdown();
             EditorService.RequestContextShutdown(this);
-            _ = DisposeCoreAsync(completion!);
+            _ = DisposeCoreAsync(publicationDrain, completion!);
         }
         if (reentrantOwnerCallback)
         {
@@ -700,11 +760,15 @@ public sealed partial class EditViewModel : IEditorContext, IAiJobResultEditorCo
             TaskScheduler.Default);
     }
 
-    private async Task DisposeCoreAsync(TaskCompletionSource<object?> completion)
+    private async Task DisposeCoreAsync(
+        Task publicationDrain,
+        TaskCompletionSource<object?> completion)
     {
         List<Exception>? failures = null;
         _logger.LogInformation("Disposing EditViewModel ({SceneId}).", SceneId);
         Scene scene = Scene;
+
+        await TryAsync(async () => await publicationDrain.ConfigureAwait(false));
 
         // Block any proxy-invalidation flush already posted to the UI thread from running after this
         // nulls Scene / disposes FrameCacheManager below.

--- a/src/Beutl/ViewModels/EditViewModel.cs
+++ b/src/Beutl/ViewModels/EditViewModel.cs
@@ -32,7 +32,7 @@ using Dispatcher = Avalonia.Threading.Dispatcher;
 
 namespace Beutl.ViewModels;
 
-public sealed partial class EditViewModel : IEditorContext, IAiJobResultEditorContext, ISupportAutoSaveEditorContext, IPreviewRenderQuality
+public sealed partial class EditViewModel : IEditorContext, IAiJobResultEditorContext, IEditorContextPublicationGate, ISupportAutoSaveEditorContext, IPreviewRenderQuality
 {
     private readonly ILogger _logger = Log.CreateLogger<EditViewModel>();
     private readonly AutoSaveService _autoSaveService = new();
@@ -635,13 +635,30 @@ public sealed partial class EditViewModel : IEditorContext, IAiJobResultEditorCo
         }
     }
 
+    // Publish under the same lifetime gate used by DisposeAsync, so shutdown cannot race
+    // publication even when the context was constructed directly (without a reservation token).
+    internal bool TryPublish(Action publish)
+    {
+        ArgumentNullException.ThrowIfNull(publish);
+        lock (_disposeGate)
+        {
+            if (_disposeTask is not null)
+                return false;
+            publish();
+            return _disposeTask is null;
+        }
+    }
+
+    bool IEditorContextPublicationGate.TryPublish(Action publish)
+        => TryPublish(publish);
+
     public ValueTask DisposeAsync()
     {
         TaskCompletionSource<object?>? completion = null;
         Task task;
         bool startDisposal = false;
         bool reentrantOwnerCallback = ToolContextDisposal.IsActive
-            || DockHost.IsMaterializingDefaultPluginCallback;
+            || DockHost.IsOwnerCallbackScope;
         lock (_disposeGate)
         {
             if (_disposeTask is not null)

--- a/src/Beutl/ViewModels/EditViewModel.cs
+++ b/src/Beutl/ViewModels/EditViewModel.cs
@@ -73,6 +73,7 @@ public sealed partial class EditViewModel : IEditorContext, IAiJobResultEditorCo
     private TaskCompletionSource? _publicationDrain;
     private int _activePublications;
     private readonly Task _restoreTask;
+    internal Task Initialization => _restoreTask;
     private readonly TaskCompletionSource _constructionCompleted = new(
         TaskCreationOptions.RunContinuationsAsynchronously);
 

--- a/src/Beutl/ViewModels/EditViewModel.cs
+++ b/src/Beutl/ViewModels/EditViewModel.cs
@@ -78,18 +78,23 @@ public sealed partial class EditViewModel : IEditorContext, IAiJobResultEditorCo
 
     internal bool IsDisposingOrDisposed => _disposed;
 
-    public EditViewModel(Scene scene, Beutl.Api.Services.ExtensionProvider extensionProvider, EditorService editorService)
+    public EditViewModel(
+        Scene scene,
+        Beutl.Api.Services.ExtensionProvider extensionProvider,
+        EditorService editorService,
+        IEditorContextCloseService closeService)
     {
         ArgumentNullException.ThrowIfNull(scene);
         ArgumentNullException.ThrowIfNull(extensionProvider);
         ArgumentNullException.ThrowIfNull(editorService);
+        ArgumentNullException.ThrowIfNull(closeService);
 
         _logger.LogInformation("Initializing EditViewModel for Scene ({SceneId}).", scene.Id);
 
         Scene = scene;
         ExtensionProvider = extensionProvider;
         EditorService = editorService;
-        _contextCloseService = new BoundContextCloseService(this, editorService);
+        _contextCloseService = new BoundContextCloseService(this, closeService);
         SceneId = scene.Id.ToString();
 
         _timelineOptionsProvider = new TimelineOptionsProviderImpl(scene)
@@ -621,6 +626,8 @@ public sealed partial class EditViewModel : IEditorContext, IAiJobResultEditorCo
 
     public EditorExtension Extension => SceneEditorExtension.Instance;
 
+    public IEditorContextCloseService CloseService => _contextCloseService;
+
     public CoreObject Object => Scene;
 
     public IKnownEditorCommands? Commands { get; private set; }
@@ -1077,20 +1084,24 @@ public sealed partial class EditViewModel : IEditorContext, IAiJobResultEditorCo
 
     private sealed class BoundContextCloseService(
         EditViewModel owner,
-        EditorService editorService) : IEditorContextCloseService
+        IEditorContextCloseService closeService) : IEditorContextCloseService
     {
         public EditorContextCloseRequest RequestClose(IEditorContext context)
         {
-            EditorContextCloseRequest request = editorService.RequestClose(context);
-            if (request.Status != EditorContextCloseRequestStatus.NotOwned
-                || !ReferenceEquals(context, owner))
+            if (!ReferenceEquals(context, owner))
             {
-                return request;
+                return new EditorContextCloseRequest(
+                    EditorContextCloseRequestStatus.NotOwned,
+                    Task.CompletedTask);
             }
+
+            EditorContextCloseRequest request = closeService.RequestClose(owner);
+            if (request.Status != EditorContextCloseRequestStatus.NotOwned)
+                return request;
 
             owner.BeforePreOwnershipCloseStart?.Invoke();
             (bool started, Task completion) = owner.GetOrStartDisposal();
-            EditorContextCloseRequest attachedRequest = editorService.RequestClose(owner);
+            EditorContextCloseRequest attachedRequest = closeService.RequestClose(owner);
             if (attachedRequest.Status != EditorContextCloseRequestStatus.NotOwned)
                 return attachedRequest;
             _ = completion.ContinueWith(
@@ -1117,7 +1128,7 @@ public sealed partial class EditViewModel : IEditorContext, IAiJobResultEditorCo
         if (serviceType.IsAssignableTo(typeof(IEditorContext)))
             return this;
 
-        if (serviceType.IsAssignableTo(typeof(IEditorContextCloseService)))
+        if (serviceType == typeof(IEditorContextCloseService))
             return _contextCloseService;
 
         if (serviceType == typeof(HistoryManager))

--- a/src/Beutl/ViewModels/EditViewModel.cs
+++ b/src/Beutl/ViewModels/EditViewModel.cs
@@ -44,6 +44,7 @@ public sealed partial class EditViewModel : IEditorContext, IAiJobResultEditorCo
     private readonly EditorClockImpl _editorClock;
     private readonly EditorSelectionImpl _editorSelection;
     private readonly ElementAdderImpl _elementAdder;
+    private readonly IEditorContextCloseService _contextCloseService;
     private SceneTimeRangeService? _sceneTimeRangeService;
     private ElementResizeService? _elementResizeService;
     private ElementSlipService? _elementSlipService;
@@ -68,11 +69,9 @@ public sealed partial class EditViewModel : IEditorContext, IAiJobResultEditorCo
     private bool _proxyInvalidationScheduled;
     private volatile bool _disposed;
     private readonly object _disposeGate = new();
-    private static readonly AsyncLocal<PublicationScope?> s_publicationScope = new();
     private Task? _disposeTask;
     private TaskCompletionSource? _publicationDrain;
     private int _activePublications;
-    private int _disposeFaultObserverAttached;
     private readonly Task _restoreTask;
     private readonly TaskCompletionSource _constructionCompleted = new(
         TaskCreationOptions.RunContinuationsAsynchronously);
@@ -90,6 +89,7 @@ public sealed partial class EditViewModel : IEditorContext, IAiJobResultEditorCo
         Scene = scene;
         ExtensionProvider = extensionProvider;
         EditorService = editorService;
+        _contextCloseService = new BoundContextCloseService(this, editorService);
         SceneId = scene.Id.ToString();
 
         _timelineOptionsProvider = new TimelineOptionsProviderImpl(scene)
@@ -638,6 +638,8 @@ public sealed partial class EditViewModel : IEditorContext, IAiJobResultEditorCo
         }
     }
 
+    internal Action? BeforePreOwnershipCloseStart { get; set; }
+
     // Admission and completion are serialized with DisposeAsync, while observer callbacks run
     // outside the gate. Teardown drains admitted callbacks after closing further admission.
     internal bool TryPublish(Action publish)
@@ -655,9 +657,6 @@ public sealed partial class EditViewModel : IEditorContext, IAiJobResultEditorCo
             }
         }
 
-        PublicationScope? previous = s_publicationScope.Value;
-        var scope = new PublicationScope(this, previous);
-        s_publicationScope.Value = scope;
         try
         {
             publish();
@@ -669,7 +668,6 @@ public sealed partial class EditViewModel : IEditorContext, IAiJobResultEditorCo
             TaskCompletionSource? drained = null;
             lock (_disposeGate)
             {
-                scope.Deactivate();
                 _activePublications--;
                 if (_activePublications == 0)
                 {
@@ -677,7 +675,6 @@ public sealed partial class EditViewModel : IEditorContext, IAiJobResultEditorCo
                     _publicationDrain = null;
                 }
             }
-            s_publicationScope.Value = previous;
             drained?.TrySetResult();
         }
     }
@@ -685,41 +682,17 @@ public sealed partial class EditViewModel : IEditorContext, IAiJobResultEditorCo
     bool IEditorContextPublicationGate.TryPublish(Action publish)
         => TryPublish(publish);
 
-    private static bool IsActivePublicationScope(EditViewModel owner)
-    {
-        for (PublicationScope? scope = s_publicationScope.Value; scope is not null; scope = scope.Parent)
-        {
-            if (scope.IsActive && ReferenceEquals(scope.Owner, owner))
-                return true;
-        }
+    /// <summary>Requests terminal disposal of the editor context.</summary>
+    public ValueTask DisposeAsync() => new(GetOrStartDisposal().Completion);
 
-        return false;
-    }
-
-    private sealed class PublicationScope(EditViewModel owner, PublicationScope? parent)
-    {
-        private int _active = 1;
-
-        public EditViewModel Owner { get; } = owner;
-
-        public PublicationScope? Parent { get; } = parent;
-
-        public bool IsActive => Volatile.Read(ref _active) != 0;
-
-        public void Deactivate() => Interlocked.Exchange(ref _active, 0);
-    }
-
-    public ValueTask DisposeAsync()
+    private (bool Started, Task Completion) GetOrStartDisposal()
     {
         TaskCompletionSource<object?>? completion = null;
         Task task;
         Task publicationDrain = Task.CompletedTask;
         bool startDisposal = false;
-        bool reentrantOwnerCallback = ToolContextDisposal.IsActive
-            || DockHost.IsOwnerCallbackScope;
         lock (_disposeGate)
         {
-            reentrantOwnerCallback |= IsActivePublicationScope(this);
             if (_disposeTask is not null)
             {
                 task = _disposeTask;
@@ -735,36 +708,32 @@ public sealed partial class EditViewModel : IEditorContext, IAiJobResultEditorCo
             }
         }
 
+        Exception? startupFailure = null;
         if (startDisposal)
         {
-            DockHost.RequestOwnerShutdown();
-            EditorService.RequestContextShutdown(this);
-            _ = DisposeCoreAsync(publicationDrain, completion!);
+            try
+            {
+                DockHost.RequestOwnerShutdown();
+                EditorService.RequestContextShutdown(this);
+            }
+            catch (Exception ex)
+            {
+                startupFailure = ex;
+            }
+            finally
+            {
+                _ = DisposeCoreAsync(publicationDrain, completion!, startupFailure);
+            }
         }
-        if (reentrantOwnerCallback)
-        {
-            ObserveReentrantDisposalFailure(task);
-            return ValueTask.CompletedTask;
-        }
-        return new ValueTask(task);
-    }
-
-    private void ObserveReentrantDisposalFailure(Task task)
-    {
-        if (Interlocked.CompareExchange(ref _disposeFaultObserverAttached, 1, 0) != 0)
-            return;
-        _ = task.ContinueWith(
-            t => _logger.LogError(t.Exception, "Reentrant editor disposal failed ({SceneId}).", SceneId),
-            CancellationToken.None,
-            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
-            TaskScheduler.Default);
+        return (startDisposal, task);
     }
 
     private async Task DisposeCoreAsync(
         Task publicationDrain,
-        TaskCompletionSource<object?> completion)
+        TaskCompletionSource<object?> completion,
+        Exception? startupFailure)
     {
-        List<Exception>? failures = null;
+        List<Exception>? failures = startupFailure is null ? null : [startupFailure];
         _logger.LogInformation("Disposing EditViewModel ({SceneId}).", SceneId);
         Scene scene = Scene;
 
@@ -1106,6 +1075,40 @@ public sealed partial class EditViewModel : IEditorContext, IAiJobResultEditorCo
         }
     }
 
+    private sealed class BoundContextCloseService(
+        EditViewModel owner,
+        EditorService editorService) : IEditorContextCloseService
+    {
+        public EditorContextCloseRequest RequestClose(IEditorContext context)
+        {
+            EditorContextCloseRequest request = editorService.RequestClose(context);
+            if (request.Status != EditorContextCloseRequestStatus.NotOwned
+                || !ReferenceEquals(context, owner))
+            {
+                return request;
+            }
+
+            owner.BeforePreOwnershipCloseStart?.Invoke();
+            (bool started, Task completion) = owner.GetOrStartDisposal();
+            EditorContextCloseRequest attachedRequest = editorService.RequestClose(owner);
+            if (attachedRequest.Status != EditorContextCloseRequestStatus.NotOwned)
+                return attachedRequest;
+            _ = completion.ContinueWith(
+                task => owner._logger.LogError(
+                    task.Exception,
+                    "Requested editor close failed ({SceneId}).",
+                    owner.SceneId),
+                CancellationToken.None,
+                TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default);
+            return new EditorContextCloseRequest(
+                started
+                    ? EditorContextCloseRequestStatus.Accepted
+                    : EditorContextCloseRequestStatus.AlreadyClosing,
+                completion);
+        }
+    }
+
     public object? GetService(Type serviceType)
     {
         if (serviceType == typeof(Scene))
@@ -1113,6 +1116,9 @@ public sealed partial class EditViewModel : IEditorContext, IAiJobResultEditorCo
 
         if (serviceType.IsAssignableTo(typeof(IEditorContext)))
             return this;
+
+        if (serviceType.IsAssignableTo(typeof(IEditorContextCloseService)))
+            return _contextCloseService;
 
         if (serviceType == typeof(HistoryManager))
             return HistoryManager;

--- a/src/Beutl/ViewModels/EditViewModel.cs
+++ b/src/Beutl/ViewModels/EditViewModel.cs
@@ -78,23 +78,22 @@ public sealed partial class EditViewModel : IEditorContext, IAiJobResultEditorCo
 
     internal bool IsDisposingOrDisposed => _disposed;
 
-    public EditViewModel(
+    /// <summary>
+    /// Initializes an editor context for a host-provided scene.
+    /// </summary>
+    internal EditViewModel(
         Scene scene,
-        Beutl.Api.Services.ExtensionProvider extensionProvider,
-        EditorService editorService,
-        IEditorContextCloseService closeService)
+        EditorService editorService)
     {
         ArgumentNullException.ThrowIfNull(scene);
-        ArgumentNullException.ThrowIfNull(extensionProvider);
         ArgumentNullException.ThrowIfNull(editorService);
-        ArgumentNullException.ThrowIfNull(closeService);
 
         _logger.LogInformation("Initializing EditViewModel for Scene ({SceneId}).", scene.Id);
 
         Scene = scene;
-        ExtensionProvider = extensionProvider;
+        ExtensionProvider = editorService.ExtensionProvider;
         EditorService = editorService;
-        _contextCloseService = new BoundContextCloseService(this, closeService);
+        _contextCloseService = new BoundContextCloseService(this, editorService);
         SceneId = scene.Id.ToString();
 
         _timelineOptionsProvider = new TimelineOptionsProviderImpl(scene)
@@ -1084,9 +1083,9 @@ public sealed partial class EditViewModel : IEditorContext, IAiJobResultEditorCo
 
     private sealed class BoundContextCloseService(
         EditViewModel owner,
-        IEditorContextCloseService closeService) : IEditorContextCloseService
+        EditorService editorService) : IEditorContextCloseService
     {
-        public EditorContextHostToken HostToken => closeService.HostToken;
+        public EditorContextHostToken HostToken => editorService.HostToken;
 
         public EditorContextCloseRequest RequestClose(IEditorContext context)
         {
@@ -1097,13 +1096,13 @@ public sealed partial class EditViewModel : IEditorContext, IAiJobResultEditorCo
                     Task.CompletedTask);
             }
 
-            EditorContextCloseRequest request = closeService.RequestClose(owner);
+            EditorContextCloseRequest request = editorService.RequestClose(owner);
             if (request.Status != EditorContextCloseRequestStatus.NotOwned)
                 return request;
 
             owner.BeforePreOwnershipCloseStart?.Invoke();
             (bool started, Task completion) = owner.GetOrStartDisposal();
-            EditorContextCloseRequest attachedRequest = closeService.RequestClose(owner);
+            EditorContextCloseRequest attachedRequest = editorService.RequestClose(owner);
             if (attachedRequest.Status != EditorContextCloseRequestStatus.NotOwned)
                 return attachedRequest;
             _ = completion.ContinueWith(

--- a/src/Beutl/ViewModels/EditViewModel.cs
+++ b/src/Beutl/ViewModels/EditViewModel.cs
@@ -24,7 +24,7 @@ using Beutl.Serialization;
 using Beutl.Services;
 using Beutl.Services.AI;
 using Beutl.Services.PrimitiveImpls;
-using Beutl.ViewModels.Tools;
+using Beutl.ViewModels.Dock;
 using Microsoft.Extensions.Logging;
 using Reactive.Bindings;
 using Reactive.Bindings.Extensions;
@@ -67,6 +67,9 @@ public sealed partial class EditViewModel : IEditorContext, IAiJobResultEditorCo
     private readonly HashSet<string> _pendingProxyInvalidations = new(StringComparer.Ordinal);
     private bool _proxyInvalidationScheduled;
     private volatile bool _disposed;
+    private readonly object _disposeGate = new();
+    private Task? _disposeTask;
+    private readonly Task _restoreTask;
 
     internal bool IsDisposingOrDisposed => _disposed;
 
@@ -187,7 +190,7 @@ public sealed partial class EditViewModel : IEditorContext, IAiJobResultEditorCo
             .DisposeWith(_disposables);
         _autoSaveService.DisposeWith(_disposables);
 
-        RestoreState();
+        _restoreTask = RestoreStateAsync();
 
         _logger.LogInformation("Initialized EditViewModel for Scene ({SceneId}).", SceneId);
     }
@@ -617,62 +620,79 @@ public sealed partial class EditViewModel : IEditorContext, IAiJobResultEditorCo
 
     IReactiveProperty<bool> IEditorContext.IsEnabled => IsEnabled;
 
-    public DockHostViewModel DockHost { get; }
+    internal DockHostViewModel DockHost { get; }
 
-    public async ValueTask DisposeAsync()
+    public ValueTask DisposeAsync()
     {
-        _logger.LogInformation("Disposing EditViewModel ({SceneId}).", SceneId);
-        Scene scene = Scene;
-
-        // Block any proxy-invalidation flush already posted to the UI thread from running after this
-        // nulls Scene / disposes FrameCacheManager below.
-        _disposed = true;
-        _autoSaveCancellation.Cancel();
-        GlobalConfiguration.Instance.EditorConfig.PropertyChanged -= OnEditorConfigPropertyChanged;
-        if (scene.Uri is not null && !EditorService.IsWorktreeMutationActive)
+        TaskCompletionSource<object?>? completion = null;
+        Task task;
+        bool reentrantToolTeardown = ToolContextDisposal.IsActive;
+        lock (_disposeGate)
         {
-            using IDisposable fileWrite = await EditorService.BeginProjectFileWriteAsync(
-                CancellationToken.None);
-            SaveState();
+            if (_disposeTask is not null)
+            {
+                return reentrantToolTeardown
+                    ? ValueTask.CompletedTask
+                    : new ValueTask(_disposeTask);
+            }
+
+            completion = new TaskCompletionSource<object?>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            _disposeTask = completion.Task;
+            task = completion.Task;
         }
-        else if (scene.Uri is not null)
+
+        _ = DisposeCoreAsync(completion);
+        return reentrantToolTeardown ? ValueTask.CompletedTask : new ValueTask(task);
+    }
+
+    private async Task DisposeCoreAsync(TaskCompletionSource<object?> completion)
+    {
+        try
         {
-            _logger.LogDebug(
-                "Skipping the final view-state save during a worktree mutation ({SceneId}).",
-                SceneId);
+            _logger.LogInformation("Disposing EditViewModel ({SceneId}).", SceneId);
+            Scene scene = Scene;
+
+            // Block any proxy-invalidation flush already posted to the UI thread from running after this
+            // nulls Scene / disposes FrameCacheManager below.
+            _disposed = true;
+            GlobalConfiguration.Instance.EditorConfig.PropertyChanged -= OnEditorConfigPropertyChanged;
+            if (scene.Uri is not null)
+                SaveState();
+            _editorSelection.SelectedObject.Value = null;
+            // Player を破棄する前にイベント購読を外し、Subject 破棄後の OnNext を抑止する。
+            DisposeCommandStateNotifier();
+            // Tool contexts can own asynchronous operations that still publish through the editor.
+            // Cancel and drain them before retiring element handlers and the player.
+            await _restoreTask.ConfigureAwait(false);
+            await DockHost.DisposeAsync();
+            // Retire and cancel UI-initiated element operations before waiting for handler leases.
+            // Awaiting yields the UI thread so cancellation continuations can release those leases.
+            await _elementAdder.DisposeAsync();
+            await Player.DisposeAsync();
+            _elementNudgeService?.Dispose();
+            _historyMutationPlaybackGuard.Dispose();
+            _disposables.Dispose();
+            IsEnabled.Dispose();
+            Player = null!;
+            BufferStatus = null!;
+
+            // History can retain an undone unsaved element across a save. Once the editor closes and
+            // history is about to be discarded, no live or redoable item may still own this directory.
+            UnsavedSceneStorage.Cleanup(scene.Id);
+            Scene = null!;
+            Commands = null!;
+            HistoryManager.Clear();
+            FrameCacheManager.Value.Dispose();
+            FrameCacheManager.Dispose();
+
+            _logger.LogInformation("Disposed EditViewModel ({SceneId}).", SceneId);
+            completion.TrySetResult(null);
         }
-        _editorSelection.SelectedObject.Value = null;
-        // Player を破棄する前にイベント購読を外し、Subject 破棄後の OnNext を抑止する。
-        DisposeCommandStateNotifier();
-        // Tool contexts can own paid-AI operations that still publish through the editor.
-        // Cancel and drain them before retiring element handlers and the player.
-        AiWorkspaceViewModel[] aiWorkspaces = DockHost.Factory.EnumerateTools()
-            .Select(static tool => tool.ToolContext)
-            .OfType<AiWorkspaceViewModel>()
-            .ToArray();
-        DockHost.Dispose();
-        await Task.WhenAll(aiWorkspaces.Select(static workspace => workspace.DisposeAsync().AsTask()));
-        // Retire and cancel UI-initiated element operations before waiting for handler leases.
-        // Awaiting yields the UI thread so cancellation continuations can release those leases.
-        await _elementAdder.DisposeAsync();
-        await Player.DisposeAsync();
-        _elementNudgeService?.Dispose();
-        _historyMutationPlaybackGuard.Dispose();
-        _disposables.Dispose();
-        IsEnabled.Dispose();
-        Player = null!;
-        BufferStatus = null!;
-
-        // Closing the editor discards every live and redoable owner of unsaved sidecars and AI
-        // resources, so its scene-scoped temporary directory must not survive the tab.
-        UnsavedSceneStorage.Cleanup(scene.Id);
-        Scene = null!;
-        Commands = null!;
-        HistoryManager.Clear();
-        FrameCacheManager.Value.Dispose();
-        FrameCacheManager.Dispose();
-
-        _logger.LogInformation("Disposed EditViewModel ({SceneId}).", SceneId);
+        catch (Exception ex)
+        {
+            completion.TrySetException(ex);
+        }
     }
 
     public T? FindToolTab<T>(Func<T, bool> condition)
@@ -687,15 +707,11 @@ public sealed partial class EditViewModel : IEditorContext, IAiJobResultEditorCo
         return FindToolTab<T>(_ => true);
     }
 
-    public bool OpenToolTab(IToolContext item)
-    {
-        return DockHost.OpenToolTab(item);
-    }
+    public ValueTask<bool> OpenToolTabAsync(IToolContext item)
+        => new(DockHost.OpenToolTabAsync(item));
 
-    public void CloseToolTab(IToolContext item)
-    {
-        DockHost.CloseToolTab(item);
-    }
+    public ValueTask CloseToolTabAsync(IToolContext item)
+        => new(DockHost.CloseToolTabAsync(item));
 
     private string ViewStateDirectory()
     {
@@ -753,7 +769,7 @@ public sealed partial class EditViewModel : IEditorContext, IAiJobResultEditorCo
         json.JsonSave(Path.Combine(viewStateDir, $"{name}.config"));
     }
 
-    private void RestoreState()
+    private async Task RestoreStateAsync()
     {
         string viewStateDir = ViewStateDirectory();
         string name = Path.GetFileNameWithoutExtension(Scene.Uri!.LocalPath);
@@ -762,7 +778,7 @@ public sealed partial class EditViewModel : IEditorContext, IAiJobResultEditorCo
         if (!File.Exists(viewStateFile))
         {
             _logger.LogInformation("No state file found, opening default tabs.");
-            SafeOpenDefaultTabs();
+            await SafeOpenDefaultTabsAsync();
             return;
         }
 
@@ -777,7 +793,7 @@ public sealed partial class EditViewModel : IEditorContext, IAiJobResultEditorCo
         {
             _logger.LogError(ex, "View state file {ViewStateFile} is malformed; quarantining and opening default tabs ({SceneId}).", viewStateFile, SceneId);
             QuarantineCorruptViewState(viewStateFile);
-            SafeOpenDefaultTabs();
+            await SafeOpenDefaultTabsAsync();
             return;
         }
         catch (Exception ex) when (ex is FileNotFoundException or DirectoryNotFoundException)
@@ -786,7 +802,7 @@ public sealed partial class EditViewModel : IEditorContext, IAiJobResultEditorCo
             // (TOCTOU — another process or a user cleanup). Nothing to protect, so treat
             // this like the no-state-file branch and let SaveState() proceed normally.
             _logger.LogWarning(ex, "View state file {ViewStateFile} disappeared before it could be read; opening default tabs ({SceneId}).", viewStateFile, SceneId);
-            SafeOpenDefaultTabs();
+            await SafeOpenDefaultTabsAsync();
             return;
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
@@ -797,7 +813,7 @@ public sealed partial class EditViewModel : IEditorContext, IAiJobResultEditorCo
             // overwrite it with the default layout before the user gets a chance to recover.
             _logger.LogError(ex, "Failed to read view state file {ViewStateFile}; opening default tabs and suppressing view state save this session ({SceneId}).", viewStateFile, SceneId);
             _viewStateSaveSuppressed = true;
-            SafeOpenDefaultTabs();
+            await SafeOpenDefaultTabsAsync();
             return;
         }
 
@@ -812,7 +828,7 @@ public sealed partial class EditViewModel : IEditorContext, IAiJobResultEditorCo
                 viewStateFile,
                 SceneId);
             QuarantineCorruptViewState(viewStateFile);
-            SafeOpenDefaultTabs();
+            await SafeOpenDefaultTabsAsync();
             return;
         }
 
@@ -881,7 +897,7 @@ public sealed partial class EditViewModel : IEditorContext, IAiJobResultEditorCo
 
             _timelineOptionsProvider.Options.Value = timelineOptions;
 
-            DockHost.ReadFromJson(jsonObject);
+            await DockHost.ReadFromJsonAsync(jsonObject);
 
             if (jsonObject.TryGetPropertyValueAsJsonValue("current-time", out string? currentTimeStr)
                 && TimeSpan.TryParse(currentTimeStr, out TimeSpan currentTime))
@@ -898,18 +914,18 @@ public sealed partial class EditViewModel : IEditorContext, IAiJobResultEditorCo
             // quarantining a valid file on those would permanently lose the layout.
             _logger.LogError(ex, "Unexpected error while restoring view state from {ViewStateFile}; quarantining and opening default tabs ({SceneId}).", viewStateFile, SceneId);
             QuarantineCorruptViewState(viewStateFile);
-            SafeOpenDefaultTabs();
+            await SafeOpenDefaultTabsAsync();
         }
     }
 
-    private void SafeOpenDefaultTabs()
+    private async Task SafeOpenDefaultTabsAsync()
     {
         // OpenDefaultTabs runs arbitrary tool-extension code, so swallow recoverable
         // exceptions here — the scene must remain openable even when the
         // default-layout fallback itself fails. OOM / cancellation propagate.
         try
         {
-            DockHost.OpenDefaultTabs();
+            await DockHost.OpenDefaultTabsAsync();
         }
         catch (Exception ex) when (ex is not OutOfMemoryException and not OperationCanceledException)
         {

--- a/src/Beutl/ViewModels/EditorHostViewModel.cs
+++ b/src/Beutl/ViewModels/EditorHostViewModel.cs
@@ -7,89 +7,72 @@ using Reactive.Bindings;
 
 namespace Beutl.ViewModels;
 
-public class EditorHostViewModel
+public class EditorHostViewModel : IAsyncDisposable
 {
     private readonly ILogger _logger = Log.CreateLogger<EditorHostViewModel>();
     private readonly ProjectService _projectService;
     private readonly EditorService _editorService;
-    private readonly object _operationGate = new();
-    private Task _operationTail = Task.CompletedTask;
-    private Project? _subscribedProject;
-    private long _subscriptionGeneration;
+    private readonly ProjectService.ProjectChangeRegistration _projectChangeRegistration;
+    private readonly object _projectChangeGate = new();
+    private Task _projectChangeTask = Task.CompletedTask;
+    private Task? _disposeTask;
+    private object? _activeProjectItems;
+    private int _disposed;
 
     public EditorHostViewModel(ProjectService projectService, EditorService editorService)
     {
         _projectService = projectService;
         _editorService = editorService;
-        _projectService.Closing += OnProjectClosingAsync;
-        _projectService.Opened += OnProjectOpenedAsync;
+        _projectChangeRegistration = _projectService.RegisterProjectChangeHandler(
+            new ProjectChangeHandler(this));
     }
 
-    private Task OnProjectClosingAsync(
-        ProjectService.ProjectCloseContext closeContext,
-        CancellationToken _)
+    internal Task WaitForPendingProjectChangesAsync()
     {
-        return QueueOperationAsync(async () =>
+        lock (_projectChangeGate)
         {
-            Project? project = _projectService.CurrentProject.Value;
-            CoreObject? selectedObject = _editorService.SelectedTabItem.Value?.Context.Value?.Object;
-            if (project is not null)
-            {
-                closeContext.RegisterCompletion(projectClosed =>
-                    RestoreAfterAbortedCloseAsync(project, selectedObject, projectClosed));
-            }
-
-            await DispatchProjectChangeAsync(null, project);
-        });
-    }
-
-    private Task OnProjectOpenedAsync(Project project)
-    {
-        return QueueOperationAsync(() => DispatchProjectChangeAsync(project, null));
-    }
-
-    private async Task DispatchProjectChangeAsync(Project? @new, Project? old)
-    {
-        if (Dispatcher.UIThread.CheckAccess())
-        {
-            await OnProjectChangedAsync(@new, old);
-        }
-        else
-        {
-            await Dispatcher.UIThread.InvokeAsync(async () =>
-                await OnProjectChangedAsync(@new, old));
+            return _projectChangeTask;
         }
     }
 
-    private Task RestoreAfterAbortedCloseAsync(
-        Project project,
-        CoreObject? selectedObject,
-        bool projectClosed)
+    private Task QueueProjectChange(Project? @new, Project? old)
     {
-        if (projectClosed || !ReferenceEquals(_projectService.CurrentProject.Value, project))
+        Task previous;
+        var completion = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        lock (_projectChangeGate)
         {
-            return Task.CompletedTask;
+            ObjectDisposedException.ThrowIf(_disposed != 0, this);
+            previous = _projectChangeTask;
+            _projectChangeTask = completion.Task;
         }
-
-        return QueueOperationAsync(async () =>
-        {
-            await DispatchProjectChangeAsync(project, null);
-            if (selectedObject is ProjectItem selectedItem && project.Items.Contains(selectedItem))
-            {
-                await DispatchAsync(() => _editorService.ActivateTabItem(selectedItem));
-            }
-        });
+        _ = AwaitPreviousAndApplyAsync(previous, @new, old, completion);
+        return completion.Task;
     }
 
-    private static async Task DispatchAsync(Action action)
+    private async Task AwaitPreviousAndApplyAsync(
+        Task previous,
+        Project? @new,
+        Project? old,
+        TaskCompletionSource completion)
     {
-        if (Dispatcher.UIThread.CheckAccess())
+        try
         {
-            action();
+            await previous;
         }
-        else
+        catch (Exception ex)
         {
-            await Dispatcher.UIThread.InvokeAsync(action);
+            _logger.LogError(ex, "A previous project change failed before the next change could run.");
+        }
+
+        try
+        {
+            await RunOnUiThreadAsync(() => OnProjectChangedAsync(@new, old));
+            completion.TrySetResult();
+        }
+        catch (Exception ex)
+        {
+            completion.TrySetException(ex);
         }
     }
 
@@ -97,56 +80,27 @@ public class EditorHostViewModel
 
     private async Task OnProjectChangedAsync(Project? @new, Project? old)
     {
-        var oldItems = _editorService.TabItems.ToArray();
+        _activeProjectItems = @new?.Items;
+        if (old is not null)
+        {
+            old.Items.CollectionChanged -= Project_Items_CollectionChanged;
+        }
+
+        if (@new is not null)
+        {
+            @new.Items.CollectionChanged += Project_Items_CollectionChanged;
+        }
+
         try
         {
-            try
-            {
-                _editorService.ClearTabItems();
-
-                if (old != null)
-                {
-                    UnsubscribeFromProject(old);
-                }
-
-                if (@new != null)
-                {
-                    SubscribeToProject(@new);
-                    foreach (ProjectItem item in @new.Items)
-                    {
-                        _editorService.ActivateTabItem(item);
-                    }
-                }
-            }
-            finally
-            {
-                foreach (var item in oldItems)
-                {
-                    // Capture FilePath before DisposeAsync nulls out the underlying context.
-                    var filePath = item.FilePath.Value;
-                    try
-                    {
-                        await item.DisposeAsync();
-                    }
-                    catch (OperationCanceledException)
-                    {
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger.LogError(ex, "Failed to dispose editor tab item. FilePath={FilePath}", filePath);
-                    }
-                }
-            }
-        }
-        catch (OperationCanceledException)
-        {
+            CoreObject[] items = @new?.Items.Cast<CoreObject>().ToArray() ?? [];
+            await _editorService.ReconcileTabItemsAsync(items);
         }
         catch (Exception ex)
         {
             _logger.LogError(
                 ex,
-                "Unhandled exception in {Method}. OldProject={OldProject} NewProject={NewProject}",
-                nameof(OnProjectChangedAsync),
+                "Failed to reconcile editor tabs while changing projects. OldProject={OldProject} NewProject={NewProject}",
                 SafeLocalPath(old?.Uri),
                 SafeLocalPath(@new?.Uri));
             NotificationService.ShowError(Strings.Project, MessageStrings.OperationFailed);
@@ -155,68 +109,92 @@ public class EditorHostViewModel
 
     private void Project_Items_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
     {
-        long generation;
-        lock (_operationGate)
-        {
-            generation = _subscriptionGeneration;
-        }
-
-        _ = QueueOperationAsync(() => HandleProjectItemsChangedAsync(sender, e, generation));
+        ProjectItemsChange change = ProjectItemsChange.Capture(sender, e);
+        QueueProjectItemChange(sender, change);
     }
 
-    private async Task HandleProjectItemsChangedAsync(
-        object? sender,
-        NotifyCollectionChangedEventArgs e,
-        long generation)
+    private void QueueProjectItemChange(object? sender, ProjectItemsChange change)
     {
-        lock (_operationGate)
+        Task previous;
+        var completion = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        lock (_projectChangeGate)
         {
-            if (generation != _subscriptionGeneration
-                || _subscribedProject is null
-                || !ReferenceEquals(sender, _subscribedProject.Items))
-            {
+            if (_disposed != 0)
                 return;
-            }
+
+            previous = _projectChangeTask;
+            _projectChangeTask = completion.Task;
+        }
+        _ = AwaitPreviousAndHandleItemsAsync(previous, sender, change, completion);
+    }
+
+    private async Task AwaitPreviousAndHandleItemsAsync(
+        Task previous,
+        object? sender,
+        ProjectItemsChange change,
+        TaskCompletionSource completion)
+    {
+        try
+        {
+            await previous;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "A previous project change failed before an item change could run.");
+        }
+
+        if (!ReferenceEquals(sender, _activeProjectItems))
+        {
+            completion.TrySetResult();
+            return;
         }
 
         try
         {
-            if (e.Action == NotifyCollectionChangedAction.Add &&
-                e.NewItems != null)
+            await RunOnUiThreadAsync(() => HandleProjectItemsChangedAsync(change));
+            completion.TrySetResult();
+        }
+        catch (Exception ex)
+        {
+            completion.TrySetException(ex);
+        }
+    }
+
+    private static async Task RunOnUiThreadAsync(Func<Task> action)
+    {
+        if (Dispatcher.UIThread.CheckAccess())
+        {
+            await action();
+        }
+        else
+        {
+            await Dispatcher.UIThread.InvokeAsync(action);
+        }
+    }
+
+    private async Task HandleProjectItemsChangedAsync(ProjectItemsChange change)
+    {
+        try
+        {
+            if (change.Action == NotifyCollectionChangedAction.Add)
             {
-                foreach (ProjectItem item in e.NewItems.OfType<ProjectItem>())
+                foreach (ProjectItem item in change.NewItems)
                 {
                     _editorService.ActivateTabItem(item);
                 }
             }
-            else if (e.Action == NotifyCollectionChangedAction.Remove &&
-                     e.OldItems != null)
+            else if (change.Action == NotifyCollectionChangedAction.Remove)
             {
-                foreach (ProjectItem item in e.OldItems.OfType<ProjectItem>())
-                {
-                    try
-                    {
-                        await _editorService.CloseTabItem(item);
-                    }
-                    catch (OperationCanceledException)
-                    {
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger.LogError(
-                            ex,
-                            "Failed to close tab for removed project item. FilePath={FilePath}",
-                            SafeLocalPath(item.Uri));
-                    }
-                }
+                await CloseProjectItemsAsync(change.OldItems);
             }
-            else
+            else if (change.Action == NotifyCollectionChangedAction.Replace)
             {
-                _logger.LogWarning(
-                    "Unhandled project items collection change. Action={Action} NewCount={NewCount} OldCount={OldCount}",
-                    e.Action,
-                    e.NewItems?.Count,
-                    e.OldItems?.Count);
+                await _editorService.ReconcileTabItemsAsync(change.CurrentItems);
+            }
+            else if (change.Action == NotifyCollectionChangedAction.Reset)
+            {
+                await _editorService.ReconcileTabItemsAsync(change.CurrentItems);
             }
         }
         catch (OperationCanceledException)
@@ -228,89 +206,144 @@ public class EditorHostViewModel
                 ex,
                 "Unhandled exception in {Method}. Action={Action}",
                 nameof(HandleProjectItemsChangedAsync),
-                e.Action);
+                change.Action);
             NotificationService.ShowError(Strings.Project, MessageStrings.OperationFailed);
         }
     }
 
-    private Task QueueOperationAsync(Func<Task> operation)
+    private async Task CloseProjectItemsAsync(IEnumerable<ProjectItem> items)
     {
-        ArgumentNullException.ThrowIfNull(operation);
-        Task previous;
-        TaskCompletionSource completion = new(
-            TaskCreationOptions.RunContinuationsAsynchronously);
-        lock (_operationGate)
-        {
-            previous = _operationTail;
-            _operationTail = completion.Task;
-        }
-
-        _ = CompleteOperationAsync(previous, operation, completion);
-        return completion.Task;
-    }
-
-    private async Task CompleteOperationAsync(
-        Task previous,
-        Func<Task> operation,
-        TaskCompletionSource completion)
-    {
-        try
+        foreach (ProjectItem item in items)
         {
             try
             {
-                await previous;
+                await _editorService.CloseTabItem(item);
+            }
+            catch (OperationCanceledException)
+            {
             }
             catch (Exception ex)
             {
                 _logger.LogError(
                     ex,
-                    "A previous editor-host operation failed before the next operation ran.");
+                    "Failed to close tab for removed project item. FilePath={FilePath}",
+                    SafeLocalPath(item.Uri));
+            }
+        }
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        Task task;
+        TaskCompletionSource? completion = null;
+        lock (_projectChangeGate)
+        {
+            if (_disposeTask is null)
+            {
+                completion = new TaskCompletionSource(
+                    TaskCreationOptions.RunContinuationsAsynchronously);
+                _disposeTask = completion.Task;
             }
 
-            await operation();
-            completion.TrySetResult();
+            task = _disposeTask;
         }
-        catch (OperationCanceledException ex)
+
+        if (completion is not null)
         {
-            completion.TrySetCanceled(ex.CancellationToken);
+            _ = DisposeCoreAsync(completion);
+        }
+
+        return new ValueTask(task);
+    }
+
+    private async Task DisposeCoreAsync(TaskCompletionSource completion)
+    {
+        Exception? failure = null;
+        try
+        {
+            await _projectChangeRegistration.BeginDisposeAsync();
+
+            Task pending;
+            lock (_projectChangeGate)
+            {
+                _disposed = 1;
+                pending = _projectChangeTask;
+            }
+
+            await pending;
+            await RunOnUiThreadAsync(async () =>
+            {
+                DetachActiveProjectItems();
+                await _editorService.ReconcileTabItemsAsync([]);
+            });
         }
         catch (Exception ex)
         {
-            completion.TrySetException(ex);
+            failure = ex;
+            lock (_projectChangeGate)
+            {
+                _disposed = 1;
+            }
+
+            try
+            {
+                await RunOnUiThreadAsync(async () =>
+                {
+                    DetachActiveProjectItems();
+                    await _editorService.ReconcileTabItemsAsync([]);
+                });
+            }
+            catch (Exception cleanupEx)
+            {
+                failure = new AggregateException(ex, cleanupEx);
+            }
+        }
+        finally
+        {
+            _projectChangeRegistration.CompleteDispose();
+            if (failure is null)
+                completion.TrySetResult();
+            else
+                completion.TrySetException(failure);
         }
     }
 
-    private void SubscribeToProject(Project project)
+    private void DetachActiveProjectItems()
     {
-        lock (_operationGate)
+        if (_activeProjectItems is INotifyCollectionChanged items)
         {
-            if (ReferenceEquals(_subscribedProject, project))
-            {
-                return;
-            }
+            items.CollectionChanged -= Project_Items_CollectionChanged;
+        }
 
-            if (_subscribedProject is { } previous)
-            {
-                previous.Items.CollectionChanged -= Project_Items_CollectionChanged;
-            }
+        _activeProjectItems = null;
+    }
 
-            project.Items.CollectionChanged += Project_Items_CollectionChanged;
-            _subscribedProject = project;
-            _subscriptionGeneration++;
+    private readonly record struct ProjectItemsChange(
+        NotifyCollectionChangedAction Action,
+        ProjectItem[] NewItems,
+        ProjectItem[] OldItems,
+        ProjectItem[] CurrentItems)
+    {
+        public static ProjectItemsChange Capture(object? sender, NotifyCollectionChangedEventArgs args)
+        {
+            ProjectItem[] newItems = args.NewItems?.OfType<ProjectItem>().ToArray() ?? [];
+            ProjectItem[] oldItems = args.OldItems?.OfType<ProjectItem>().ToArray() ?? [];
+            ProjectItem[] currentItems = (args.Action is
+                NotifyCollectionChangedAction.Reset or NotifyCollectionChangedAction.Replace)
+                && sender is IEnumerable<ProjectItem> items
+                    ? items.ToArray()
+                    : [];
+            return new ProjectItemsChange(args.Action, newItems, oldItems, currentItems);
         }
     }
 
-    private void UnsubscribeFromProject(Project project)
+    private sealed class ProjectChangeHandler(EditorHostViewModel owner) : IProjectChangeHandler
     {
-        lock (_operationGate)
-        {
-            if (ReferenceEquals(_subscribedProject, project))
-            {
-                project.Items.CollectionChanged -= Project_Items_CollectionChanged;
-                _subscribedProject = null;
-                _subscriptionGeneration++;
-            }
-        }
+        public Task ApplyProjectChangeAsync(Project? @new, Project? old)
+            => owner.QueueProjectChange(@new, old);
+
+        public Task WaitForPendingProjectChangesAsync()
+            => owner.WaitForPendingProjectChangesAsync();
     }
 
     // Uri.LocalPath throws InvalidOperationException for relative URIs; protect log

--- a/src/Beutl/ViewModels/EditorHostViewModel.cs
+++ b/src/Beutl/ViewModels/EditorHostViewModel.cs
@@ -102,8 +102,7 @@ public class EditorHostViewModel
         {
             try
             {
-                _editorService.SelectedTabItem.Value = null;
-                _editorService.TabItems.Clear();
+                _editorService.ClearTabItems();
 
                 if (old != null)
                 {

--- a/src/Beutl/ViewModels/EditorHostViewModel.cs
+++ b/src/Beutl/ViewModels/EditorHostViewModel.cs
@@ -76,7 +76,7 @@ public class EditorHostViewModel : IAsyncDisposable
         }
     }
 
-    public IReactiveProperty<EditorTabItem?> SelectedTabItem => _editorService.SelectedTabItem;
+    public IReadOnlyReactiveProperty<EditorTabItem?> SelectedTabItem => _editorService.SelectedTabItem;
 
     private async Task OnProjectChangedAsync(Project? @new, Project? old)
     {
@@ -181,7 +181,7 @@ public class EditorHostViewModel : IAsyncDisposable
             {
                 foreach (ProjectItem item in change.NewItems)
                 {
-                    _editorService.ActivateTabItem(item);
+                    await _editorService.ActivateTabItemAsync(item);
                 }
             }
             else if (change.Action == NotifyCollectionChangedAction.Remove)

--- a/src/Beutl/ViewModels/EditorHostViewModel.cs
+++ b/src/Beutl/ViewModels/EditorHostViewModel.cs
@@ -339,6 +339,25 @@ public class EditorHostViewModel : IAsyncDisposable
 
     private sealed class ProjectChangeHandler(EditorHostViewModel owner) : IProjectChangeHandler
     {
+        public async Task ApplyProjectCloseAsync(ProjectService.ProjectCloseContext context)
+        {
+            Project? project = owner._projectService.CurrentProject.Value;
+            CoreObject? selected = owner._editorService.SelectedTabItem.Value?.Context.Value?.Object;
+            if (project is not null)
+            {
+                context.RegisterCompletion(async closed =>
+                {
+                    if (!closed && ReferenceEquals(owner._projectService.CurrentProject.Value, project))
+                    {
+                        await owner.QueueProjectChange(project, null);
+                        if (selected is ProjectItem item && project.Items.Contains(item))
+                            await RunOnUiThreadAsync(async () => await owner._editorService.ActivateTabItemAsync(item));
+                    }
+                });
+            }
+            await owner.QueueProjectChange(null, project);
+        }
+
         public Task ApplyProjectChangeAsync(Project? @new, Project? old)
             => owner.QueueProjectChange(@new, old);
 

--- a/src/Beutl/ViewModels/Editors/GraphModelEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/GraphModelEditorViewModel.cs
@@ -83,7 +83,7 @@ public sealed class GraphModelEditorViewModel : ValueEditorViewModel<GraphModel?
         }
     }
 
-    public void OpenNodeGraphTab()
+    public async void OpenNodeGraphTab()
     {
         if (this.GetService<IEditorContext>() is not { } editorContext) return;
         if (Value.Value == null) return;
@@ -97,7 +97,7 @@ public sealed class GraphModelEditorViewModel : ValueEditorViewModel<GraphModel?
 
         tab.Model.Value = Value.Value;
 
-        editorContext.OpenToolTab(tab);
+        await editorContext.OpenToolTabAsync(tab);
     }
 
     protected override void Dispose(bool disposing)

--- a/src/Beutl/ViewModels/Editors/GraphModelEditorViewModel.cs
+++ b/src/Beutl/ViewModels/Editors/GraphModelEditorViewModel.cs
@@ -83,7 +83,7 @@ public sealed class GraphModelEditorViewModel : ValueEditorViewModel<GraphModel?
         }
     }
 
-    public async void OpenNodeGraphTab()
+    public async Task OpenNodeGraphTabAsync()
     {
         if (this.GetService<IEditorContext>() is not { } editorContext) return;
         if (Value.Value == null) return;

--- a/src/Beutl/ViewModels/MainViewModel.cs
+++ b/src/Beutl/ViewModels/MainViewModel.cs
@@ -323,6 +323,15 @@ public sealed class MainViewModel : BasePageViewModel, IContextCommandHandler
             await DisposeCoreAsync();
             completion.TrySetResult();
         }
+        catch (ProjectCloseAbortedException ex)
+        {
+            lock (_disposeGate)
+            {
+                if (ReferenceEquals(_disposeTask, completion.Task))
+                    _disposeTask = null;
+            }
+            completion.TrySetException(ex);
+        }
         catch (Exception ex)
         {
             completion.TrySetException(ex);
@@ -392,6 +401,7 @@ public sealed class MainViewModel : BasePageViewModel, IContextCommandHandler
 
     private async Task DisposeCoreAsync()
     {
+        await _projectService.CloseProjectAsync();
         try
         {
             PackageInstaller packageInstaller = _beutlClients.GetResource<PackageInstaller>();

--- a/src/Beutl/ViewModels/MainViewModel.cs
+++ b/src/Beutl/ViewModels/MainViewModel.cs
@@ -290,23 +290,49 @@ public sealed class MainViewModel : BasePageViewModel, IContextCommandHandler
     }
 
     public override void Dispose()
+        => _ = GetOrStartDisposal();
+
+    /// <summary>Disposes the application composition root and joins editor teardown.</summary>
+    public ValueTask DisposeAsync()
+        => new(GetOrStartDisposal());
+
+    private Task GetOrStartDisposal()
+    {
+        TaskCompletionSource? completion = null;
+        Task task;
+        lock (_disposeGate)
+        {
+            if (_disposeTask is null)
+            {
+                completion = new TaskCompletionSource(
+                    TaskCreationOptions.RunContinuationsAsynchronously);
+                _disposeTask = completion.Task;
+            }
+            task = _disposeTask;
+        }
+
+        if (completion is not null)
+            _ = CompleteDisposalAsync(completion);
+        return task;
+    }
+
+    private async Task CompleteDisposalAsync(TaskCompletionSource completion)
     {
         try
         {
-            BeginDisposeOrThrow();
+            await DisposeCoreAsync();
+            completion.TrySetResult();
         }
-        catch (ProjectCloseAbortedException)
+        catch (Exception ex)
         {
+            completion.TrySetException(ex);
         }
     }
 
     private void BeginDisposeOrThrow()
     {
         _projectService.CloseProjectOrThrow();
-        lock (_disposeGate)
-        {
-            _disposeTask ??= DisposeCoreAsync();
-        }
+        _ = GetOrStartDisposal();
     }
 
     internal bool TryDisposeForWindowClose()
@@ -327,6 +353,40 @@ public sealed class MainViewModel : BasePageViewModel, IContextCommandHandler
         lock (_disposeGate)
         {
             return _disposeTask ?? Task.CompletedTask;
+        }
+    }
+
+    internal static async Task DisposeComponentsAsync(
+        Action disposeCommandPalette,
+        Action stopAgentHost,
+        Func<Task> closeProject,
+        Func<ValueTask> disposeEditorHost,
+        Action clearApplicationItems)
+    {
+        List<Exception>? failures = null;
+        Try(disposeCommandPalette);
+        Try(stopAgentHost);
+        await TryAsync(closeProject);
+        await TryAsync(async () => await disposeEditorHost());
+        Try(clearApplicationItems);
+
+        if (failures is not null)
+        {
+            throw failures.Count == 1
+                ? failures[0]
+                : new AggregateException(failures);
+        }
+
+        void Try(Action action)
+        {
+            try { action(); }
+            catch (Exception ex) { (failures ??= []).Add(ex); }
+        }
+
+        async Task TryAsync(Func<Task> action)
+        {
+            try { await action(); }
+            catch (Exception ex) { (failures ??= []).Add(ex); }
         }
     }
 

--- a/src/Beutl/ViewModels/MainViewModel.cs
+++ b/src/Beutl/ViewModels/MainViewModel.cs
@@ -26,7 +26,7 @@ using Reactive.Bindings;
 
 namespace Beutl.ViewModels;
 
-public sealed class MainViewModel : BasePageViewModel, IContextCommandHandler
+public sealed class MainViewModel : BasePageViewModel, IContextCommandHandler, IAsyncDisposable
 {
     internal readonly BeutlApiApplication _beutlClients;
     private readonly HttpClient _authHttpClient;
@@ -338,17 +338,11 @@ public sealed class MainViewModel : BasePageViewModel, IContextCommandHandler
         }
     }
 
-    private void BeginDisposeOrThrow()
-    {
-        _projectService.CloseProjectOrThrow();
-        _ = GetOrStartDisposal();
-    }
-
-    internal bool TryDisposeForWindowClose()
+    internal async Task<bool> TryDisposeForWindowCloseAsync()
     {
         try
         {
-            BeginDisposeOrThrow();
+            await DisposeAsync();
             return true;
         }
         catch (ProjectCloseAbortedException)
@@ -401,7 +395,18 @@ public sealed class MainViewModel : BasePageViewModel, IContextCommandHandler
 
     private async Task DisposeCoreAsync()
     {
-        await _projectService.CloseProjectAsync();
+        try
+        {
+            await _projectService.CloseProjectAsync();
+        }
+        catch (ProjectCloseAbortedException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to close the active project during shutdown.");
+        }
         try
         {
             PackageInstaller packageInstaller = _beutlClients.GetResource<PackageInstaller>();
@@ -533,14 +538,14 @@ public sealed class MainViewModel : BasePageViewModel, IContextCommandHandler
             workspace = CreateAiWorkspaceViewModel(editorContext);
             if (!await TryOpenNewAiWorkspaceAsync(
                     workspace,
-                    () => editorContext.OpenToolTab(workspace)))
+                    () => editorContext.OpenToolTabAsync(workspace)))
             {
                 return null;
             }
         }
         else
         {
-            if (!editorContext.OpenToolTab(workspace))
+            if (!await editorContext.OpenToolTabAsync(workspace))
             {
                 return null;
             }
@@ -562,11 +567,11 @@ public sealed class MainViewModel : BasePageViewModel, IContextCommandHandler
 
     internal static async Task<bool> TryOpenNewAiWorkspaceAsync(
         AiWorkspaceViewModel workspace,
-        Func<bool> tryOpen)
+        Func<ValueTask<bool>> tryOpen)
     {
         ArgumentNullException.ThrowIfNull(workspace);
         ArgumentNullException.ThrowIfNull(tryOpen);
-        if (tryOpen())
+        if (await tryOpen())
             return true;
 
         await workspace.DisposeAsync();
@@ -679,36 +684,13 @@ public sealed class MainViewModel : BasePageViewModel, IContextCommandHandler
 
     private async Task CloseEditorSessionAsync()
     {
-        EditorTabItem[] tabs = _editorService.TabItems.ToArray();
         try
         {
-            _editorService.SelectedTabItem.Value = null;
-            _editorService.TabItems.Clear();
+            await EditorHost.DisposeAsync();
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to unpublish editor tabs during shutdown.");
-        }
-
-        foreach (EditorTabItem tab in tabs)
-        {
-            try
-            {
-                await tab.DisposeAsync();
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Failed to dispose an editor tab during shutdown.");
-            }
-        }
-
-        try
-        {
-            _projectService.CloseProject();
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to close the active project during shutdown.");
+            _logger.LogError(ex, "Failed to drain editor services during shutdown.");
         }
     }
 

--- a/src/Beutl/ViewModels/MenuBarViewModel.Files.cs
+++ b/src/Beutl/ViewModels/MenuBarViewModel.Files.cs
@@ -61,7 +61,7 @@ public partial class MenuBarViewModel
             item => RecentProjectItems.Remove(item),
             RecentProjectItems.Clear);
 
-        OpenRecentFile.Subscribe(OpenFileCore);
+        OpenRecentFile.Subscribe(async file => await OpenFileCore(file));
 
         OpenRecentProject.Subscribe(async file =>
         {
@@ -257,7 +257,7 @@ public partial class MenuBarViewModel
             item.FileName.Value);
     }
 
-    internal void OpenFileCore(string file)
+    internal async Task OpenFileCore(string file)
     {
         try
         {
@@ -275,11 +275,11 @@ public partial class MenuBarViewModel
                 ProjectPersistence.AddItemAndPersist(project, projItem);
             }
 
-            _editorService.ActivateTabItem(projItem);
+            await _editorService.ActivateTabItemAsync(projItem);
         }
         catch (Exception ex)
         {
-            _ = ex.Handle();
+            await ex.Handle();
         }
     }
 

--- a/src/Beutl/ViewModels/MenuBarViewModel.Files.cs
+++ b/src/Beutl/ViewModels/MenuBarViewModel.Files.cs
@@ -26,8 +26,8 @@ public partial class MenuBarViewModel
         CloseFileCore = new ReactiveCommandSlim<EditorTabItem>()
             .WithSubscribe(OnCloseFileCore);
 
-        CloseProject = new ReactiveCommandSlim(IsProjectOpened)
-            .WithSubscribe(CloseProjectCore);
+        CloseProject = new AsyncReactiveCommand(IsProjectOpened)
+            .WithSubscribe(_projectService.CloseProjectAsync);
 
         Save = new AsyncReactiveCommand(IsProjectOpened)
             .WithSubscribe(OnSave);
@@ -95,7 +95,7 @@ public partial class MenuBarViewModel
 
     public ReactiveCommandSlim CloseFile { get; private set; }
 
-    public ReactiveCommandSlim CloseProject { get; private set; }
+    public AsyncReactiveCommand CloseProject { get; private set; }
 
     public AsyncReactiveCommand Save { get; private set; }
 

--- a/src/Beutl/ViewModels/MenuBarViewModel.Files.cs
+++ b/src/Beutl/ViewModels/MenuBarViewModel.Files.cs
@@ -27,7 +27,7 @@ public partial class MenuBarViewModel
             .WithSubscribe(OnCloseFileCore);
 
         CloseProject = new AsyncReactiveCommand(IsProjectOpened)
-            .WithSubscribe(_projectService.CloseProjectAsync);
+            .WithSubscribe(CloseProjectCore);
 
         Save = new AsyncReactiveCommand(IsProjectOpened)
             .WithSubscribe(OnSave);
@@ -119,11 +119,11 @@ public partial class MenuBarViewModel
 
     public AsyncReactiveCommand ImportProject { get; } = new();
 
-    private void CloseProjectCore()
+    private async Task CloseProjectCore()
     {
         try
         {
-            _projectService.CloseProject();
+            await _projectService.CloseProjectAsync();
         }
         catch (ProjectCloseAbortedException)
         {

--- a/src/Beutl/ViewModels/MenuBarViewModel.Files.cs
+++ b/src/Beutl/ViewModels/MenuBarViewModel.Files.cs
@@ -61,7 +61,7 @@ public partial class MenuBarViewModel
             item => RecentProjectItems.Remove(item),
             RecentProjectItems.Clear);
 
-        OpenRecentFile.Subscribe(async file => await OpenFileCore(file));
+        OpenRecentFile.Subscribe(file => { _ = OpenFileCore(file); });
 
         OpenRecentProject.Subscribe(async file =>
         {

--- a/src/Beutl/ViewModels/MenuBarViewModel.Scene.cs
+++ b/src/Beutl/ViewModels/MenuBarViewModel.Scene.cs
@@ -36,7 +36,7 @@ public partial class MenuBarViewModel
         PasteLayer = new AsyncReactiveCommand(isSceneOpened)
             .WithSubscribe(OnPasteElement);
 
-        ShowSceneSettings = new ReactiveCommandSlim(isSceneOpened)
+        ShowSceneSettings = new AsyncReactiveCommand(isSceneOpened)
             .WithSubscribe(OnShowSceneSettings);
     }
 
@@ -65,7 +65,7 @@ public partial class MenuBarViewModel
 
     public AsyncReactiveCommand PasteLayer { get; private set; }
 
-    public ReactiveCommandSlim ShowSceneSettings { get; private set; }
+    public AsyncReactiveCommand ShowSceneSettings { get; private set; }
 
     private bool TryGetSelectedEditViewModel([NotNullWhen(true)] out EditViewModel? viewModel)
     {
@@ -133,7 +133,7 @@ public partial class MenuBarViewModel
             : Task.CompletedTask;
     }
 
-    private void OnShowSceneSettings()
+    private async Task OnShowSceneSettings()
     {
         if (TryGetSelectedEditViewModel(out EditViewModel? viewModel))
         {
@@ -144,7 +144,7 @@ public partial class MenuBarViewModel
             }
             else
             {
-                viewModel.OpenToolTab(new SceneSettingsTabViewModel(viewModel));
+                await viewModel.OpenToolTabAsync(new SceneSettingsTabViewModel(viewModel));
             }
         }
     }

--- a/src/Beutl/ViewModels/MenuBarViewModel.View.cs
+++ b/src/Beutl/ViewModels/MenuBarViewModel.View.cs
@@ -12,14 +12,14 @@ public partial class MenuBarViewModel
     private void InitializeViewCommands(IObservable<bool> isSceneOpened)
     {
         ResetDockLayout = new ReactiveCommandSlim(isSceneOpened)
-            .WithSubscribe(OnResetDockLayout);
+            .WithSubscribe(async () => await OnResetDockLayoutAsync());
 
         ApplyDockLayout = new ReactiveCommandSlim<DockLayoutPresetItem>(isSceneOpened)
-            .WithSubscribe(OnApplyDockLayout);
+            .WithSubscribe(async preset => await OnApplyDockLayoutAsync(preset));
 
         // Saving, renaming and deleting live in the dock layout tool tab.
         OpenDockLayoutTab = new ReactiveCommandSlim(isSceneOpened)
-            .WithSubscribe(OnOpenDockLayoutTab);
+            .WithSubscribe(async () => await OnOpenDockLayoutTabAsync());
     }
 
     // View
@@ -34,15 +34,15 @@ public partial class MenuBarViewModel
 
     public ICoreList<DockLayoutPresetItem> DockLayoutPresets => DockLayoutPresetService.Instance.Items;
 
-    private void OnResetDockLayout()
+    private async Task OnResetDockLayoutAsync()
     {
         if (TryGetSelectedEditViewModel(out EditViewModel? viewModel))
         {
-            viewModel.DockHost.ResetLayout();
+            await viewModel.DockHost.ResetLayoutAsync();
         }
     }
 
-    private void OnOpenDockLayoutTab()
+    private async Task OnOpenDockLayoutTabAsync()
     {
         if (!TryGetSelectedEditViewModel(out EditViewModel? viewModel)) return;
 
@@ -53,18 +53,16 @@ public partial class MenuBarViewModel
         }
 
         if (DockLayoutTabExtension.Instance.TryCreateContext(viewModel, out IToolContext? context)
-            && !viewModel.OpenToolTab(context))
-        {
-            context.Dispose();
-        }
+            )
+            await viewModel.DockHost.OpenToolTabAsync(context);
     }
 
-    private void OnApplyDockLayout(DockLayoutPresetItem? preset)
+    private async Task OnApplyDockLayoutAsync(DockLayoutPresetItem? preset)
     {
         if (preset is null) return;
         if (!TryGetSelectedEditViewModel(out EditViewModel? viewModel)) return;
 
-        if (viewModel.DockHost.ApplyLayout(preset.Layout))
+        if (await viewModel.DockHost.ApplyLayoutAsync(preset.Layout))
         {
             _logger.LogInformation("Applied dock layout preset '{Name}'.", preset.Name.Value);
         }

--- a/src/Beutl/ViewModels/MenuBarViewModel.View.cs
+++ b/src/Beutl/ViewModels/MenuBarViewModel.View.cs
@@ -12,14 +12,14 @@ public partial class MenuBarViewModel
     private void InitializeViewCommands(IObservable<bool> isSceneOpened)
     {
         ResetDockLayout = new ReactiveCommandSlim(isSceneOpened)
-            .WithSubscribe(async () => await OnResetDockLayoutAsync());
+            .WithSubscribe(async () => await Beutl.Editor.Components.Helpers.ToolTabCallback.RunAsync(OnResetDockLayoutAsync));
 
         ApplyDockLayout = new ReactiveCommandSlim<DockLayoutPresetItem>(isSceneOpened)
-            .WithSubscribe(async preset => await OnApplyDockLayoutAsync(preset));
+            .WithSubscribe(async preset => await Beutl.Editor.Components.Helpers.ToolTabCallback.RunAsync(() => OnApplyDockLayoutAsync(preset)));
 
         // Saving, renaming and deleting live in the dock layout tool tab.
         OpenDockLayoutTab = new ReactiveCommandSlim(isSceneOpened)
-            .WithSubscribe(async () => await OnOpenDockLayoutTabAsync());
+            .WithSubscribe(async () => await Beutl.Editor.Components.Helpers.ToolTabCallback.RunAsync(OnOpenDockLayoutTabAsync));
     }
 
     // View
@@ -53,7 +53,7 @@ public partial class MenuBarViewModel
         }
 
         if (DockLayoutTabExtension.Instance.TryCreateContext(viewModel, out IToolContext? context)
-            )
+            && context is not null)
             await viewModel.DockHost.OpenToolTabAsync(context);
     }
 

--- a/src/Beutl/ViewModels/PlayerViewModel.cs
+++ b/src/Beutl/ViewModels/PlayerViewModel.cs
@@ -117,7 +117,7 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
             .DisposeWith(_disposables);
 
         Next = new ReactiveCommand(_isEnabled)
-            .WithSubscribe(() =>
+            .WithSubscribe(async () =>
             {
                 int rate = GetFrameRate();
                 UpdateCurrentFrame(_editorClock.CurrentTime.Value + TimeSpan.FromSeconds(1d / rate));
@@ -125,7 +125,7 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
             .DisposeWith(_disposables);
 
         Previous = new ReactiveCommand(_isEnabled)
-            .WithSubscribe(() =>
+            .WithSubscribe(async () =>
             {
                 int rate = GetFrameRate();
                 UpdateCurrentFrame(_editorClock.CurrentTime.Value - TimeSpan.FromSeconds(1d / rate));
@@ -133,7 +133,7 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
             .DisposeWith(_disposables);
 
         Start = new ReactiveCommand(_isEnabled)
-            .WithSubscribe(() =>
+            .WithSubscribe(async () =>
             {
                 int rate = GetFrameRate();
                 var endTime = Scene.Start + Scene.Duration - TimeSpan.FromSeconds(1d / rate);
@@ -245,7 +245,7 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
             .DisposeWith(_disposables);
 
         OpenPreviewSettings = new ReactiveCommand()
-            .WithSubscribe(() =>
+            .WithSubscribe(async () =>
             {
                 if (_editViewModel.FindToolTab<PreviewSettingsTabViewModel>() is { } tab)
                 {
@@ -253,7 +253,7 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
                 }
                 else
                 {
-                    _editViewModel.OpenToolTab(new PreviewSettingsTabViewModel(_editViewModel));
+                    await _editViewModel.OpenToolTabAsync(new PreviewSettingsTabViewModel(_editViewModel));
                 }
             })
             .DisposeWith(_disposables);

--- a/src/Beutl/ViewModels/PlayerViewModel.cs
+++ b/src/Beutl/ViewModels/PlayerViewModel.cs
@@ -117,7 +117,7 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
             .DisposeWith(_disposables);
 
         Next = new ReactiveCommand(_isEnabled)
-            .WithSubscribe(async () =>
+            .WithSubscribe(() =>
             {
                 int rate = GetFrameRate();
                 UpdateCurrentFrame(_editorClock.CurrentTime.Value + TimeSpan.FromSeconds(1d / rate));
@@ -125,7 +125,7 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
             .DisposeWith(_disposables);
 
         Previous = new ReactiveCommand(_isEnabled)
-            .WithSubscribe(async () =>
+            .WithSubscribe(() =>
             {
                 int rate = GetFrameRate();
                 UpdateCurrentFrame(_editorClock.CurrentTime.Value - TimeSpan.FromSeconds(1d / rate));
@@ -133,7 +133,7 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
             .DisposeWith(_disposables);
 
         Start = new ReactiveCommand(_isEnabled)
-            .WithSubscribe(async () =>
+            .WithSubscribe(() =>
             {
                 int rate = GetFrameRate();
                 var endTime = Scene.Start + Scene.Duration - TimeSpan.FromSeconds(1d / rate);
@@ -244,7 +244,7 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
             })
             .DisposeWith(_disposables);
 
-        OpenPreviewSettings = new ReactiveCommand()
+        OpenPreviewSettings = new AsyncReactiveCommand()
             .WithSubscribe(async () =>
             {
                 if (_editViewModel.FindToolTab<PreviewSettingsTabViewModel>() is { } tab)
@@ -253,7 +253,8 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
                 }
                 else
                 {
-                    await _editViewModel.OpenToolTabAsync(new PreviewSettingsTabViewModel(_editViewModel));
+                    await Beutl.Editor.Components.Helpers.ToolTabCallback.OpenAsync(
+                        _editViewModel, new PreviewSettingsTabViewModel(_editViewModel));
                 }
             })
             .DisposeWith(_disposables);
@@ -467,7 +468,7 @@ public sealed class PlayerViewModel : IAsyncDisposable, IPreviewPlayer
 
     public ReactiveProperty<float> ToneMappingExposure { get; }
 
-    public ReactiveCommand OpenPreviewSettings { get; }
+    public AsyncReactiveCommand OpenPreviewSettings { get; }
 
     public event EventHandler? PreviewInvalidated;
 

--- a/src/Beutl/ViewModels/TitleBreadcrumbBarViewModel.cs
+++ b/src/Beutl/ViewModels/TitleBreadcrumbBarViewModel.cs
@@ -27,7 +27,7 @@ public class TitleBreadcrumbBarViewModel
 
     // TabItems
     // SelectedTabItem
-    public ICoreList<EditorTabItem> TabItems => _editorService.TabItems;
+    public ICoreReadOnlyList<EditorTabItem> TabItems => _editorService.TabItems;
 
     public IReactiveProperty<EditorTabItem?> SelectedTabItem => _editorService.SelectedTabItem;
 

--- a/src/Beutl/ViewModels/TitleBreadcrumbBarViewModel.cs
+++ b/src/Beutl/ViewModels/TitleBreadcrumbBarViewModel.cs
@@ -29,7 +29,10 @@ public class TitleBreadcrumbBarViewModel
     // SelectedTabItem
     public ICoreReadOnlyList<EditorTabItem> TabItems => _editorService.TabItems;
 
-    public IReactiveProperty<EditorTabItem?> SelectedTabItem => _editorService.SelectedTabItem;
+    public IReadOnlyReactiveProperty<EditorTabItem?> SelectedTabItem => _editorService.SelectedTabItem;
+
+    public bool ActivateTabItem(EditorTabItem item)
+        => _editorService.ActivateTabItem(item);
 
     public AsyncReactiveCommand OpenFile => _viewModel.MenuBar.OpenFile;
 

--- a/src/Beutl/ViewModels/Tools/DockLayoutViewModel.cs
+++ b/src/Beutl/ViewModels/Tools/DockLayoutViewModel.cs
@@ -82,12 +82,12 @@ public sealed class DockLayoutViewModel : IToolContext
     }
 
     /// <summary>Applies <paramref name="item"/>, or the selected layout when null.</summary>
-    public bool Apply(DockLayoutPresetItem? item = null)
+    public async Task<bool> ApplyAsync(DockLayoutPresetItem? item = null)
     {
         DockLayoutPresetItem? target = item ?? SelectedItem.Value;
         if (target is null) return false;
 
-        if (_editViewModel.DockHost.ApplyLayout(target.Layout))
+        if (await _editViewModel.DockHost.ApplyLayoutAsync(target.Layout))
         {
             _logger.LogInformation("Applied dock layout '{Name}'.", target.Name.Value);
             return true;
@@ -129,15 +129,17 @@ public sealed class DockLayoutViewModel : IToolContext
         return false;
     }
 
-    public void ResetLayout()
+    public Task ResetLayoutAsync()
     {
-        _editViewModel.DockHost.ResetLayout();
+        return _editViewModel.DockHost.ResetLayoutAsync();
     }
 
-    public void Dispose()
+    public ValueTask DisposeAsync()
     {
         _disposables.Dispose();
+        return ValueTask.CompletedTask;
     }
+
 
     public object? GetService(Type serviceType)
     {

--- a/src/Beutl/ViewModels/Tools/HistoryViewModel.cs
+++ b/src/Beutl/ViewModels/Tools/HistoryViewModel.cs
@@ -86,10 +86,12 @@ public sealed class HistoryViewModel : IToolContext
         await _editViewModel.RedoHistoryAsync();
     }
 
-    public void Dispose()
+    public ValueTask DisposeAsync()
     {
         _disposables.Dispose();
+        return ValueTask.CompletedTask;
     }
+
 
     public object? GetService(Type serviceType)
     {

--- a/src/Beutl/ViewModels/Tools/OutputTabViewModel.cs
+++ b/src/Beutl/ViewModels/Tools/OutputTabViewModel.cs
@@ -125,10 +125,12 @@ public class OutputTabViewModel : IToolContext
         _logger.LogInformation("Items saved successfully.");
     }
 
-    public void Dispose()
+    public ValueTask DisposeAsync()
     {
         _outputService.Dispose();
+        return ValueTask.CompletedTask;
     }
+
 
     public void WriteToJson(JsonObject json)
     {

--- a/src/Beutl/Views/Dock/ToolTabAddButton.cs
+++ b/src/Beutl/Views/Dock/ToolTabAddButton.cs
@@ -50,7 +50,7 @@ public sealed class ToolTabAddButton : Button
             IsEnabled = extension.CanMultiple || !factory.IsToolTabOpen(extension),
         };
 
-        item.Click += (_, _) => factory.OpenToolTab(extension, target);
+        item.Click += async (_, _) => await factory.OpenToolTabAsync(extension, target);
         return item;
     }
 }

--- a/src/Beutl/Views/Dock/ToolTabAddButton.cs
+++ b/src/Beutl/Views/Dock/ToolTabAddButton.cs
@@ -50,7 +50,7 @@ public sealed class ToolTabAddButton : Button
             IsEnabled = extension.CanMultiple || !factory.IsToolTabOpen(extension),
         };
 
-        item.Click += async (_, _) => await factory.OpenToolTabAsync(extension, target);
+        item.Click += async (_, _) => await Beutl.Editor.Components.Helpers.ToolTabCallback.RunAsync(() => factory.OpenToolTabAsync(extension, target));
         return item;
     }
 }

--- a/src/Beutl/Views/Editors/BrushEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/BrushEditor.axaml.cs
@@ -189,7 +189,7 @@ public sealed partial class BrushEditor : UserControl
         _flyout.ShowAt(this, true);
     }
 
-    private void OnEditDrawableClicked(object? sender, EventArgs e)
+    private async void OnEditDrawableClicked(object? sender, EventArgs e)
     {
         // TODO: DrawablePropertyEditorを開く
         // ObjectPropertyEditorは不要なプロパティも表示されてしまうので
@@ -202,7 +202,7 @@ public sealed partial class BrushEditor : UserControl
               ?? new ObjectPropertyTabViewModel(editViewModel);
 
         objViewModel.NavigateCore(drawable, false, viewModel);
-        editViewModel.OpenToolTab(objViewModel);
+        await editViewModel.OpenToolTabAsync(objViewModel);
     }
 
     private async void OnChangeDrawableClicked(object? sender, Button e)

--- a/src/Beutl/Views/Editors/CoreObjectEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/CoreObjectEditor.axaml.cs
@@ -55,7 +55,7 @@ public partial class CoreObjectEditor : UserControl
         }
     }
 
-    private void Navigate_Click(object? sender, RoutedEventArgs e)
+    private async void Navigate_Click(object? sender, RoutedEventArgs e)
     {
         if (DataContext is not ICoreObjectEditorViewModel { IsDisposed: false } viewModel) return;
         if (viewModel.GetService<EditViewModel>() is not { } editViewModel) return;
@@ -66,7 +66,7 @@ public partial class CoreObjectEditor : UserControl
               ?? new ObjectPropertyTabViewModel(editViewModel);
 
         objViewModel.NavigateCore(viewModel.Value.Value, false, viewModel);
-        editViewModel.OpenToolTab(objViewModel);
+        await editViewModel.OpenToolTabAsync(objViewModel);
     }
 
     private async void NewClick(object? sender, RoutedEventArgs e)

--- a/src/Beutl/Views/Editors/CurveMapEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/CurveMapEditor.axaml.cs
@@ -15,7 +15,7 @@ public partial class CurveMapEditor : UserControl
         InitializeComponent();
     }
 
-    private void OpenCurvesTab_Click(object? sender, RoutedEventArgs e)
+    private async void OpenCurvesTab_Click(object? sender, RoutedEventArgs e)
     {
         if (DataContext is CurveMapEditorViewModel { IsDisposed: false } viewModel
             && viewModel.GetService<EditViewModel>() is { } editViewModel
@@ -35,7 +35,7 @@ public partial class CurveMapEditor : UserControl
                 context.SelectCurveByPropertyName(prop.Name);
             }
 
-            editViewModel.OpenToolTab(context);
+            await editViewModel.OpenToolTabAsync(context);
         }
     }
 }

--- a/src/Beutl/Views/Editors/GraphModelEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/GraphModelEditor.axaml.cs
@@ -15,11 +15,11 @@ public partial class GraphModelEditor : UserControl
         InitializeComponent();
     }
 
-    private void OpenNodeGraphTab_Click(object? sender, RoutedEventArgs e)
+    private async void OpenNodeGraphTab_Click(object? sender, RoutedEventArgs e)
     {
         if (DataContext is GraphModelEditorViewModel { IsDisposed: false } viewModel)
         {
-            viewModel.OpenNodeGraphTab();
+            await Beutl.Editor.Components.Helpers.ToolTabCallback.RunAsync(viewModel.OpenNodeGraphTabAsync);
         }
     }
 }

--- a/src/Beutl/Views/Editors/NavigateButton.axaml.cs
+++ b/src/Beutl/Views/Editors/NavigateButton.axaml.cs
@@ -51,7 +51,7 @@ public partial class NavigateButton : UserControl
 public sealed class NavigateButton<T> : NavigateButton
     where T : ICoreObject
 {
-    protected override void OnNavigate()
+    protected override async void OnNavigate()
     {
         if (this.FindLogicalAncestorOfType<EditView>()?.DataContext is EditViewModel editViewModel
             && DataContext is NavigationButtonViewModel<T> { IsDisposed: false } viewModel)
@@ -61,7 +61,7 @@ public sealed class NavigateButton<T> : NavigateButton
                   ?? new ObjectPropertyTabViewModel(editViewModel);
 
             objViewModel.NavigateCore(viewModel.Value.Value, false, viewModel);
-            editViewModel.OpenToolTab(objViewModel);
+            await editViewModel.OpenToolTabAsync(objViewModel);
         }
     }
 

--- a/src/Beutl/Views/Editors/PathFigureListItemEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/PathFigureListItemEditor.axaml.cs
@@ -39,7 +39,7 @@ public partial class PathFigureListItemEditor : UserControl, IListItemEditor
         }
     }
 
-    private void EditInTabClicked(object? sender, RoutedEventArgs e)
+    private async void EditInTabClicked(object? sender, RoutedEventArgs e)
     {
         if (DataContext is PathFigureEditorViewModel { IsDisposed: false } viewModel
             && viewModel.GetService<EditViewModel>() is { } editViewModel)
@@ -60,7 +60,7 @@ public partial class PathFigureListItemEditor : UserControl, IListItemEditor
                 context.StartOrFinishEdit(viewModel);
             }
 
-            editViewModel.OpenToolTab(context);
+            await editViewModel.OpenToolTabAsync(context);
         }
     }
 

--- a/src/Beutl/Views/Editors/PropertyEditorMenu.axaml.cs
+++ b/src/Beutl/Views/Editors/PropertyEditorMenu.axaml.cs
@@ -83,7 +83,7 @@ public sealed partial class PropertyEditorMenu : UserControl
         }
     }
 
-    private void EditAnimation_Click(object? sender, RoutedEventArgs e)
+    private async void EditAnimation_Click(object? sender, RoutedEventArgs e)
     {
         if (DataContext is BaseEditorViewModel { IsDisposed: false } viewModel
             && viewModel.PropertyAdapter is IAnimatablePropertyAdapter animatableProperty
@@ -99,7 +99,7 @@ public sealed partial class PropertyEditorMenu : UserControl
                 ?? new GraphEditorTabViewModel(editViewModel);
             anmTimelineTabViewModel.Element.Value = element;
             anmTimelineTabViewModel.Select(animation);
-            editViewModel.OpenToolTab(anmTimelineTabViewModel);
+            await editViewModel.OpenToolTabAsync(anmTimelineTabViewModel);
         }
     }
 

--- a/src/Beutl/Views/MacWindow.axaml.cs
+++ b/src/Beutl/Views/MacWindow.axaml.cs
@@ -173,10 +173,9 @@ public sealed partial class MacWindow : Window
             menuItem.Click += async (s, e) =>
             {
                 if (viewModel.EditorService.SelectedTabItem.Value?.Context.Value is IEditorContext editorContext
-                    && s is NativeMenuItem { CommandParameter: ToolTabExtension ext }
-                    && ext.TryCreateContext(editorContext, out IToolContext? toolContext))
+                    && s is NativeMenuItem { CommandParameter: ToolTabExtension ext })
                 {
-                    await editorContext.OpenToolTabAsync(toolContext);
+                    await Beutl.Editor.Components.Helpers.ToolTabCallback.OpenFromExtensionAsync(editorContext, ext);
                 }
             };
 

--- a/src/Beutl/Views/MacWindow.axaml.cs
+++ b/src/Beutl/Views/MacWindow.axaml.cs
@@ -456,10 +456,7 @@ public sealed partial class MacWindow : Window
         if (!_viewModelDisposed && DataContext is MainViewModel viewModel)
         {
             e.Cancel = true;
-            if (_viewModelDisposeTask is null && viewModel.TryDisposeForWindowClose())
-            {
-                _viewModelDisposeTask = DisposeViewModelAndCloseAsync(viewModel);
-            }
+            _viewModelDisposeTask ??= DisposeViewModelAndCloseAsync(viewModel);
             return;
         }
 
@@ -472,14 +469,24 @@ public sealed partial class MacWindow : Window
 
     private async Task DisposeViewModelAndCloseAsync(MainViewModel viewModel)
     {
+        await Task.Yield();
         try
         {
-            await viewModel.WaitForDisposalAsync();
+            if (await viewModel.TryDisposeForWindowCloseAsync())
+            {
+                _viewModelDisposed = true;
+                Close();
+            }
+        }
+        catch (Exception ex)
+        {
+            await ex.Handle();
+            _viewModelDisposed = true;
+            Close();
         }
         finally
         {
-            _viewModelDisposed = true;
-            Close();
+            _viewModelDisposeTask = null;
         }
     }
 

--- a/src/Beutl/Views/MacWindow.axaml.cs
+++ b/src/Beutl/Views/MacWindow.axaml.cs
@@ -219,15 +219,13 @@ public sealed partial class MacWindow : Window
                         await commands.OnSave();
                     }
 
-                    if (selectedTab.Context.Value is { } selectedContext
-                        && editorExtension.TryCreateContext(
-                            selectedContext.Object,
-                            new EditorContextServices(viewModel.EditorService, viewModel.ExtensionProvider),
-                            out IEditorContext? context))
+                    if (selectedTab.Context.Value is not null)
                     {
                         try
                         {
-                            if (!await selectedTab.ReplaceContextAsync(context))
+                            EditorContextReplacementStatus replacement =
+                                await viewModel.EditorService.ReplaceContextAsync(selectedTab, editorExtension);
+                            if (replacement != EditorContextReplacementStatus.Succeeded)
                             {
                                 NotificationService.ShowInformation(
                                     title: MessageStrings.ContextNotCreated,

--- a/src/Beutl/Views/MacWindow.axaml.cs
+++ b/src/Beutl/Views/MacWindow.axaml.cs
@@ -170,17 +170,13 @@ public sealed partial class MacWindow : Window
         {
             var menuItem = new NativeMenuItem() { Header = item.Header, CommandParameter = item };
 
-            menuItem.Click += (s, e) =>
+            menuItem.Click += async (s, e) =>
             {
                 if (viewModel.EditorService.SelectedTabItem.Value?.Context.Value is IEditorContext editorContext
                     && s is NativeMenuItem { CommandParameter: ToolTabExtension ext }
                     && ext.TryCreateContext(editorContext, out IToolContext? toolContext))
                 {
-                    bool result = editorContext.OpenToolTab(toolContext);
-                    if (!result)
-                    {
-                        toolContext.Dispose();
-                    }
+                    await editorContext.OpenToolTabAsync(toolContext);
                 }
             };
 
@@ -228,8 +224,21 @@ public sealed partial class MacWindow : Window
                             new EditorContextServices(viewModel.EditorService, viewModel.ExtensionProvider),
                             out IEditorContext? context))
                     {
-                        selectedTab.Context.Value.Dispose();
-                        selectedTab.Context.Value = context;
+                        try
+                        {
+                            if (!await selectedTab.ReplaceContextAsync(context))
+                            {
+                                NotificationService.ShowInformation(
+                                    title: MessageStrings.ContextNotCreated,
+                                    message: MessageStrings.OperationFailed);
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            NotificationService.ShowError(
+                                MessageStrings.ContextNotCreated,
+                                ex.Message);
+                        }
                     }
                     else
                     {

--- a/src/Beutl/Views/MacWindow.axaml.cs
+++ b/src/Beutl/Views/MacWindow.axaml.cs
@@ -219,8 +219,9 @@ public sealed partial class MacWindow : Window
                         await commands.OnSave();
                     }
 
-                    if (editorExtension.TryCreateContext(
-                            selectedTab.Context.Value.Object,
+                    if (selectedTab.Context.Value is { } selectedContext
+                        && editorExtension.TryCreateContext(
+                            selectedContext.Object,
                             new EditorContextServices(viewModel.EditorService, viewModel.ExtensionProvider),
                             out IEditorContext? context))
                     {

--- a/src/Beutl/Views/MainView.axaml.InitializeMenuBar.cs
+++ b/src/Beutl/Views/MainView.axaml.InitializeMenuBar.cs
@@ -340,7 +340,9 @@ public partial class MainView
         if (project != null && selectedTabItem != null)
         {
             string filePath = selectedTabItem.FilePath.Value;
-            ProjectItem? projItem = project.Items.FirstOrDefault(i => i == selectedTabItem.Context.Value.Object);
+            ProjectItem? projItem = selectedTabItem.Context.Value is { } context
+                ? project.Items.FirstOrDefault(i => i == context.Object)
+                : null;
             if (projItem == null)
                 return;
 

--- a/src/Beutl/Views/MainView.axaml.InitializeMenuBar.cs
+++ b/src/Beutl/Views/MainView.axaml.InitializeMenuBar.cs
@@ -391,7 +391,7 @@ public partial class MainView
             {
                 if (file.TryGetLocalPath() is { } path)
                 {
-                    viewModel.MenuBar.OpenFileCore(path);
+                    await viewModel.MenuBar.OpenFileCore(path);
                 }
             }
         }

--- a/src/Beutl/Views/MainView.axaml.cs
+++ b/src/Beutl/Views/MainView.axaml.cs
@@ -260,15 +260,13 @@ public sealed partial class MainView : UserControl
                         await commands.OnSave();
                     }
 
-                    if (selectedTab.Context.Value is { } selectedContext
-                        && editorExtension.TryCreateContext(
-                            selectedContext.Object,
-                            new EditorContextServices(viewModel.EditorService, viewModel.ExtensionProvider),
-                            out IEditorContext? context))
+                    if (selectedTab.Context.Value is not null)
                     {
                         try
                         {
-                            if (!await selectedTab.ReplaceContextAsync(context))
+                            EditorContextReplacementStatus replacement =
+                                await viewModel.EditorService.ReplaceContextAsync(selectedTab, editorExtension);
+                            if (replacement != EditorContextReplacementStatus.Succeeded)
                             {
                                 NotificationService.ShowInformation(
                                     title: MessageStrings.ContextNotCreated,
@@ -277,7 +275,7 @@ public sealed partial class MainView : UserControl
                         }
                         catch (Exception ex)
                         {
-                            _logger.LogError(ex, "Failed to dispose the current editor before replacing it");
+                            _logger.LogError(ex, "Failed to replace the current editor context");
                             NotificationService.ShowError(
                                 MessageStrings.ContextNotCreated,
                                 MessageStrings.OperationFailed);

--- a/src/Beutl/Views/MainView.axaml.cs
+++ b/src/Beutl/Views/MainView.axaml.cs
@@ -217,10 +217,9 @@ public sealed partial class MainView : UserControl
             menuItem.Click += async (s, e) =>
             {
                 if (viewModel.EditorService.SelectedTabItem.Value?.Context.Value is IEditorContext editorContext
-                    && s is MenuItem { DataContext: ToolTabExtension ext }
-                    && ext.TryCreateContext(editorContext, out IToolContext? toolContext))
+                    && s is MenuItem { DataContext: ToolTabExtension ext })
                 {
-                    await editorContext.OpenToolTabAsync(toolContext);
+                    await Beutl.Editor.Components.Helpers.ToolTabCallback.OpenFromExtensionAsync(editorContext, ext);
                 }
             };
 

--- a/src/Beutl/Views/MainView.axaml.cs
+++ b/src/Beutl/Views/MainView.axaml.cs
@@ -214,17 +214,13 @@ public sealed partial class MainView : UserControl
         {
             var menuItem = new MenuItem() { Header = item.Header, DataContext = item };
 
-            menuItem.Click += (s, e) =>
+            menuItem.Click += async (s, e) =>
             {
                 if (viewModel.EditorService.SelectedTabItem.Value?.Context.Value is IEditorContext editorContext
                     && s is MenuItem { DataContext: ToolTabExtension ext }
                     && ext.TryCreateContext(editorContext, out IToolContext? toolContext))
                 {
-                    bool result = editorContext.OpenToolTab(toolContext);
-                    if (!result)
-                    {
-                        toolContext.Dispose();
-                    }
+                    await editorContext.OpenToolTabAsync(toolContext);
                 }
             };
 
@@ -269,8 +265,22 @@ public sealed partial class MainView : UserControl
                             new EditorContextServices(viewModel.EditorService, viewModel.ExtensionProvider),
                             out IEditorContext? context))
                     {
-                        selectedTab.Context.Value.Dispose();
-                        selectedTab.Context.Value = context;
+                        try
+                        {
+                            if (!await selectedTab.ReplaceContextAsync(context))
+                            {
+                                NotificationService.ShowInformation(
+                                    title: MessageStrings.ContextNotCreated,
+                                    message: MessageStrings.OperationFailed);
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            _logger.LogError(ex, "Failed to dispose the current editor before replacing it");
+                            NotificationService.ShowError(
+                                MessageStrings.ContextNotCreated,
+                                MessageStrings.OperationFailed);
+                        }
                     }
                     else
                     {

--- a/src/Beutl/Views/MainView.axaml.cs
+++ b/src/Beutl/Views/MainView.axaml.cs
@@ -260,8 +260,9 @@ public sealed partial class MainView : UserControl
                         await commands.OnSave();
                     }
 
-                    if (editorExtension.TryCreateContext(
-                            selectedTab.Context.Value.Object,
+                    if (selectedTab.Context.Value is { } selectedContext
+                        && editorExtension.TryCreateContext(
+                            selectedContext.Object,
                             new EditorContextServices(viewModel.EditorService, viewModel.ExtensionProvider),
                             out IEditorContext? context))
                     {

--- a/src/Beutl/Views/MainWindow.axaml.cs
+++ b/src/Beutl/Views/MainWindow.axaml.cs
@@ -91,10 +91,7 @@ public sealed partial class MainWindow : AppWindow
         if (!_viewModelDisposed && DataContext is MainViewModel viewModel)
         {
             e.Cancel = true;
-            if (_viewModelDisposeTask is null && viewModel.TryDisposeForWindowClose())
-            {
-                _viewModelDisposeTask = DisposeViewModelAndCloseAsync(viewModel);
-            }
+            _viewModelDisposeTask ??= DisposeViewModelAndCloseAsync(viewModel);
             return;
         }
 
@@ -107,14 +104,24 @@ public sealed partial class MainWindow : AppWindow
 
     private async Task DisposeViewModelAndCloseAsync(MainViewModel viewModel)
     {
+        await Task.Yield();
         try
         {
-            await viewModel.WaitForDisposalAsync();
+            if (await viewModel.TryDisposeForWindowCloseAsync())
+            {
+                _viewModelDisposed = true;
+                Close();
+            }
+        }
+        catch (Exception ex)
+        {
+            await ex.Handle();
+            _viewModelDisposed = true;
+            Close();
         }
         finally
         {
-            _viewModelDisposed = true;
-            Close();
+            _viewModelDisposeTask = null;
         }
     }
 

--- a/src/Beutl/Views/TitleBreadcrumbBar.axaml
+++ b/src/Beutl/Views/TitleBreadcrumbBar.axaml
@@ -43,7 +43,8 @@
                                 Theme="{StaticResource CompactFlyoutItemButtonTheme}" />
                         <Separator Height="1" Background="{DynamicResource DividerStrokeColorDefaultBrush}" />
                         <ListBox ItemsSource="{Binding TabItems}"
-                                 SelectedItem="{Binding SelectedTabItem.Value}"
+                                 SelectedItem="{Binding SelectedTabItem.Value, Mode=OneWay}"
+                                 SelectionChanged="OnSelectedTabItemChanged"
                                  Tapped="OnListBoxTapped">
                             <ListBox.Resources>
                                 <x:Double x:Key="ListViewItemMinHeight">36</x:Double>

--- a/src/Beutl/Views/TitleBreadcrumbBar.axaml.cs
+++ b/src/Beutl/Views/TitleBreadcrumbBar.axaml.cs
@@ -59,4 +59,18 @@ public partial class TitleBreadcrumbBar : UserControl
             flyout.Hide();
         }
     }
+
+    private void OnSelectedTabItemChanged(object? sender, SelectionChangedEventArgs e)
+    {
+        if (sender is not ListBox listBox
+            || listBox.SelectedItem is not EditorTabItem item
+            || DataContext is not TitleBreadcrumbBarViewModel viewModel
+            || ReferenceEquals(viewModel.SelectedTabItem.Value, item))
+        {
+            return;
+        }
+
+        if (!viewModel.ActivateTabItem(item))
+            listBox.SelectedItem = viewModel.SelectedTabItem.Value;
+    }
 }

--- a/src/Beutl/Views/Tools/DockLayoutView.axaml.cs
+++ b/src/Beutl/Views/Tools/DockLayoutView.axaml.cs
@@ -26,7 +26,7 @@ public partial class DockLayoutView : UserControl
         flyout.ShowAt(anchor);
     }
 
-    private void OnItemDoubleTapped(object? sender, TappedEventArgs e)
+    private async void OnItemDoubleTapped(object? sender, TappedEventArgs e)
     {
         if (ViewModel is not { } viewModel) return;
 
@@ -40,15 +40,15 @@ public partial class DockLayoutView : UserControl
 
         if (ItemFrom(e.Source) is not { } item) return;
 
-        viewModel.Apply(item);
+        await viewModel.ApplyAsync(item);
         e.Handled = true;
     }
 
-    private void OnApplyClick(object? sender, RoutedEventArgs e)
+    private async void OnApplyClick(object? sender, RoutedEventArgs e)
     {
         if (ViewModel is { } viewModel && ItemFrom(sender) is { } item)
         {
-            viewModel.Apply(item);
+            await viewModel.ApplyAsync(item);
         }
     }
 
@@ -70,9 +70,10 @@ public partial class DockLayoutView : UserControl
         }
     }
 
-    private void OnResetClick(object? sender, RoutedEventArgs e)
+    private async void OnResetClick(object? sender, RoutedEventArgs e)
     {
-        ViewModel?.ResetLayout();
+        if (ViewModel is { } viewModel)
+            await viewModel.ResetLayoutAsync();
     }
 
     // The acted-on layout comes from the row's DataContext, not the list selection.

--- a/src/Beutl/Views/Tools/DockLayoutView.axaml.cs
+++ b/src/Beutl/Views/Tools/DockLayoutView.axaml.cs
@@ -40,8 +40,8 @@ public partial class DockLayoutView : UserControl
 
         if (ItemFrom(e.Source) is not { } item) return;
 
-        await viewModel.ApplyAsync(item);
         e.Handled = true;
+        await Beutl.Editor.Components.Helpers.ToolTabCallback.RunAsync(() => viewModel.ApplyAsync(item));
     }
 
     private async void OnApplyClick(object? sender, RoutedEventArgs e)

--- a/tests/Beutl.HeadlessUITests/AgentHostEndpointTests.cs
+++ b/tests/Beutl.HeadlessUITests/AgentHostEndpointTests.cs
@@ -37,7 +37,7 @@ public sealed class AgentHostEndpointTests
                 "live",
                 location))!;
             Scene scene = project.Items.OfType<Scene>().Single();
-            TestShell.Editor.ActivateTabItem(scene);
+            await TestShell.Editor.ActivateTabItemAsync(scene);
             Beutl.Testing.Headless.HeadlessTestHelpers.Settle();
             var editor = (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
             var binding = new EditViewModelLiveBinding(editor);
@@ -97,7 +97,7 @@ public sealed class AgentHostEndpointTests
                 "live",
                 location))!;
             Scene scene = project.Items.OfType<Scene>().Single();
-            TestShell.Editor.ActivateTabItem(scene);
+            await TestShell.Editor.ActivateTabItemAsync(scene);
             Beutl.Testing.Headless.HeadlessTestHelpers.Settle();
             var editor = (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
             var liveSessions = new LiveSessionSource();
@@ -191,7 +191,7 @@ public sealed class AgentHostEndpointTests
                 "live",
                 location))!;
             Scene scene = project.Items.OfType<Scene>().Single();
-            TestShell.Editor.ActivateTabItem(scene);
+            await TestShell.Editor.ActivateTabItemAsync(scene);
             Beutl.Testing.Headless.HeadlessTestHelpers.Settle();
             var editor = (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
             var binding = new EditViewModelLiveBinding(editor);
@@ -235,7 +235,7 @@ public sealed class AgentHostEndpointTests
                 "live",
                 location))!;
             Scene scene = project.Items.OfType<Scene>().Single();
-            TestShell.Editor.ActivateTabItem(scene);
+            await TestShell.Editor.ActivateTabItemAsync(scene);
             Beutl.Testing.Headless.HeadlessTestHelpers.Settle();
             var editor = (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
             var binding = new EditViewModelLiveBinding(editor);

--- a/tests/Beutl.HeadlessUITests/AiDialogWorkflowTests.cs
+++ b/tests/Beutl.HeadlessUITests/AiDialogWorkflowTests.cs
@@ -5633,7 +5633,7 @@ public sealed class AiDialogWorkflowTests
         Project project = (await TestShell.Project.CreateProject(
             640, 480, 30, 44100, name, workspace))!;
         Scene scene = project.Items.OfType<Scene>().First();
-        TestShell.Editor.ActivateTabItem(scene);
+        await TestShell.Editor.ActivateTabItemAsync(scene);
         HeadlessTestHelpers.Settle();
         return (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value!;
     }

--- a/tests/Beutl.HeadlessUITests/AiJobCenterTests.cs
+++ b/tests/Beutl.HeadlessUITests/AiJobCenterTests.cs
@@ -46,7 +46,7 @@ public sealed class AiJobCenterTests
         };
         Beutl.Serialization.CoreSerializer.StoreToUri(second, second.Uri!);
         TestShell.Project.CurrentProject.Value!.Items.Add(second);
-        TestShell.Editor.ActivateTabItem(second);
+        await TestShell.Editor.ActivateTabItemAsync(second);
         HeadlessTestHelpers.Settle();
         var selected = (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value!;
         var result = new AiCaptionHistoryResult(new AiJobId("origin-caption"),
@@ -2037,7 +2037,7 @@ public sealed class AiJobCenterTests
         Project project = (await TestShell.Project.CreateProject(
             640, 480, 30, 44100, name, workspace))!;
         Scene scene = project.Items.OfType<Scene>().First();
-        TestShell.Editor.ActivateTabItem(scene);
+        await TestShell.Editor.ActivateTabItemAsync(scene);
         HeadlessTestHelpers.Settle();
         return (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value!;
     }

--- a/tests/Beutl.HeadlessUITests/AiResultImporterTests.cs
+++ b/tests/Beutl.HeadlessUITests/AiResultImporterTests.cs
@@ -58,7 +58,7 @@ public sealed class AiResultImporterTests
         Project project = (await TestShell.Project.CreateProject(
             640, 480, 30, 44100, name, workspace))!;
         Scene scene = project.Items.OfType<Scene>().First();
-        TestShell.Editor.ActivateTabItem(scene);
+        await TestShell.Editor.ActivateTabItemAsync(scene);
         HeadlessTestHelpers.Settle();
         return (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value!;
     }

--- a/tests/Beutl.HeadlessUITests/AiShellEntryPointTests.cs
+++ b/tests/Beutl.HeadlessUITests/AiShellEntryPointTests.cs
@@ -96,7 +96,7 @@ public sealed class AiShellEntryPointTests
             AiWorkspaceViewModel first = editor.FindToolTab<AiWorkspaceViewModel>()!;
 
             AiWorkspaceViewModel second = mainViewModel.CreateAiWorkspaceViewModel(editor);
-            Assert.That(editor.OpenToolTab(second), Is.True);
+            Assert.That(await editor.OpenToolTabAsync(second), Is.True);
             HeadlessTestHelpers.Settle();
 
             using (Assert.EnterMultipleScope())
@@ -210,9 +210,14 @@ public sealed class AiShellEntryPointTests
         var page = new StubPage();
         var workspace = new AiWorkspaceViewModel(editor, _ => page);
 
-        bool opened = await MainViewModel.TryOpenNewAiWorkspaceAsync(
+        var admission = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        Task<bool> opening = MainViewModel.TryOpenNewAiWorkspaceAsync(
             workspace,
-            static () => false);
+            () => new ValueTask<bool>(admission.Task));
+        Assert.That(opening.IsCompleted, Is.False);
+        Assert.That(page.IsDisposed, Is.False);
+        admission.SetResult(false);
+        bool opened = await opening;
 
         using (Assert.EnterMultipleScope())
         {
@@ -377,7 +382,7 @@ public sealed class AiShellEntryPointTests
         Project project = (await TestShell.Project.CreateProject(
             640, 480, 30, 44100, name, workspace))!;
         Scene scene = project.Items.OfType<Scene>().First();
-        TestShell.Editor.ActivateTabItem(scene);
+        await TestShell.Editor.ActivateTabItemAsync(scene);
         HeadlessTestHelpers.Settle();
         return (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value!;
     }

--- a/tests/Beutl.HeadlessUITests/AiSubtitleTemplateTests.cs
+++ b/tests/Beutl.HeadlessUITests/AiSubtitleTemplateTests.cs
@@ -53,7 +53,7 @@ public class AiSubtitleTemplateTests
         HeadlessTestHelpers.Settle();
         Scene scene = project.Items.OfType<Scene>().First();
 
-        TestShell.Editor.ActivateTabItem(scene);
+        await TestShell.Editor.ActivateTabItemAsync(scene);
         HeadlessTestHelpers.Settle();
 
         return (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value!;

--- a/tests/Beutl.HeadlessUITests/AiToolTabCaptureTests.cs
+++ b/tests/Beutl.HeadlessUITests/AiToolTabCaptureTests.cs
@@ -183,7 +183,7 @@ public class AiToolTabCaptureTests
             640, 480, 30, 44100, name, workspace))!;
         HeadlessTestHelpers.Settle();
         Scene scene = project.Items.OfType<Scene>().First();
-        TestShell.Editor.ActivateTabItem(scene);
+        await TestShell.Editor.ActivateTabItemAsync(scene);
         HeadlessTestHelpers.Settle();
         return (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value!;
     }

--- a/tests/Beutl.HeadlessUITests/ContextCommandDispatchTests.cs
+++ b/tests/Beutl.HeadlessUITests/ContextCommandDispatchTests.cs
@@ -132,11 +132,12 @@ public class ContextCommandDispatchTests
             HeadlessTestHelpers.Settle();
             var editor = (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
             var adder = (IElementAdder)editor.GetService(typeof(IElementAdder))!;
-            adder.AddElement(new ElementDescription(
+            ElementAddResult added = await adder.AddAsync([new ElementDescription(
                 Start: TimeSpan.Zero,
                 Length: TimeSpan.FromSeconds(1),
                 Layer: 0,
-                EngineObjectFactory: () => new RectShape()));
+                Source: new ElementSource.EngineObject(() => new RectShape()))], CancellationToken.None);
+            Assert.That(added.IsSuccess, Is.True);
             HeadlessTestHelpers.Settle();
             TimelineTabViewModel timeline = editor.FindToolTab<TimelineTabViewModel>()!;
             ElementViewModel target = timeline.Elements.Single();
@@ -182,11 +183,12 @@ public class ContextCommandDispatchTests
             HeadlessTestHelpers.Settle();
             var editor = (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
             var adder = (IElementAdder)editor.GetService(typeof(IElementAdder))!;
-            adder.AddElement(new ElementDescription(
+            ElementAddResult added = await adder.AddAsync([new ElementDescription(
                 Start: TimeSpan.Zero,
                 Length: TimeSpan.FromSeconds(1),
                 Layer: 0,
-                EngineObjectFactory: () => new RectShape()));
+                Source: new ElementSource.EngineObject(() => new RectShape()))], CancellationToken.None);
+            Assert.That(added.IsSuccess, Is.True);
             HeadlessTestHelpers.Settle();
             TimelineTabViewModel timeline = editor.FindToolTab<TimelineTabViewModel>()!;
             ElementViewModel target = timeline.Elements.Single();

--- a/tests/Beutl.HeadlessUITests/ContextCommandDispatchTests.cs
+++ b/tests/Beutl.HeadlessUITests/ContextCommandDispatchTests.cs
@@ -90,7 +90,7 @@ public class ContextCommandDispatchTests
                 "edit-handler",
                 location))!;
             Scene scene = project.Items.OfType<Scene>().Single();
-            TestShell.Editor.ActivateTabItem(scene);
+            await TestShell.Editor.ActivateTabItemAsync(scene);
             HeadlessTestHelpers.Settle();
             var editor = (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
             var gate = new TaskCompletionSource(
@@ -128,7 +128,7 @@ public class ContextCommandDispatchTests
                 "timeline-handler",
                 location))!;
             Scene scene = project.Items.OfType<Scene>().Single();
-            TestShell.Editor.ActivateTabItem(scene);
+            await TestShell.Editor.ActivateTabItemAsync(scene);
             HeadlessTestHelpers.Settle();
             var editor = (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
             var adder = (IElementAdder)editor.GetService(typeof(IElementAdder))!;
@@ -178,7 +178,7 @@ public class ContextCommandDispatchTests
                 "timeline-handler",
                 location))!;
             Scene scene = project.Items.OfType<Scene>().Single();
-            TestShell.Editor.ActivateTabItem(scene);
+            await TestShell.Editor.ActivateTabItemAsync(scene);
             HeadlessTestHelpers.Settle();
             var editor = (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
             var adder = (IElementAdder)editor.GetService(typeof(IElementAdder))!;

--- a/tests/Beutl.HeadlessUITests/CreateNewProjectDialogTests.cs
+++ b/tests/Beutl.HeadlessUITests/CreateNewProjectDialogTests.cs
@@ -75,7 +75,7 @@ public class CreateNewProjectDialogTests
             Assert.That(menuBarSessionConstructor, Is.Not.Null);
             Assert.That(
                 typeof(MenuBarViewModel).GetProperty(nameof(MenuBarViewModel.CloseProject))!.PropertyType,
-                Is.EqualTo(typeof(ReactiveCommandSlim)));
+                Is.EqualTo(typeof(AsyncReactiveCommand)));
         });
 
         var projectService = new ProjectService();

--- a/tests/Beutl.HeadlessUITests/DefaultLayoutTests.cs
+++ b/tests/Beutl.HeadlessUITests/DefaultLayoutTests.cs
@@ -33,7 +33,7 @@ public class DefaultLayoutTests
 
         TestShell.Editor.ActivateTabItem(scene);
         HeadlessTestHelpers.Settle();
-        return (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
+        return (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value!;
     }
 
     [AvaloniaTest]

--- a/tests/Beutl.HeadlessUITests/DefaultLayoutTests.cs
+++ b/tests/Beutl.HeadlessUITests/DefaultLayoutTests.cs
@@ -31,7 +31,7 @@ public class DefaultLayoutTests
         HeadlessTestHelpers.Settle();
         Scene scene = project.Items.OfType<Scene>().First();
 
-        TestShell.Editor.ActivateTabItem(scene);
+        await TestShell.Editor.ActivateTabItemAsync(scene);
         HeadlessTestHelpers.Settle();
         return (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value!;
     }

--- a/tests/Beutl.HeadlessUITests/DockLayoutPresetTests.cs
+++ b/tests/Beutl.HeadlessUITests/DockLayoutPresetTests.cs
@@ -67,7 +67,7 @@ public class DockLayoutPresetTests
         // Make the layout distinguishable from the default: close the library tab.
         BeutlToolDockable library = source.DockHost.Factory.EnumerateTools()
             .First(t => t.ToolContext.Extension is LibraryTabExtension);
-        source.DockHost.CloseToolTab(library.ToolContext);
+        await source.DockHost.CloseToolTabAsync(library.ToolContext);
         HeadlessTestHelpers.Settle();
 
         string[] expected = ToolExtensionNames(source);
@@ -80,7 +80,7 @@ public class DockLayoutPresetTests
         EditViewModel target = await OpenEditorForNewScene("preset-target");
         Assert.That(ToolExtensionNames(target), Does.Contain(typeof(LibraryTabExtension).FullName));
 
-        Assert.That(target.DockHost.ApplyLayout(preset!.Layout), Is.True);
+        Assert.That(await target.DockHost.ApplyLayoutAsync(preset!.Layout), Is.True);
         HeadlessTestHelpers.Settle();
 
         Assert.That(ToolExtensionNames(target), Is.EqualTo(expected));
@@ -131,10 +131,13 @@ public class DockLayoutPresetTests
         string[] before = ToolExtensionNames(editor);
         IRootDock layoutBefore = editor.DockHost.Layout.Value;
 
-        Assert.That(editor.DockHost.ApplyLayout(new JsonObject()), Is.False);
+        Assert.That(await editor.DockHost.ApplyLayoutAsync(new JsonObject()), Is.False);
         Assert.That(
-            editor.DockHost.ApplyLayout(new JsonObject { ["DockLayout"] = new JsonObject { ["$type"] = "tool" } }),
+            await editor.DockHost.ApplyLayoutAsync(new JsonObject { ["DockLayout"] = new JsonObject { ["$type"] = "tool" } }),
             Is.False);
+        JsonObject invalidFieldType = editor.DockHost.CaptureLayout();
+        ((JsonObject)invalidFieldType["DockLayout"]!)["id"] = new JsonObject();
+        Assert.That(await editor.DockHost.ApplyLayoutAsync(invalidFieldType), Is.False);
 
         Assert.That(editor.DockHost.Layout.Value, Is.SameAs(layoutBefore));
         Assert.That(ToolExtensionNames(editor), Is.EqualTo(before));
@@ -160,7 +163,7 @@ public class DockLayoutPresetTests
         // mirroring. Record the current state to prove the survivors were left alone.
         bool[] selectedBefore = liveBefore.Select(t => t.ToolContext.IsSelected.Value).ToArray();
 
-        Assert.That(editor.DockHost.ApplyLayout(broken), Is.False);
+        Assert.That(await editor.DockHost.ApplyLayoutAsync(broken), Is.False);
         Assert.That(editor.DockHost.Layout.Value, Is.SameAs(layoutBefore), "the live layout must survive");
         Assert.That(editor.DockHost.Factory.EnumerateTools(), Is.EquivalentTo(liveBefore));
 
@@ -183,13 +186,13 @@ public class DockLayoutPresetTests
         EditViewModel editor = await OpenEditorForNewScene("preset-version");
 
         JsonObject captured = editor.DockHost.CaptureLayout();
-        Assert.That(editor.DockHost.ApplyLayout(captured), Is.True, "the captured layout should apply as-is");
+        Assert.That(await editor.DockHost.ApplyLayoutAsync(captured), Is.True, "the captured layout should apply as-is");
 
         IRootDock layoutBefore = editor.DockHost.Layout.Value;
         var stale = (JsonObject)captured.DeepClone();
         stale["_dockVersion"] = 1;
 
-        Assert.That(editor.DockHost.ApplyLayout(stale), Is.False);
+        Assert.That(await editor.DockHost.ApplyLayoutAsync(stale), Is.False);
         Assert.That(editor.DockHost.Layout.Value, Is.SameAs(layoutBefore));
     }
 

--- a/tests/Beutl.HeadlessUITests/DockLayoutPresetTests.cs
+++ b/tests/Beutl.HeadlessUITests/DockLayoutPresetTests.cs
@@ -19,7 +19,7 @@ using Dock.Model.Core;
 
 namespace Beutl.HeadlessUITests;
 
-[TestFixture]
+[TestFixture, NonParallelizable]
 public class DockLayoutPresetTests
 {
     private static Task ResetProjectAsync() => TestReset.ResetShellAsync();
@@ -40,7 +40,7 @@ public class DockLayoutPresetTests
 
         TestShell.Editor.ActivateTabItem(scene);
         HeadlessTestHelpers.Settle();
-        return (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
+        return (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value!;
     }
 
     private static DockLayoutPresetService NewService()
@@ -58,7 +58,7 @@ public class DockLayoutPresetTests
             .ToArray();
     }
 
-    [AvaloniaTest]
+    [AvaloniaTest, NonParallelizable]
     public async Task Saved_layout_can_be_applied_to_another_scene()
     {
         await ResetProjectAsync();
@@ -79,11 +79,17 @@ public class DockLayoutPresetTests
 
         EditViewModel target = await OpenEditorForNewScene("preset-target");
         Assert.That(ToolExtensionNames(target), Does.Contain(typeof(LibraryTabExtension).FullName));
+        int restoredBeforePublication = -1;
+        target.DockHost.BeforeLayoutPublication = root =>
+            restoredBeforePublication = BeutlDockFactory.Traverse(root)
+                .OfType<BeutlToolDockable>()
+                .Count();
 
         Assert.That(await target.DockHost.ApplyLayoutAsync(preset!.Layout), Is.True);
-        HeadlessTestHelpers.Settle();
+        string[] immediatelyAfterApply = ToolExtensionNames(target);
 
-        Assert.That(ToolExtensionNames(target), Is.EqualTo(expected));
+        Assert.That(immediatelyAfterApply, Is.EqualTo(expected),
+            $"restored before publication: {restoredBeforePublication}; immediate: {string.Join(",", immediatelyAfterApply)}");
         Assert.That(target.DockHost.Layout.Value.Id, Is.EqualTo(DockIds.Root));
     }
 
@@ -194,6 +200,43 @@ public class DockLayoutPresetTests
 
         Assert.That(await editor.DockHost.ApplyLayoutAsync(stale), Is.False);
         Assert.That(editor.DockHost.Layout.Value, Is.SameAs(layoutBefore));
+    }
+
+    [AvaloniaTest]
+    public async Task PublicationFailureDisposesRestoredToolsAndReturnsToAStableLayout()
+    {
+        await ResetProjectAsync();
+        EditViewModel editor = await OpenEditorForNewScene("preset-publication-failure");
+        JsonObject captured = editor.DockHost.CaptureLayout();
+        BeutlToolDockable[]? restoredTools = null;
+        editor.DockHost.BeforeLayoutPublication = root =>
+        {
+            restoredTools = BeutlDockFactory.Traverse(root)
+                .OfType<BeutlToolDockable>()
+                .ToArray();
+            throw new InvalidOperationException("publication failed");
+        };
+
+        Exception? publicationError = null;
+        try
+        {
+            await editor.DockHost.ApplyLayoutAsync(captured).WaitAsync(TimeSpan.FromSeconds(5));
+        }
+        catch (Exception ex)
+        {
+            publicationError = ex;
+        }
+        Assert.That(publicationError, Is.TypeOf<InvalidOperationException>());
+        editor.DockHost.BeforeLayoutPublication = null;
+
+        Assert.That(restoredTools, Is.Not.Null.And.Not.Empty);
+        foreach (BeutlToolDockable tool in restoredTools!)
+        {
+            Assert.That(tool.Owner, Is.Null);
+            Assert.Throws<ObjectDisposedException>(() => _ = tool.ToolContext);
+        }
+        Assert.DoesNotThrow(() => editor.DockHost.CaptureLayout());
+        await editor.DockHost.ResetLayoutAsync().WaitAsync(TimeSpan.FromSeconds(5));
     }
 
     [Test]

--- a/tests/Beutl.HeadlessUITests/DockLayoutPresetTests.cs
+++ b/tests/Beutl.HeadlessUITests/DockLayoutPresetTests.cs
@@ -38,7 +38,7 @@ public class DockLayoutPresetTests
         HeadlessTestHelpers.Settle();
         Scene scene = project.Items.OfType<Scene>().First();
 
-        TestShell.Editor.ActivateTabItem(scene);
+        await TestShell.Editor.ActivateTabItemAsync(scene);
         HeadlessTestHelpers.Settle();
         return (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value!;
     }

--- a/tests/Beutl.HeadlessUITests/DockLayoutPresetTests.cs
+++ b/tests/Beutl.HeadlessUITests/DockLayoutPresetTests.cs
@@ -50,6 +50,62 @@ public class DockLayoutPresetTests
         return new DockLayoutPresetService(path);
     }
 
+    [AvaloniaTest]
+    public async Task Dock_serialization_preserves_non_dock_editor_state()
+    {
+        await ResetProjectAsync();
+        EditViewModel editor = await OpenEditorForNewScene("dock-state-preservation");
+        var json = new JsonObject
+        {
+            ["selected-object"] = "selection",
+            ["scale"] = 2,
+            ["bpm"] = 140,
+        };
+        editor.DockHost.WriteToJson(json);
+        Assert.Multiple(() =>
+        {
+            Assert.That(json["selected-object"]!.GetValue<string>(), Is.EqualTo("selection"));
+            Assert.That(json["scale"]!.GetValue<int>(), Is.EqualTo(2));
+            Assert.That(json["bpm"]!.GetValue<int>(), Is.EqualTo(140));
+            Assert.That(json.ContainsKey("DockLayout"), Is.True);
+        });
+    }
+
+    [AvaloniaTest]
+    public async Task Detached_dock_cleanup_never_activates_a_splitter()
+    {
+        await ResetProjectAsync();
+        EditViewModel editor = await OpenEditorForNewScene("dock-splitter-selection");
+        BeutlDockFactory factory = editor.DockHost.Factory;
+        IProportionalDock owner = factory.CreateProportionalDock();
+        IProportionalDock removed = factory.CreateProportionalDock();
+        IProportionalDock retained = factory.CreateProportionalDock();
+        owner.VisibleDockables = factory.CreateList<IDockable>(
+            factory.CreateProportionalDockSplitter(), retained);
+        owner.ActiveDockable = removed;
+        removed.Owner = owner;
+        typeof(BeutlDockFactory).GetMethod("CleanupDetachedState",
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+            .Invoke(factory, [removed, owner, null]);
+        Assert.That(owner.ActiveDockable, Is.SameAs(retained));
+    }
+
+    [AvaloniaTest]
+    public async Task Excessively_nested_in_memory_layout_is_rejected_before_cloning()
+    {
+        await ResetProjectAsync();
+        EditViewModel editor = await OpenEditorForNewScene("dock-depth-limit");
+        JsonObject layout = editor.DockHost.CaptureLayout();
+        JsonObject current = layout;
+        for (int i = 0; i < 256; i++)
+        {
+            var child = new JsonObject();
+            current["nested"] = child;
+            current = child;
+        }
+        Assert.That(await editor.DockHost.ApplyLayoutAsync(layout), Is.False);
+    }
+
     private static string[] ToolExtensionNames(EditViewModel editor)
     {
         return editor.DockHost.Factory.EnumerateTools()

--- a/tests/Beutl.HeadlessUITests/DockLayoutTabTests.cs
+++ b/tests/Beutl.HeadlessUITests/DockLayoutTabTests.cs
@@ -74,15 +74,15 @@ public class DockLayoutTabTests
 
         BeutlToolDockable library = editor.DockHost.Factory.EnumerateTools()
             .First(t => t.ToolContext.Extension is LibraryTabExtension);
-        editor.DockHost.CloseToolTab(library.ToolContext);
+        await editor.DockHost.CloseToolTabAsync(library.ToolContext);
         HeadlessTestHelpers.Settle();
         Assert.That(ToolExtensionNames(editor), Is.Not.EqualTo(saved));
 
-        Assert.That(viewModel.Apply(), Is.True);
+        Assert.That(await viewModel.ApplyAsync(), Is.True);
         HeadlessTestHelpers.Settle();
         Assert.That(ToolExtensionNames(editor), Is.EqualTo(saved));
 
-        viewModel.Dispose();
+        await viewModel.DisposeAsync();
     }
 
     [AvaloniaTest]
@@ -104,7 +104,7 @@ public class DockLayoutTabTests
         Assert.That(viewModel.Save(null), Is.Null);
         Assert.That(service.Items, Has.Count.EqualTo(1));
 
-        viewModel.Dispose();
+        await viewModel.DisposeAsync();
     }
 
     [AvaloniaTest]
@@ -122,7 +122,7 @@ public class DockLayoutTabTests
         viewModel.Save(first);
         Assert.That(viewModel.SuggestName(), Is.EqualTo($"{Strings.DockLayout} 2"));
 
-        viewModel.Dispose();
+        await viewModel.DisposeAsync();
     }
 
     [AvaloniaTest]
@@ -151,7 +151,7 @@ public class DockLayoutTabTests
         // Re-saving under an existing name is how a layout gets refreshed.
         BeutlToolDockable library = editor.DockHost.Factory.EnumerateTools()
             .First(t => t.ToolContext.Extension is LibraryTabExtension);
-        editor.DockHost.CloseToolTab(library.ToolContext);
+        await editor.DockHost.CloseToolTabAsync(library.ToolContext);
         HeadlessTestHelpers.Settle();
 
         Assert.That(viewModel.Save("Rough cut"), Is.Not.Null);
@@ -159,9 +159,9 @@ public class DockLayoutTabTests
         Assert.That(viewModel.SelectedItem.Value?.Name.Value, Is.EqualTo("Rough cut"));
 
         string[] afterClose = ToolExtensionNames(editor);
-        editor.DockHost.ResetLayout();
+        await editor.DockHost.ResetLayoutAsync();
         HeadlessTestHelpers.Settle();
-        Assert.That(viewModel.Apply(), Is.True);
+        Assert.That(await viewModel.ApplyAsync(), Is.True);
         HeadlessTestHelpers.Settle();
         Assert.That(ToolExtensionNames(editor), Is.EqualTo(afterClose));
 
@@ -169,7 +169,7 @@ public class DockLayoutTabTests
         Assert.That(service.Items.Select(i => i.Name.Value), Is.EqualTo(new[] { "Grading" }));
         Assert.That(viewModel.HasSelection.Value, Is.False, "removing the selected layout clears the selection");
 
-        viewModel.Dispose();
+        await viewModel.DisposeAsync();
     }
 
     [AvaloniaTest]
@@ -194,8 +194,8 @@ public class DockLayoutTabTests
         ListBox list = control.GetLogicalDescendants().OfType<ListBox>().Single();
         Assert.That(list.ItemsSource, Is.SameAs(service.Items));
 
-        context.Dispose();
-        viewModel.Dispose();
+        await context.DisposeAsync();
+        await viewModel.DisposeAsync();
     }
 
     [AvaloniaTest]
@@ -222,7 +222,7 @@ public class DockLayoutTabTests
             viewModel.HasSelection.Value, Is.True,
             "removing another row must not clear the selection");
 
-        viewModel.Dispose();
+        await viewModel.DisposeAsync();
     }
 
     [AvaloniaTest]
@@ -239,7 +239,7 @@ public class DockLayoutTabTests
 
         BeutlToolDockable library = editor.DockHost.Factory.EnumerateTools()
             .First(t => t.ToolContext.Extension is LibraryTabExtension);
-        editor.DockHost.CloseToolTab(library.ToolContext);
+        await editor.DockHost.CloseToolTabAsync(library.ToolContext);
         HeadlessTestHelpers.Settle();
 
         viewModel.Save("No library");
@@ -250,12 +250,12 @@ public class DockLayoutTabTests
         Assert.That(viewModel.SelectedItem.Value?.Name.Value, Is.EqualTo("No library"));
 
         DockLayoutPresetItem fullItem = service.Items.First(i => i.Name.Value == "Full");
-        Assert.That(viewModel.Apply(fullItem), Is.True);
+        Assert.That(await viewModel.ApplyAsync(fullItem), Is.True);
         HeadlessTestHelpers.Settle();
 
         Assert.That(ToolExtensionNames(editor), Is.EqualTo(full));
 
-        viewModel.Dispose();
+        await viewModel.DisposeAsync();
     }
 
     [AvaloniaTest]
@@ -289,7 +289,7 @@ public class DockLayoutTabTests
         finally
         {
             Directory.Delete(path, recursive: true);
-            viewModel.Dispose();
+            await viewModel.DisposeAsync();
         }
     }
 
@@ -342,7 +342,7 @@ public class DockLayoutTabTests
         finally
         {
             window.Close();
-            viewModel.Dispose();
+            await viewModel.DisposeAsync();
         }
     }
 
@@ -375,7 +375,7 @@ public class DockLayoutTabTests
 
         Assert.That(
             DockLayoutTabExtension.Instance.TryCreateContext(editor, out IToolContext? context), Is.True);
-        Assert.That(editor.OpenToolTab(context!), Is.True);
+        Assert.That(await editor.DockHost.OpenToolTabAsync(context!), Is.True);
         HeadlessTestHelpers.Settle();
 
         Assert.That(editor.DockHost.FindToolContext(typeof(DockLayoutTabExtension)), Is.SameAs(context));

--- a/tests/Beutl.HeadlessUITests/DockLayoutTabTests.cs
+++ b/tests/Beutl.HeadlessUITests/DockLayoutTabTests.cs
@@ -39,7 +39,7 @@ public class DockLayoutTabTests
 
         TestShell.Editor.ActivateTabItem(scene);
         HeadlessTestHelpers.Settle();
-        return (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
+        return (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value!;
     }
 
     private static DockLayoutPresetService NewService()

--- a/tests/Beutl.HeadlessUITests/DockLayoutTabTests.cs
+++ b/tests/Beutl.HeadlessUITests/DockLayoutTabTests.cs
@@ -37,7 +37,7 @@ public class DockLayoutTabTests
         HeadlessTestHelpers.Settle();
         Scene scene = project.Items.OfType<Scene>().First();
 
-        TestShell.Editor.ActivateTabItem(scene);
+        await TestShell.Editor.ActivateTabItemAsync(scene);
         HeadlessTestHelpers.Settle();
         return (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value!;
     }

--- a/tests/Beutl.HeadlessUITests/DockTabAddButtonTests.cs
+++ b/tests/Beutl.HeadlessUITests/DockTabAddButtonTests.cs
@@ -40,7 +40,7 @@ public class DockTabAddButtonTests
 
         TestShell.Editor.ActivateTabItem(scene);
         HeadlessTestHelpers.Settle();
-        return (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
+        return (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value!;
     }
 
     [AvaloniaTest]

--- a/tests/Beutl.HeadlessUITests/DockTabAddButtonTests.cs
+++ b/tests/Beutl.HeadlessUITests/DockTabAddButtonTests.cs
@@ -206,7 +206,7 @@ public class DockTabAddButtonTests
         EditViewModel editor = await OpenEditorForNewScene("dock-tab-add-null-context");
         IToolDock target = editor.DockHost.Factory.GetAnchoredDock(DockAnchor.Left)!;
 
-        bool opened = editor.DockHost.OpenToolTabFromExtension(new NullContextToolTabExtension(), target);
+        bool opened = await editor.DockHost.OpenToolTabFromExtensionAsync(new NullContextToolTabExtension(), target);
 
         Assert.That(opened, Is.False);
     }

--- a/tests/Beutl.HeadlessUITests/DockTabAddButtonTests.cs
+++ b/tests/Beutl.HeadlessUITests/DockTabAddButtonTests.cs
@@ -38,7 +38,7 @@ public class DockTabAddButtonTests
         HeadlessTestHelpers.Settle();
         Scene scene = project.Items.OfType<Scene>().First();
 
-        TestShell.Editor.ActivateTabItem(scene);
+        await TestShell.Editor.ActivateTabItemAsync(scene);
         HeadlessTestHelpers.Settle();
         return (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value!;
     }

--- a/tests/Beutl.HeadlessUITests/EditorHostProjectQueueTests.cs
+++ b/tests/Beutl.HeadlessUITests/EditorHostProjectQueueTests.cs
@@ -105,6 +105,262 @@ public sealed class EditorHostProjectQueueTests
     }
 
     [AvaloniaTest]
+    public async Task CloseProject_waits_for_already_removed_tab_teardown()
+    {
+        await TestReset.ResetShellAsync();
+        var contexts = new TestContextFactory { BlockNextDispose = true };
+        (ProjectService projectService, EditorService editorService, EditorHostViewModel host) =
+            CreateComposition(contexts);
+
+        try
+        {
+            Project project = (await projectService.CreateProject(
+                320, 180, 30, 44100, "queue-removed-close", NewWorkspace("removed-close")))!;
+            TestContext context = contexts.Contexts.Single();
+            EditorTabItem tab = editorService.TabItems.Single();
+
+            Task tabClose = editorService.CloseTabItem(tab).AsTask();
+            await context.DisposeStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.That(editorService.TabItems, Is.Empty);
+
+            var admissionClosed = new TaskCompletionSource(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            editorService.AfterTabAdmissionClosed = () => admissionClosed.TrySetResult();
+            Task projectClose = projectService.CloseProjectAsync();
+            try
+            {
+                await admissionClosed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+                Assert.Multiple(() =>
+                {
+                    Assert.That(projectClose.IsCompleted, Is.False);
+                    Assert.That(BeutlApplication.Current.Project, Is.SameAs(project));
+                });
+            }
+            finally
+            {
+                context.ReleaseDispose();
+            }
+
+            await Task.WhenAll(tabClose, projectClose).WaitAsync(TimeSpan.FromSeconds(5));
+            editorService.AfterTabAdmissionClosed = null;
+            Assert.Multiple(() =>
+            {
+                Assert.That(BeutlApplication.Current.Project, Is.Null);
+                Assert.That(context.DisposeCount, Is.EqualTo(1));
+            });
+        }
+        finally
+        {
+            await DisposeCompositionAsync(projectService, editorService, host);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task Project_transition_waits_for_failed_activation_cleanup()
+    {
+        await TestReset.ResetShellAsync();
+        var extensionProvider = new ExtensionProvider();
+        var editorService = new EditorService(extensionProvider);
+        var extension = new BlockingFailedActivationExtension();
+        extensionProvider.AddExtensions(ExtensionPackageId, [extension]);
+        editorService.BeforeActivationTabConstruction =
+            _ => throw new InvalidOperationException("activation construction failed");
+        var projectService = new ProjectService();
+        var host = new EditorHostViewModel(projectService, editorService);
+        TestContext? createdContext = null;
+
+        try
+        {
+            Task<Project?> creation = projectService.CreateProject(
+                320, 180, 30, 44100, "queue-activation-cleanup", NewWorkspace("activation-cleanup"));
+            TestContext context = await extension.CreatedContext.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            createdContext = context;
+            await context.DisposeStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(creation.IsCompleted, Is.False);
+                Assert.That(BeutlApplication.Current.Project, Is.Null);
+                Assert.That(editorService.TabItems, Is.Empty);
+            });
+
+            context.ReleaseDispose();
+            Project project = (await creation.WaitAsync(TimeSpan.FromSeconds(5)))!;
+            Assert.Multiple(() =>
+            {
+                Assert.That(BeutlApplication.Current.Project, Is.SameAs(project));
+                Assert.That(context.DisposeCount, Is.EqualTo(1));
+            });
+        }
+        finally
+        {
+            editorService.BeforeActivationTabConstruction = null;
+            createdContext?.ReleaseDispose();
+            await DisposeCompositionAsync(projectService, editorService, host);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task Replacement_factory_cannot_synchronously_enqueue_close_project()
+    {
+        await TestReset.ResetShellAsync();
+        var contexts = new TestContextFactory();
+        (ProjectService projectService, EditorService editorService, EditorHostViewModel host) =
+            CreateComposition(contexts);
+
+        try
+        {
+            Project project = (await projectService.CreateProject(
+                320, 180, 30, 44100, "queue-reentrant-close", NewWorkspace("reentrant-close")))!;
+            EditorTabItem tab = editorService.TabItems.Single();
+            var extension = new ReentrantProjectOperationExtension(
+                projectService.CloseProjectAsync);
+
+            Task<EditorContextReplacementStatus> replacement = Task.Run(
+                () => editorService.ReplaceContextAsync(tab, extension).AsTask());
+            InvalidOperationException failure = await CaptureInvalidOperationAsync(replacement);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(failure.Message, Does.Contain("project transition"));
+                Assert.That(extension.CreationCount, Is.EqualTo(1));
+                Assert.That(BeutlApplication.Current.Project, Is.SameAs(project));
+                Assert.That(editorService.TabItems, Does.Contain(tab));
+                Assert.That(tab.Context.Value, Is.SameAs(contexts.Contexts.Single()));
+            });
+        }
+        finally
+        {
+            await DisposeCompositionAsync(projectService, editorService, host);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task Replacement_factory_cannot_synchronously_wait_for_project_changes()
+    {
+        await TestReset.ResetShellAsync();
+        var contexts = new TestContextFactory();
+        (ProjectService projectService, EditorService editorService, EditorHostViewModel host) =
+            CreateComposition(contexts);
+
+        try
+        {
+            Project project = (await projectService.CreateProject(
+                320, 180, 30, 44100, "queue-reentrant-wait", NewWorkspace("reentrant-wait")))!;
+            EditorTabItem tab = editorService.TabItems.Single();
+            var extension = new ReentrantProjectOperationExtension(
+                projectService.WaitForPendingProjectChangesAsync);
+
+            InvalidOperationException failure = await CaptureInvalidOperationAsync(
+                editorService.ReplaceContextAsync(tab, extension).AsTask());
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(failure.Message, Does.Contain("Project changes"));
+                Assert.That(extension.CreationCount, Is.EqualTo(1));
+                Assert.That(BeutlApplication.Current.Project, Is.SameAs(project));
+                Assert.That(editorService.TabItems, Does.Contain(tab));
+                Assert.That(tab.Context.Value, Is.SameAs(contexts.Contexts.Single()));
+            });
+        }
+        finally
+        {
+            await DisposeCompositionAsync(projectService, editorService, host);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task Replacement_factory_cannot_join_external_close_waiting_for_its_admission()
+    {
+        await TestReset.ResetShellAsync().WaitAsync(TimeSpan.FromSeconds(5));
+        var contexts = new TestContextFactory();
+        (ProjectService projectService, EditorService editorService, EditorHostViewModel host) =
+            CreateComposition(contexts);
+
+        try
+        {
+            await projectService.CreateProject(
+                    320, 180, 30, 44100, "queue-reentrant-dedup", NewWorkspace("reentrant-dedup"))
+                .WaitAsync(TimeSpan.FromSeconds(5));
+            EditorTabItem tab = editorService.TabItems.Single();
+            var extension = new CoordinatedCloseProjectExtension(projectService);
+            var admissionClosed = new TaskCompletionSource(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            editorService.AfterTabAdmissionClosed = () => admissionClosed.TrySetResult();
+
+            Task<EditorContextReplacementStatus> replacement = Task.Run(
+                () => editorService.ReplaceContextAsync(tab, extension).AsTask());
+            await extension.Entered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            Task externalClose = projectService.CloseProjectAsync();
+            try
+            {
+                await admissionClosed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            }
+            finally
+            {
+                extension.Release.TrySetResult();
+            }
+            InvalidOperationException? failure = null;
+            try
+            {
+                await replacement.WaitAsync(TimeSpan.FromSeconds(5));
+                Assert.Fail("Expected the reentrant close to be rejected.");
+            }
+            catch (InvalidOperationException ex)
+            {
+                failure = ex;
+            }
+            await externalClose.WaitAsync(TimeSpan.FromSeconds(5));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(failure!.Message, Does.Contain("project transition"));
+                Assert.That(BeutlApplication.Current.Project, Is.Null);
+                Assert.That(editorService.TabItems, Is.Empty);
+            });
+            editorService.AfterTabAdmissionClosed = null;
+        }
+        finally
+        {
+            await DisposeCompositionAsync(projectService, editorService, host)
+                .WaitAsync(TimeSpan.FromSeconds(5));
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task Context_disposal_cannot_synchronously_close_its_project()
+    {
+        await TestReset.ResetShellAsync();
+        var contexts = new TestContextFactory();
+        (ProjectService projectService, EditorService editorService, EditorHostViewModel host) =
+            CreateComposition(contexts);
+
+        try
+        {
+            Project project = (await projectService.CreateProject(
+                320, 180, 30, 44100, "queue-dispose-close", NewWorkspace("dispose-close")))!;
+            EditorTabItem tab = editorService.TabItems.Single();
+            TestContext context = contexts.Contexts.Single();
+            context.OnDispose = () => projectService.CloseProjectAsync().GetAwaiter().GetResult();
+
+            InvalidOperationException failure = await CaptureInvalidOperationAsync(
+                editorService.CloseTabItem(tab).AsTask());
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(failure.Message, Does.Contain("project transition"));
+                Assert.That(BeutlApplication.Current.Project, Is.SameAs(project));
+                Assert.That(editorService.TabItems, Is.Empty);
+                Assert.That(context.DisposeCount, Is.EqualTo(1));
+            });
+        }
+        finally
+        {
+            await DisposeCompositionAsync(projectService, editorService, host);
+        }
+    }
+
+    [AvaloniaTest]
     public async Task Close_after_queued_replacement_is_not_deduplicated_with_earlier_close()
     {
         await TestReset.ResetShellAsync();
@@ -738,6 +994,21 @@ public sealed class EditorHostProjectQueueTests
         }
     }
 
+    private static async Task<InvalidOperationException> CaptureInvalidOperationAsync(Task task)
+    {
+        try
+        {
+            await task.WaitAsync(TimeSpan.FromSeconds(5));
+        }
+        catch (InvalidOperationException ex)
+        {
+            return ex;
+        }
+
+        Assert.Fail("Expected an InvalidOperationException.");
+        return null!;
+    }
+
     private static async Task WaitForPublishedProjectChangeAsync(
         ProjectService projectService,
         Task<Project?> operation)
@@ -780,6 +1051,109 @@ public sealed class EditorHostProjectQueueTests
 
         public override bool MatchFileExtension(string ext)
             => ext.Equals(".scene", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private sealed class ReentrantProjectOperationExtension(Func<Task> operation)
+        : EditorExtension
+    {
+        public int CreationCount { get; private set; }
+
+        public override FilePickerFileType GetFilePickerFileType() => new("Reentrant close");
+
+        public override IconSource? GetIcon() => null;
+
+        public override bool TryCreateEditor(
+            CoreObject obj,
+            [NotNullWhen(true)] out Control? editor)
+        {
+            editor = null;
+            return false;
+        }
+
+        public override bool MatchFileExtension(string ext) => false;
+
+        public override bool TryCreateContext(
+            CoreObject obj,
+            IEditorContextServices services,
+            [NotNullWhen(true)] out IEditorContext? context)
+        {
+            CreationCount++;
+            operation().GetAwaiter().GetResult();
+            context = null;
+            return false;
+        }
+    }
+
+    private sealed class BlockingFailedActivationExtension : EditorExtension
+    {
+        public TaskCompletionSource<TestContext> CreatedContext { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public override FilePickerFileType GetFilePickerFileType() => new("Blocking activation");
+
+        public override IconSource? GetIcon() => null;
+
+        public override bool TryCreateEditor(
+            CoreObject obj,
+            [NotNullWhen(true)] out Control? editor)
+        {
+            editor = null;
+            return false;
+        }
+
+        public override bool MatchFileExtension(string ext)
+            => ext.Equals(".scene", StringComparison.OrdinalIgnoreCase);
+
+        public override bool TryCreateContext(
+            CoreObject obj,
+            IEditorContextServices services,
+            [NotNullWhen(true)] out IEditorContext? context)
+        {
+            var created = new TestContext(
+                obj,
+                this,
+                services.CloseService,
+                blockDispose: true);
+            CreatedContext.TrySetResult(created);
+            context = created;
+            return true;
+        }
+    }
+
+    private sealed class CoordinatedCloseProjectExtension(ProjectService projectService)
+        : EditorExtension
+    {
+        public TaskCompletionSource Entered { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource Release { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public override FilePickerFileType GetFilePickerFileType() => new("Coordinated close");
+
+        public override IconSource? GetIcon() => null;
+
+        public override bool TryCreateEditor(
+            CoreObject obj,
+            [NotNullWhen(true)] out Control? editor)
+        {
+            editor = null;
+            return false;
+        }
+
+        public override bool MatchFileExtension(string ext) => false;
+
+        public override bool TryCreateContext(
+            CoreObject obj,
+            IEditorContextServices services,
+            [NotNullWhen(true)] out IEditorContext? context)
+        {
+            Entered.TrySetResult();
+            Release.Task.GetAwaiter().GetResult();
+            projectService.CloseProjectAsync().GetAwaiter().GetResult();
+            context = null;
+            return false;
+        }
     }
 
     private sealed class TestContextFactory

--- a/tests/Beutl.HeadlessUITests/EditorHostProjectQueueTests.cs
+++ b/tests/Beutl.HeadlessUITests/EditorHostProjectQueueTests.cs
@@ -1,0 +1,609 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using Avalonia.Controls;
+using Avalonia.Headless.NUnit;
+using Avalonia.Platform.Storage;
+using Avalonia.Threading;
+using Beutl.Api.Services;
+using Beutl.Collections;
+using Beutl.Extensibility;
+using Beutl.ProjectSystem;
+using Beutl.Services;
+using Beutl.Testing.Headless;
+using Beutl.ViewModels;
+using FluentAvalonia.UI.Controls;
+using Reactive.Bindings;
+
+namespace Beutl.HeadlessUITests;
+
+[TestFixture, NonParallelizable]
+public sealed class EditorHostProjectQueueTests
+{
+    private const int ExtensionPackageId = 930001;
+
+    [AvaloniaTest]
+    public async Task CreateProject_waits_for_old_context_teardown_and_keeps_new_tab()
+    {
+        await TestReset.ResetShellAsync();
+        var contexts = new TestContextFactory { BlockNextDispose = true };
+        (ProjectService projectService, EditorService editorService, EditorHostViewModel host) =
+            CreateComposition(contexts);
+
+        try
+        {
+            Project first = (await projectService.CreateProject(
+                320, 180, 30, 44100, "queue-first", NewWorkspace("create-first")))!;
+            TestContext oldContext = contexts.Contexts.Single();
+
+            Task<Project?> replacement = projectService.CreateProject(
+                640, 360, 24, 48000, "queue-second", NewWorkspace("create-second"));
+            await oldContext.DisposeStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            Assert.That(replacement.IsCompleted, Is.False,
+                "CreateProject must not complete while the old tab context is still tearing down.");
+            Assert.That(BeutlApplication.Current.Project, Is.SameAs(first),
+                "CurrentProject must not advance before the replacement editor is stable.");
+
+            oldContext.ReleaseDispose();
+            Project second = (await replacement.WaitAsync(TimeSpan.FromSeconds(5)))!;
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(second, Is.Not.SameAs(first));
+                Assert.That(BeutlApplication.Current.Project, Is.SameAs(second));
+                Assert.That(editorService.TabItems.Count, Is.EqualTo(1));
+                Assert.That(editorService.TabItems.Single().Context.Value?.Object,
+                    Is.SameAs(second.Items.Single()));
+                Assert.That(oldContext.DisposeCount, Is.EqualTo(1));
+            });
+        }
+        finally
+        {
+            await DisposeCompositionAsync(projectService, editorService, host);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task Repeated_close_joins_the_same_pending_editor_teardown()
+    {
+        await TestReset.ResetShellAsync();
+        var contexts = new TestContextFactory { BlockNextDispose = true };
+        (ProjectService projectService, EditorService editorService, EditorHostViewModel host) =
+            CreateComposition(contexts);
+
+        try
+        {
+            _ = await projectService.CreateProject(
+                320, 180, 30, 44100, "queue-close", NewWorkspace("repeated-close"));
+            TestContext context = contexts.Contexts.Single();
+
+            Task first = projectService.CloseProjectAsync();
+            await context.DisposeStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            Task second = projectService.CloseProjectAsync();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(second, Is.SameAs(first));
+                Assert.That(first.IsCompleted, Is.False);
+                Assert.That(second.IsCompleted, Is.False);
+            });
+
+            context.ReleaseDispose();
+            await Task.WhenAll(first, second).WaitAsync(TimeSpan.FromSeconds(5));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(BeutlApplication.Current.Project, Is.Null);
+                Assert.That(editorService.TabItems, Is.Empty);
+                Assert.That(context.DisposeCount, Is.EqualTo(1));
+            });
+        }
+        finally
+        {
+            await DisposeCompositionAsync(projectService, editorService, host);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task Close_after_queued_replacement_is_not_deduplicated_with_earlier_close()
+    {
+        await TestReset.ResetShellAsync();
+        var contexts = new TestContextFactory { BlockNextDispose = true };
+        (ProjectService projectService, EditorService editorService, EditorHostViewModel host) =
+            CreateComposition(contexts);
+
+        try
+        {
+            _ = await projectService.CreateProject(
+                320, 180, 30, 44100, "queue-close-order", NewWorkspace("close-order"));
+            TestContext context = contexts.Contexts.Single();
+
+            Task firstClose = projectService.CloseProjectAsync();
+            await context.DisposeStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            Task<Project?> replacement = projectService.CreateProject(
+                640, 360, 24, 48000, "queue-close-order-next", NewWorkspace("close-order-next"));
+            Task finalClose = projectService.CloseProjectAsync();
+
+            Assert.That(finalClose, Is.Not.SameAs(firstClose));
+            context.ReleaseDispose();
+            await Task.WhenAll(firstClose, replacement, finalClose).WaitAsync(TimeSpan.FromSeconds(5));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(BeutlApplication.Current.Project, Is.Null);
+                Assert.That(editorService.TabItems, Is.Empty);
+            });
+        }
+        finally
+        {
+            await DisposeCompositionAsync(projectService, editorService, host);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task Concurrent_create_requests_preserve_invocation_order()
+    {
+        await TestReset.ResetShellAsync();
+        var contexts = new TestContextFactory();
+        (ProjectService projectService, EditorService editorService, EditorHostViewModel host) =
+            CreateComposition(contexts);
+        var firstPreparationStarted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseFirstPreparation = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var secondPreparationCompleted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        projectService.BeforeCreateProjectPreparation = async name =>
+        {
+            if (name == "queue-order-first")
+            {
+                firstPreparationStarted.TrySetResult();
+                await releaseFirstPreparation.Task;
+            }
+        };
+        projectService.AfterCreateProjectPreparation = name =>
+        {
+            if (name == "queue-order-second")
+                secondPreparationCompleted.TrySetResult();
+        };
+
+        try
+        {
+            Task<Project?> first = projectService.CreateProject(
+                320, 180, 30, 44100, "queue-order-first", NewWorkspace("order-first"));
+            await firstPreparationStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            Task<Project?> second = projectService.CreateProject(
+                640, 360, 24, 48000, "queue-order-second", NewWorkspace("order-second"));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(second.IsCompleted, Is.False);
+                Assert.That(secondPreparationCompleted.Task.IsCompleted, Is.False,
+                    "A later request must not begin preparation ahead of an earlier accepted transition.");
+            });
+            releaseFirstPreparation.TrySetResult();
+
+            Project firstProject = (await first.WaitAsync(TimeSpan.FromSeconds(5)))!;
+            Project secondProject = (await second.WaitAsync(TimeSpan.FromSeconds(5)))!;
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(firstProject, Is.Not.SameAs(secondProject));
+                Assert.That(BeutlApplication.Current.Project, Is.SameAs(secondProject));
+                Assert.That(editorService.TabItems.Single().Context.Value?.Object,
+                    Is.SameAs(secondProject.Items.Single()));
+            });
+        }
+        finally
+        {
+            releaseFirstPreparation.TrySetResult();
+            projectService.BeforeCreateProjectPreparation = null;
+            projectService.AfterCreateProjectPreparation = null;
+            await DisposeCompositionAsync(projectService, editorService, host);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task Replacement_rejects_old_context_reactivation_during_teardown()
+    {
+        await TestReset.ResetShellAsync();
+        var contexts = new TestContextFactory();
+        (ProjectService projectService, EditorService editorService, EditorHostViewModel host) =
+            CreateComposition(contexts);
+
+        try
+        {
+            Project first = (await projectService.CreateProject(
+                320, 180, 30, 44100, "queue-reentrant-first", NewWorkspace("reentrant-first")))!;
+            ProjectItem oldItem = first.Items.Single();
+            contexts.Contexts.Single().OnDispose = () => editorService.ActivateTabItem(oldItem);
+
+            Project second = (await projectService.CreateProject(
+                640, 360, 24, 48000, "queue-reentrant-second", NewWorkspace("reentrant-second")))!;
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(editorService.TryGetTabItem(oldItem, out _), Is.False);
+                Assert.That(editorService.TabItems.Count, Is.EqualTo(1));
+                Assert.That(editorService.TabItems.Single().Context.Value?.Object,
+                    Is.SameAs(second.Items.Single()));
+                Assert.That(contexts.Contexts.Count, Is.EqualTo(2),
+                    "Rejected reactivation must not create another old-project context.");
+            });
+        }
+        finally
+        {
+            await DisposeCompositionAsync(projectService, editorService, host);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task Background_project_item_add_is_applied_on_ui_by_wait_for_pending_changes()
+    {
+        await TestReset.ResetShellAsync();
+        var contexts = new TestContextFactory();
+        (ProjectService projectService, EditorService editorService, EditorHostViewModel host) =
+            CreateComposition(contexts);
+
+        try
+        {
+            Project project = (await projectService.CreateProject(
+                320, 180, 30, 44100, "queue-add", NewWorkspace("background-add")))!;
+            var added = new Scene(160, 90, "background-item")
+            {
+                Uri = new Uri(Path.Combine(NewWorkspace("background-add-item"), "background-item.scene")),
+            };
+
+            await Task.Run(() => project.Items.Add(added));
+            await projectService.WaitForPendingProjectChangesAsync();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(project.Items, Does.Contain(added));
+                Assert.That(editorService.TabItems.Count, Is.EqualTo(2));
+                Assert.That(editorService.TryGetTabItem(added, out _), Is.True);
+                Assert.That(editorService.SelectedTabItem.Value?.Context.Value?.Object,
+                    Is.SameAs(added));
+            });
+        }
+        finally
+        {
+            await DisposeCompositionAsync(projectService, editorService, host);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task Queued_old_project_item_event_is_ignored_after_replacement()
+    {
+        await TestReset.ResetShellAsync();
+        var contexts = new TestContextFactory();
+        (ProjectService projectService, EditorService editorService, EditorHostViewModel host) =
+            CreateComposition(contexts);
+
+        try
+        {
+            Project first = (await projectService.CreateProject(
+                320, 180, 30, 44100, "queue-stale-first", NewWorkspace("stale-first")))!;
+            Scene stale = new(160, 90, "stale-item")
+            {
+                Uri = new Uri(Path.Combine(NewWorkspace("stale-item"), "stale-item.scene")),
+            };
+
+            // Keep the dispatcher occupied while the replacement publishes its project-change
+            // task. The old-item event is then queued behind that replacement and must be fenced
+            // by the host's active-items identity check.
+            var dispatcherEntered = new TaskCompletionSource(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            var releaseDispatcher = new TaskCompletionSource(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            Dispatcher.UIThread.Post(() =>
+            {
+                dispatcherEntered.TrySetResult();
+                releaseDispatcher.Task.GetAwaiter().GetResult();
+            });
+
+            Task<Project> scenario = Task.Run(async () =>
+            {
+                await dispatcherEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+                Task<Project?> replacement = projectService.CreateProject(
+                    640, 360, 24, 48000, "queue-stale-second", NewWorkspace("stale-second"));
+                await WaitForPublishedProjectChangeAsync(projectService, replacement);
+
+                // This event is raised while the replacement is already the pending project
+                // change, but before the UI callback can detach the old collection.
+                first.Items.Add(stale);
+                releaseDispatcher.TrySetResult();
+
+                Project second = (await replacement.WaitAsync(TimeSpan.FromSeconds(5)))!;
+                await projectService.WaitForPendingProjectChangesAsync();
+                return second;
+            });
+
+            Project secondProject = (await scenario.WaitAsync(TimeSpan.FromSeconds(10)))!;
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(BeutlApplication.Current.Project, Is.SameAs(secondProject));
+                Assert.That(editorService.TryGetTabItem(stale, out _), Is.False,
+                    "The old project's late item event must not create a tab in the replacement project.");
+                Assert.That(editorService.TabItems.Count, Is.EqualTo(1));
+                Assert.That(editorService.TabItems.Single().Context.Value?.Object,
+                    Is.SameAs(secondProject.Items.Single()));
+            });
+        }
+        finally
+        {
+            await DisposeCompositionAsync(projectService, editorService, host);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task Second_editor_host_registration_throws_and_dispose_allows_replacement()
+    {
+        await TestReset.ResetShellAsync();
+        var contexts = new TestContextFactory { BlockNextDispose = true };
+        var projectService = new ProjectService();
+        var firstEditorService = CreateEditorService(contexts);
+        var firstHost = new EditorHostViewModel(projectService, firstEditorService);
+
+        try
+        {
+            Project project = (await projectService.CreateProject(
+                320, 180, 30, 44100, "queue-host-replay", NewWorkspace("host-replay")))!;
+            Assert.Throws<InvalidOperationException>(() =>
+                new EditorHostViewModel(projectService, new EditorService(new ExtensionProvider())));
+
+            TestContext firstContext = contexts.Contexts.Single();
+            Task firstDisposal = firstHost.DisposeAsync().AsTask();
+            await firstContext.DisposeStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.Throws<InvalidOperationException>(() =>
+                new EditorHostViewModel(projectService, firstEditorService));
+            firstContext.ReleaseDispose();
+            await firstDisposal.WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.That(firstEditorService.TabItems, Is.Empty);
+
+            await using var replacementHost = new EditorHostViewModel(
+                projectService, firstEditorService);
+            await projectService.WaitForPendingProjectChangesAsync();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(BeutlApplication.Current.Project, Is.SameAs(project));
+                Assert.That(firstEditorService.TabItems.Count, Is.EqualTo(1));
+                Assert.That(firstEditorService.TabItems.Single().Context.Value?.Object,
+                    Is.SameAs(project.Items.Single()));
+            });
+        }
+        finally
+        {
+            await firstHost.DisposeAsync();
+            await projectService.CloseProjectAsync();
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task Replacing_project_items_disposes_old_context_before_pending_changes_complete()
+    {
+        await TestReset.ResetShellAsync();
+        var contexts = new TestContextFactory { BlockNextDispose = true };
+        (ProjectService projectService, EditorService editorService, EditorHostViewModel host) =
+            CreateComposition(contexts);
+
+        try
+        {
+            Project project = (await projectService.CreateProject(
+                320, 180, 30, 44100, "queue-reset", NewWorkspace("reset")))!;
+            TestContext oldContext = contexts.Contexts.Single();
+            ProjectItem oldItem = project.Items.Single();
+            var replacement = new Scene(640, 360, "replacement")
+            {
+                Uri = new Uri(Path.Combine(NewWorkspace("reset-item"), "replacement.scene")),
+            };
+
+            project.Items.Replace([replacement]);
+            Task pending = projectService.WaitForPendingProjectChangesAsync();
+            await oldContext.DisposeStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.That(pending.IsCompleted, Is.False);
+
+            oldContext.ReleaseDispose();
+            await pending.WaitAsync(TimeSpan.FromSeconds(5));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(oldContext.DisposeCount, Is.EqualTo(1));
+                Assert.That(editorService.TryGetTabItem(replacement, out _), Is.True);
+                Assert.That(editorService.TryGetTabItem(oldItem, out _), Is.False);
+                Assert.That(editorService.TabItems.Count, Is.EqualTo(1));
+            });
+        }
+        finally
+        {
+            await DisposeCompositionAsync(projectService, editorService, host);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task Resetting_project_items_disposes_old_context_before_pending_changes_complete()
+    {
+        await TestReset.ResetShellAsync();
+        var contexts = new TestContextFactory { BlockNextDispose = true };
+        (ProjectService projectService, EditorService editorService, EditorHostViewModel host) =
+            CreateComposition(contexts);
+
+        try
+        {
+            Project project = (await projectService.CreateProject(
+                320, 180, 30, 44100, "queue-clear", NewWorkspace("clear")))!;
+            TestContext oldContext = contexts.Contexts.Single();
+            project.Items.ResetBehavior = ResetBehavior.Reset;
+
+            project.Items.Clear();
+            Task pending = projectService.WaitForPendingProjectChangesAsync();
+            await oldContext.DisposeStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.That(pending.IsCompleted, Is.False);
+
+            oldContext.ReleaseDispose();
+            await pending.WaitAsync(TimeSpan.FromSeconds(5));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(oldContext.DisposeCount, Is.EqualTo(1));
+                Assert.That(editorService.TabItems, Is.Empty);
+                Assert.That(editorService.SelectedTabItem.Value, Is.Null);
+            });
+        }
+        finally
+        {
+            await DisposeCompositionAsync(projectService, editorService, host);
+        }
+    }
+
+    private static (ProjectService ProjectService, EditorService EditorService, EditorHostViewModel Host)
+        CreateComposition(TestContextFactory contexts)
+    {
+        EditorService editorService = CreateEditorService(contexts);
+        var projectService = new ProjectService();
+        var host = new EditorHostViewModel(projectService, editorService);
+        return (projectService, editorService, host);
+    }
+
+    private static EditorService CreateEditorService(TestContextFactory contexts)
+    {
+        var extensionProvider = new ExtensionProvider();
+        extensionProvider.AddExtensions(ExtensionPackageId, [new TestEditorExtension(contexts)]);
+        return new EditorService(extensionProvider);
+    }
+
+    private static async Task DisposeCompositionAsync(
+        ProjectService projectService,
+        EditorService editorService,
+        EditorHostViewModel host)
+    {
+        try
+        {
+            await projectService.CloseProjectAsync();
+        }
+        finally
+        {
+            await host.DisposeAsync();
+            await editorService.ClearTabItemsAsync();
+        }
+    }
+
+    private static string NewWorkspace(string name)
+    {
+        string path = Path.Combine(BeutlHomeIsolation.CurrentHome!, $"project-queue-{name}-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    private static async Task WaitForPublishedProjectChangeAsync(
+        ProjectService projectService,
+        Task<Project?> operation)
+    {
+        FieldInfo field = typeof(ProjectService).GetField(
+            "_lastProjectChangeTask", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        while (!operation.IsCompleted)
+        {
+            if (field.GetValue(projectService) is Task task && !task.IsCompleted)
+                return;
+
+            await Task.Yield();
+        }
+
+        Assert.Fail("The replacement operation completed before its project-change task was published.");
+    }
+
+    private sealed class TestEditorExtension(TestContextFactory contexts) : EditorExtension
+    {
+        public override FilePickerFileType GetFilePickerFileType() => new("Queue test");
+
+        public override IconSource? GetIcon() => null;
+
+        public override bool TryCreateEditor(
+            CoreObject obj,
+            [NotNullWhen(true)] out Control? editor)
+        {
+            editor = null;
+            return false;
+        }
+
+        public override bool TryCreateContext(
+            CoreObject obj,
+            IEditorContextServices services,
+            [NotNullWhen(true)] out IEditorContext? context)
+        {
+            context = contexts.Create(obj, this, services.CloseService);
+            return true;
+        }
+
+        public override bool MatchFileExtension(string ext)
+            => ext.Equals(".scene", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private sealed class TestContextFactory
+    {
+        public List<TestContext> Contexts { get; } = [];
+
+        public bool BlockNextDispose { get; set; }
+
+        public TestContext Create(
+            CoreObject obj,
+            EditorExtension extension,
+            IEditorContextCloseService closeService)
+        {
+            var context = new TestContext(obj, extension, closeService, BlockNextDispose);
+            BlockNextDispose = false;
+            Contexts.Add(context);
+            return context;
+        }
+    }
+
+    private sealed class TestContext(
+        CoreObject obj,
+        EditorExtension extension,
+        IEditorContextCloseService closeService,
+        bool blockDispose) : IEditorContext
+    {
+        private readonly TaskCompletionSource _releaseDispose = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource DisposeStarted { get; } = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public int DisposeCount { get; private set; }
+
+        public Action? OnDispose { get; set; }
+
+        public CoreObject Object { get; } = obj;
+
+        public EditorExtension Extension { get; } = extension;
+
+        public IEditorContextCloseService CloseService { get; } = closeService;
+
+        public IReactiveProperty<bool> IsEnabled { get; } = new ReactivePropertySlim<bool>(true);
+
+        public IKnownEditorCommands? Commands => null;
+
+        public async ValueTask DisposeAsync()
+        {
+            DisposeCount++;
+            DisposeStarted.TrySetResult();
+            OnDispose?.Invoke();
+            if (blockDispose)
+                await _releaseDispose.Task.ConfigureAwait(false);
+        }
+
+        public void ReleaseDispose() => _releaseDispose.TrySetResult();
+
+        public T? FindToolTab<T>(Func<T, bool> condition) where T : IToolContext => default;
+
+        public T? FindToolTab<T>() where T : IToolContext => default;
+
+        public ValueTask<bool> OpenToolTabAsync(IToolContext item) => new(false);
+
+        public ValueTask CloseToolTabAsync(IToolContext item) => ValueTask.CompletedTask;
+
+        public object? GetService(Type serviceType) => null;
+    }
+}

--- a/tests/Beutl.HeadlessUITests/EditorHostProjectQueueTests.cs
+++ b/tests/Beutl.HeadlessUITests/EditorHostProjectQueueTests.cs
@@ -345,6 +345,7 @@ public sealed class EditorHostProjectQueueTests
         var projectService = new ProjectService();
         var firstEditorService = CreateEditorService(contexts);
         var firstHost = new EditorHostViewModel(projectService, firstEditorService);
+        EditorHostViewModel? replacementHost = null;
 
         try
         {
@@ -362,7 +363,7 @@ public sealed class EditorHostProjectQueueTests
             await firstDisposal.WaitAsync(TimeSpan.FromSeconds(5));
             Assert.That(firstEditorService.TabItems, Is.Empty);
 
-            await using var replacementHost = new EditorHostViewModel(
+            replacementHost = new EditorHostViewModel(
                 projectService, firstEditorService);
             await projectService.WaitForPendingProjectChangesAsync();
 
@@ -376,8 +377,236 @@ public sealed class EditorHostProjectQueueTests
         }
         finally
         {
+            if (replacementHost is not null)
+            {
+                await projectService.CloseProjectAsync();
+                await replacementHost.DisposeAsync();
+            }
+            else
+            {
+                await firstHost.DisposeAsync();
+            }
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task Already_admitted_transition_drains_through_old_handler_before_unregister()
+    {
+        await TestReset.ResetShellAsync();
+        var contexts = new TestContextFactory();
+        (ProjectService projectService, EditorService editorService, EditorHostViewModel host) =
+            CreateComposition(contexts);
+        var preparationStarted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var releasePreparation = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        projectService.BeforeCreateProjectPreparation = async name =>
+        {
+            if (name == "queue-unregister-admitted")
+            {
+                preparationStarted.TrySetResult();
+                await releasePreparation.Task;
+            }
+        };
+
+        EditorHostViewModel? replacementHost = null;
+        try
+        {
+            _ = await projectService.CreateProject(
+                320, 180, 30, 44100, "queue-unregister-first", NewWorkspace("unregister-first"));
+
+            Task<Project?> replacement = projectService.CreateProject(
+                640,
+                360,
+                24,
+                48000,
+                "queue-unregister-admitted",
+                NewWorkspace("unregister-admitted"));
+            await preparationStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            Task dispose = host.DisposeAsync().AsTask();
+            Assert.That(dispose.IsCompleted, Is.False,
+                "Unregister must wait for an already-admitted transition before removing its handler.");
+
+            releasePreparation.TrySetResult();
+            Project admitted = (await replacement.WaitAsync(TimeSpan.FromSeconds(5)))!;
+            await dispose.WaitAsync(TimeSpan.FromSeconds(5));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(contexts.Contexts.Count, Is.EqualTo(2),
+                    "The transition must still reach the old handler after unregister begins.");
+                Assert.That(BeutlApplication.Current.Project, Is.SameAs(admitted));
+            });
+
+            replacementHost = new EditorHostViewModel(projectService, editorService);
+            await projectService.WaitForPendingProjectChangesAsync();
+            Project retry = (await projectService.CreateProject(
+                1024,
+                576,
+                30,
+                44100,
+                "queue-unregister-fence-retry",
+                NewWorkspace("unregister-fence-retry")))!;
+            Assert.That(BeutlApplication.Current.Project, Is.SameAs(retry));
+        }
+        finally
+        {
+            releasePreparation.TrySetResult();
+            projectService.BeforeCreateProjectPreparation = null;
+            if (replacementHost is not null)
+            {
+                await projectService.CloseProjectAsync();
+                await replacementHost.DisposeAsync();
+            }
+            else
+            {
+                await host.DisposeAsync();
+            }
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task Transitions_started_during_unregister_fail_without_committing()
+    {
+        await TestReset.ResetShellAsync();
+        var contexts = new TestContextFactory { BlockNextDispose = true };
+        (ProjectService projectService, EditorService editorService, EditorHostViewModel host) =
+            CreateComposition(contexts);
+        EditorHostViewModel? replacementHost = null;
+
+        try
+        {
+            Project first = (await projectService.CreateProject(
+                320, 180, 30, 44100, "queue-unregister-fence-first", NewWorkspace("unregister-fence-first")))!;
+            TestContext oldContext = contexts.Contexts.Single();
+            Task<Project?> admitted = projectService.CreateProject(
+                640,
+                360,
+                24,
+                48000,
+                "queue-unregister-fence-admitted",
+                NewWorkspace("unregister-fence-admitted"));
+            await oldContext.DisposeStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            Task dispose = host.DisposeAsync().AsTask();
+            Task<Project?> createDuringFence = projectService.CreateProject(
+                800, 450, 30, 44100, "queue-unregister-fence-create", NewWorkspace("unregister-fence-create"));
+            Task openDuringFence = projectService.OpenProject(first.Uri!.LocalPath);
+            Task closeDuringFence = projectService.CloseProjectAsync();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(createDuringFence.IsCompleted, Is.False);
+                Assert.That(openDuringFence.IsCompleted, Is.False);
+                Assert.That(closeDuringFence.IsCompleted, Is.False);
+            });
+
+            oldContext.ReleaseDispose();
+            Project admittedProject = (await admitted.WaitAsync(TimeSpan.FromSeconds(5)))!;
+            await dispose.WaitAsync(TimeSpan.FromSeconds(5));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(BeutlApplication.Current.Project, Is.SameAs(admittedProject));
+            });
+            await AssertInvalidOperationAsync(createDuringFence);
+            await AssertInvalidOperationAsync(openDuringFence);
+            await AssertInvalidOperationAsync(closeDuringFence);
+
+            replacementHost = new EditorHostViewModel(projectService, editorService);
+            await projectService.WaitForPendingProjectChangesAsync();
+        }
+        finally
+        {
+            if (replacementHost is not null)
+            {
+                await projectService.CloseProjectAsync();
+                await replacementHost.DisposeAsync();
+            }
+            else
+            {
+                await host.DisposeAsync();
+            }
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task Disposing_replacement_host_before_replay_keeps_new_admission_closed()
+    {
+        await TestReset.ResetShellAsync();
+        var contexts = new TestContextFactory();
+        (ProjectService projectService, EditorService editorService, EditorHostViewModel firstHost) =
+            CreateComposition(contexts);
+        var initializationStarted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseInitialization = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        EditorHostViewModel? secondHost = null;
+        EditorHostViewModel? finalHost = null;
+
+        try
+        {
+            Project current = (await projectService.CreateProject(
+                320, 180, 30, 44100, "queue-replacement-dispose", NewWorkspace("replacement-dispose")))!;
             await firstHost.DisposeAsync();
-            await projectService.CloseProjectAsync();
+
+            projectService.BeforeProjectChangeHandlerInitialization = async () =>
+            {
+                initializationStarted.TrySetResult();
+                await releaseInitialization.Task;
+            };
+            secondHost = new EditorHostViewModel(projectService, editorService);
+            await initializationStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            Task secondDisposal = secondHost.DisposeAsync().AsTask();
+            Task<Project?> fenced = projectService.CreateProject(
+                640,
+                360,
+                24,
+                48000,
+                "queue-replacement-dispose-fenced",
+                NewWorkspace("replacement-dispose-fenced"));
+            Assert.That(fenced.IsCompleted, Is.False);
+
+            releaseInitialization.TrySetResult();
+            await secondDisposal.WaitAsync(TimeSpan.FromSeconds(5));
+            await AssertInvalidOperationAsync(fenced);
+            Assert.Multiple(() =>
+            {
+                Assert.That(BeutlApplication.Current.Project, Is.SameAs(current));
+                Assert.That(editorService.TabItems, Is.Empty);
+            });
+
+            projectService.BeforeProjectChangeHandlerInitialization = null;
+            finalHost = new EditorHostViewModel(projectService, editorService);
+            await projectService.WaitForPendingProjectChangesAsync();
+            Project retry = (await projectService.CreateProject(
+                800,
+                450,
+                30,
+                44100,
+                "queue-replacement-dispose-retry",
+                NewWorkspace("replacement-dispose-retry")))!;
+            Assert.That(BeutlApplication.Current.Project, Is.SameAs(retry));
+        }
+        finally
+        {
+            releaseInitialization.TrySetResult();
+            projectService.BeforeProjectChangeHandlerInitialization = null;
+            if (finalHost is not null)
+            {
+                await projectService.CloseProjectAsync();
+                await finalHost.DisposeAsync();
+            }
+            else if (secondHost is not null)
+            {
+                await secondHost.DisposeAsync();
+            }
+            else
+            {
+                await firstHost.DisposeAsync();
+            }
         }
     }
 
@@ -495,6 +724,18 @@ public sealed class EditorHostProjectQueueTests
         string path = Path.Combine(BeutlHomeIsolation.CurrentHome!, $"project-queue-{name}-{Guid.NewGuid():N}");
         Directory.CreateDirectory(path);
         return path;
+    }
+
+    private static async Task AssertInvalidOperationAsync(Task task)
+    {
+        try
+        {
+            await task.WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.Fail("Expected an InvalidOperationException.");
+        }
+        catch (InvalidOperationException)
+        {
+        }
     }
 
     private static async Task WaitForPublishedProjectChangeAsync(

--- a/tests/Beutl.HeadlessUITests/EditorHostProjectQueueTests.cs
+++ b/tests/Beutl.HeadlessUITests/EditorHostProjectQueueTests.cs
@@ -23,6 +23,42 @@ public sealed class EditorHostProjectQueueTests
     private const int ExtensionPackageId = 930001;
 
     [AvaloniaTest]
+    public async Task Host_unregister_waits_for_an_admitted_git_transition_scope()
+    {
+        await TestReset.ResetShellAsync();
+        var contexts = new TestContextFactory();
+        (ProjectService projectService, EditorService editorService, EditorHostViewModel host) =
+            CreateComposition(contexts);
+        ProjectService.ProjectTransitionScope? transition = null;
+        Task? disposal = null;
+        try
+        {
+            await projectService.CreateProject(
+                320, 180, 30, 44100, "git-admitted", NewWorkspace("git-admitted"));
+            transition = await projectService.BeginVersionControlTransitionAsync(
+                new object(), CancellationToken.None);
+            disposal = host.DisposeAsync().AsTask();
+            Assert.That(disposal.IsCompleted, Is.False);
+
+            await transition.CloseProjectAsync().WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.That(editorService.TabItems, Is.Empty);
+            Assert.That(disposal.IsCompleted, Is.False);
+            await transition.DisposeAsync();
+            transition = null;
+            await disposal.WaitAsync(TimeSpan.FromSeconds(5));
+        }
+        finally
+        {
+            if (transition is not null)
+                await transition.DisposeAsync();
+            if (disposal is not null)
+                await disposal.WaitAsync(TimeSpan.FromSeconds(5));
+            else
+                await host.DisposeAsync();
+        }
+    }
+
+    [AvaloniaTest]
     public async Task CreateProject_waits_for_old_context_teardown_and_keeps_new_tab()
     {
         await TestReset.ResetShellAsync();

--- a/tests/Beutl.HeadlessUITests/EditorHostProjectQueueTests.cs
+++ b/tests/Beutl.HeadlessUITests/EditorHostProjectQueueTests.cs
@@ -6,6 +6,7 @@ using Avalonia.Platform.Storage;
 using Avalonia.Threading;
 using Beutl.Api.Services;
 using Beutl.Collections;
+using Beutl.Configuration;
 using Beutl.Extensibility;
 using Beutl.ProjectSystem;
 using Beutl.Services;
@@ -460,6 +461,73 @@ public sealed class EditorHostProjectQueueTests
     }
 
     [AvaloniaTest]
+    public async Task Project_transition_tail_includes_recent_project_updates()
+    {
+        await TestReset.ResetShellAsync();
+        var contexts = new TestContextFactory();
+        (ProjectService projectService, EditorService editorService, EditorHostViewModel host) =
+            CreateComposition(contexts);
+        var firstRecentUpdateStarted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseFirstRecentUpdate = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var secondPreparationStarted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        projectService.BeforeRecentProjectUpdate = async file =>
+        {
+            if (Path.GetFileNameWithoutExtension(file) == "tail-first")
+            {
+                firstRecentUpdateStarted.TrySetResult();
+                await releaseFirstRecentUpdate.Task;
+            }
+        };
+        projectService.BeforeCreateProjectPreparation = name =>
+        {
+            if (name == "tail-second")
+                secondPreparationStarted.TrySetResult();
+            return Task.CompletedTask;
+        };
+
+        try
+        {
+            Task<Project?> first = projectService.CreateProject(
+                320, 180, 30, 44100, "tail-first", NewWorkspace("tail-first"));
+            await firstRecentUpdateStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            Task<Project?> second = projectService.CreateProject(
+                640, 360, 24, 48000, "tail-second", NewWorkspace("tail-second"));
+            Task prematureStart = await Task.WhenAny(
+                secondPreparationStarted.Task,
+                Task.Delay(TimeSpan.FromSeconds(1)));
+
+            Assert.That(
+                prematureStart,
+                Is.Not.SameAs(secondPreparationStarted.Task),
+                "A later transition must not pass the serialized tail while the earlier recent-project update is blocked.");
+
+            releaseFirstRecentUpdate.TrySetResult();
+            Project firstProject = (await first.WaitAsync(TimeSpan.FromSeconds(5)))!;
+            Project secondProject = (await second.WaitAsync(TimeSpan.FromSeconds(5)))!;
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(firstProject, Is.Not.SameAs(secondProject));
+                Assert.That(BeutlApplication.Current.Project, Is.SameAs(secondProject));
+                Assert.That(
+                    GlobalConfiguration.Instance.ViewConfig.LastOpenedProjectFile,
+                    Is.EqualTo(secondProject.Uri!.LocalPath));
+            });
+        }
+        finally
+        {
+            releaseFirstRecentUpdate.TrySetResult();
+            projectService.BeforeRecentProjectUpdate = null;
+            projectService.BeforeCreateProjectPreparation = null;
+            await DisposeCompositionAsync(projectService, editorService, host);
+        }
+    }
+
+    [AvaloniaTest]
     public async Task Replacement_rejects_old_context_reactivation_during_teardown()
     {
         await TestReset.ResetShellAsync();
@@ -472,7 +540,7 @@ public sealed class EditorHostProjectQueueTests
             Project first = (await projectService.CreateProject(
                 320, 180, 30, 44100, "queue-reentrant-first", NewWorkspace("reentrant-first")))!;
             ProjectItem oldItem = first.Items.Single();
-            contexts.Contexts.Single().OnDispose = () => editorService.ActivateTabItem(oldItem);
+            contexts.Contexts.Single().OnDispose = () => _ = editorService.ActivateTabItemAsync(oldItem);
 
             Project second = (await projectService.CreateProject(
                 640, 360, 24, 48000, "queue-reentrant-second", NewWorkspace("reentrant-second")))!;
@@ -1040,13 +1108,12 @@ public sealed class EditorHostProjectQueueTests
             return false;
         }
 
-        public override bool TryCreateContext(
+        public override ValueTask<IEditorContext?> CreateContextAsync(
             CoreObject obj,
-            IEditorContextServices services,
-            [NotNullWhen(true)] out IEditorContext? context)
+            IEditorContextServices services)
         {
-            context = contexts.Create(obj, this, services.CloseService);
-            return true;
+            return ValueTask.FromResult<IEditorContext?>(
+                contexts.Create(obj, this, services.CloseService));
         }
 
         public override bool MatchFileExtension(string ext)
@@ -1072,15 +1139,13 @@ public sealed class EditorHostProjectQueueTests
 
         public override bool MatchFileExtension(string ext) => false;
 
-        public override bool TryCreateContext(
+        public override async ValueTask<IEditorContext?> CreateContextAsync(
             CoreObject obj,
-            IEditorContextServices services,
-            [NotNullWhen(true)] out IEditorContext? context)
+            IEditorContextServices services)
         {
             CreationCount++;
-            operation().GetAwaiter().GetResult();
-            context = null;
-            return false;
+            await operation();
+            return null;
         }
     }
 
@@ -1104,10 +1169,9 @@ public sealed class EditorHostProjectQueueTests
         public override bool MatchFileExtension(string ext)
             => ext.Equals(".scene", StringComparison.OrdinalIgnoreCase);
 
-        public override bool TryCreateContext(
+        public override ValueTask<IEditorContext?> CreateContextAsync(
             CoreObject obj,
-            IEditorContextServices services,
-            [NotNullWhen(true)] out IEditorContext? context)
+            IEditorContextServices services)
         {
             var created = new TestContext(
                 obj,
@@ -1115,8 +1179,7 @@ public sealed class EditorHostProjectQueueTests
                 services.CloseService,
                 blockDispose: true);
             CreatedContext.TrySetResult(created);
-            context = created;
-            return true;
+            return ValueTask.FromResult<IEditorContext?>(created);
         }
     }
 
@@ -1143,16 +1206,14 @@ public sealed class EditorHostProjectQueueTests
 
         public override bool MatchFileExtension(string ext) => false;
 
-        public override bool TryCreateContext(
+        public override async ValueTask<IEditorContext?> CreateContextAsync(
             CoreObject obj,
-            IEditorContextServices services,
-            [NotNullWhen(true)] out IEditorContext? context)
+            IEditorContextServices services)
         {
             Entered.TrySetResult();
-            Release.Task.GetAwaiter().GetResult();
-            projectService.CloseProjectAsync().GetAwaiter().GetResult();
-            context = null;
-            return false;
+            await Release.Task;
+            await projectService.CloseProjectAsync();
+            return null;
         }
     }
 

--- a/tests/Beutl.HeadlessUITests/EditorHostProjectQueueTests.cs
+++ b/tests/Beutl.HeadlessUITests/EditorHostProjectQueueTests.cs
@@ -59,6 +59,60 @@ public sealed class EditorHostProjectQueueTests
     }
 
     [AvaloniaTest]
+    public async Task Failed_close_removes_prepared_project_files_and_allows_retry()
+    {
+        await TestReset.ResetShellAsync();
+        var contexts = new TestContextFactory();
+        var (projects, editors, host) = CreateComposition(contexts);
+        Func<ProjectService.ProjectCloseContext, CancellationToken, Task> reject =
+            (_, _) => Task.FromException(new ProjectCloseAbortedException("close rejected"));
+        string location = NewWorkspace("create-retry-cleanup");
+        try
+        {
+            Project? original = await projects.CreateProject(16, 16, 30, 44100, "original", location);
+            projects.ClosingPreparing += reject;
+            Assert.That(await projects.CreateProject(16, 16, 30, 44100, "retry", location), Is.Null);
+            Assert.That(projects.CurrentProject.Value, Is.SameAs(original));
+            Assert.That(Directory.Exists(Path.Combine(location, "retry")), Is.False);
+            projects.ClosingPreparing -= reject;
+            Assert.That(await projects.CreateProject(16, 16, 30, 44100, "retry", location), Is.Not.Null);
+        }
+        finally
+        {
+            projects.ClosingPreparing -= reject;
+            await DisposeCompositionAsync(projects, editors, host);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task Requests_queued_during_host_initialization_preserve_invocation_order()
+    {
+        await TestReset.ResetShellAsync();
+        var contexts = new TestContextFactory();
+        EditorService editors = CreateEditorService(contexts);
+        var projects = new ProjectService();
+        var initialization = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        projects.BeforeProjectChangeHandlerInitialization = () => initialization.Task;
+        var host = new EditorHostViewModel(projects, editors);
+        var order = new List<string>();
+        projects.AfterCreateProjectPreparation = order.Add;
+        Task<Project?> first = projects.CreateProject(16, 16, 30, 44100, "first", NewWorkspace("ordered-init"));
+        Task<Project?> second = projects.CreateProject(16, 16, 30, 44100, "second", NewWorkspace("ordered-init"));
+        try
+        {
+            initialization.TrySetResult();
+            await Task.WhenAll(first, second).WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.That(order, Is.EqualTo(new[] { "first", "second" }));
+            Assert.That(projects.CurrentProject.Value, Is.SameAs(await second));
+        }
+        finally
+        {
+            initialization.TrySetResult();
+            await DisposeCompositionAsync(projects, editors, host);
+        }
+    }
+
+    [AvaloniaTest]
     public async Task CreateProject_waits_for_old_context_teardown_and_keeps_new_tab()
     {
         await TestReset.ResetShellAsync();

--- a/tests/Beutl.HeadlessUITests/EditorHostProjectQueueTests.cs
+++ b/tests/Beutl.HeadlessUITests/EditorHostProjectQueueTests.cs
@@ -75,7 +75,11 @@ public sealed class EditorHostProjectQueueTests
             Assert.That(projects.CurrentProject.Value, Is.SameAs(original));
             Assert.That(Directory.Exists(Path.Combine(location, "retry")), Is.False);
             projects.ClosingPreparing -= reject;
-            Assert.That(await projects.CreateProject(16, 16, 30, 44100, "retry", location), Is.Not.Null);
+            Project? retried = await projects.CreateProject(16, 16, 30, 44100, "retry", location);
+            Assert.That(retried, Is.Not.Null);
+            Project restored = Beutl.Serialization.CoreSerializer.RestoreFromUri<Project>(retried!.Uri!);
+            Assert.That(restored.Items.Single().Uri, Is.EqualTo(retried.Items.Single().Uri));
+            Assert.That(Directory.EnumerateDirectories(location, ".beutl-create-*"), Is.Empty);
         }
         finally
         {
@@ -108,6 +112,39 @@ public sealed class EditorHostProjectQueueTests
         finally
         {
             initialization.TrySetResult();
+            await DisposeCompositionAsync(projects, editors, host);
+        }
+    }
+
+    [AvaloniaTest]
+    [TestCase(true)]
+    [TestCase(false)]
+    public async Task Project_preparation_never_removes_a_competing_destination(bool abortClose)
+    {
+        await TestReset.ResetShellAsync();
+        var (projects, editors, host) = CreateComposition(new TestContextFactory());
+        string location = NewWorkspace("competing-project-" + abortClose);
+        string destination = Path.Combine(location, "competing");
+        string foreignFile = Path.Combine(destination, $"competing.{Beutl.Editor.EditorConstants.ProjectFileExtension}");
+        Func<ProjectService.ProjectCloseContext, CancellationToken, Task> compete = (_, _) =>
+        {
+            Directory.CreateDirectory(destination);
+            File.WriteAllText(foreignFile, "foreign project");
+            return abortClose
+                ? Task.FromException(new ProjectCloseAbortedException("close rejected"))
+                : Task.CompletedTask;
+        };
+        try
+        {
+            await projects.CreateProject(16, 16, 30, 44100, "original", location);
+            projects.ClosingPreparing += compete;
+            Assert.That(await projects.CreateProject(16, 16, 30, 44100, "competing", location), Is.Null);
+            Assert.That(File.ReadAllText(foreignFile), Is.EqualTo("foreign project"));
+            Assert.That(Directory.EnumerateDirectories(location, ".beutl-create-*"), Is.Empty);
+        }
+        finally
+        {
+            projects.ClosingPreparing -= compete;
             await DisposeCompositionAsync(projects, editors, host);
         }
     }

--- a/tests/Beutl.HeadlessUITests/EditorProjectSessionGatewayTests.cs
+++ b/tests/Beutl.HeadlessUITests/EditorProjectSessionGatewayTests.cs
@@ -73,8 +73,8 @@ public class EditorProjectSessionGatewayTests
             Assert.That(result.Session.Source, Is.EqualTo(EditingSessionSource.LiveEditor));
             Assert.That(sessions.CurrentSession, Is.Not.Null);
             Assert.That(sessions.CurrentSession!.SessionId, Is.EqualTo(result.Session.SessionId));
-            Assert.That(TestShell.Editor.SelectedTabItem.Value?.Context.Value, Is.InstanceOf<EditViewModel>());
-            var editViewModel = (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
+            Assert.That(TestShell.Editor.SelectedTabItem.Value?.Context.Value!, Is.InstanceOf<EditViewModel>());
+            var editViewModel = (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value!;
             Assert.That(editViewModel.Scene, Is.SameAs(result.Session.Root));
         });
     }
@@ -203,7 +203,7 @@ public class EditorProjectSessionGatewayTests
         {
             Assert.That(added.Project.Items.OfType<Scene>().Count(), Is.EqualTo(2));
             Assert.That(File.Exists(added.Scene.Uri!.LocalPath), Is.True);
-            var editViewModel = TestShell.Editor.SelectedTabItem.Value?.Context.Value as EditViewModel;
+            var editViewModel = TestShell.Editor.SelectedTabItem.Value?.Context.Value! as EditViewModel;
             Assert.That(editViewModel?.Scene, Is.SameAs(added.Scene));
             // The live session must be rebound to the newly activated scene, not left on the first.
             Assert.That(added.Session.Root, Is.SameAs(added.Scene));

--- a/tests/Beutl.HeadlessUITests/EditorProjectSessionGatewayTests.cs
+++ b/tests/Beutl.HeadlessUITests/EditorProjectSessionGatewayTests.cs
@@ -223,7 +223,7 @@ public class EditorProjectSessionGatewayTests
         // Swap the open project out from under the captured session: its Root scene is no longer in
         // the live project, so add_scene must refuse rather than mutate a document the client is not
         // editing.
-        TestShell.Project.CloseProject();
+        await TestShell.Project.CloseProjectAsync();
         await TestShell.Project.OpenProject(secondProject);
         HeadlessTestHelpers.Settle();
 

--- a/tests/Beutl.HeadlessUITests/EditorServiceTests.cs
+++ b/tests/Beutl.HeadlessUITests/EditorServiceTests.cs
@@ -17,6 +17,43 @@ namespace Beutl.HeadlessUITests;
 public sealed class EditorServiceTests
 {
     [Test]
+    public async Task Final_save_skips_an_active_worktree_mutation()
+    {
+        var service = new EditorService(new ExtensionProvider());
+        using IDisposable? mutation = service.TryBeginWorktreeMutation();
+        Assert.That(mutation, Is.Not.Null);
+        using IProjectFileWriteLease? write = await service.BeginFinalProjectFileWriteAsync()
+            .AsTask().WaitAsync(TimeSpan.FromSeconds(2));
+        Assert.That(write, Is.Null);
+    }
+
+    [Test]
+    public async Task Final_save_waits_for_an_ordinary_writer_then_reserves_the_workspace()
+    {
+        var service = new EditorService(new ExtensionProvider());
+        using IProjectFileWriteLease ordinary = await service.BeginProjectFileWriteAsync(CancellationToken.None);
+        Task<IProjectFileWriteLease?> pending = service.BeginFinalProjectFileWriteAsync().AsTask();
+        Assert.That(pending.IsCompleted, Is.False);
+        ordinary.Dispose();
+        using IProjectFileWriteLease? final = await pending.WaitAsync(TimeSpan.FromSeconds(2));
+        Assert.That(final, Is.Not.Null);
+        Assert.That(service.TryBeginWorktreeMutation(), Is.Null);
+    }
+
+    [Test]
+    public async Task Final_save_skips_when_a_writer_hands_its_reservation_to_git()
+    {
+        var service = new EditorService(new ExtensionProvider());
+        using IProjectFileWriteLease ordinary = await service.BeginProjectFileWriteAsync(CancellationToken.None);
+        Task<IProjectFileWriteLease?> pending = service.BeginFinalProjectFileWriteAsync().AsTask();
+        Assert.That(pending.IsCompleted, Is.False);
+        using IDisposable? mutation = service.TryBeginWorktreeMutation(ordinary);
+        Assert.That(mutation, Is.Not.Null);
+        using IProjectFileWriteLease? final = await pending.WaitAsync(TimeSpan.FromSeconds(2));
+        Assert.That(final, Is.Null);
+    }
+
+    [Test]
     public async Task Project_file_writes_and_worktree_mutations_are_mutually_exclusive()
     {
         var editorService = new EditorService(new ExtensionProvider());
@@ -246,8 +283,8 @@ public sealed class EditorServiceTests
     {
         var editorService = new EditorService(new ExtensionProvider(), (_, _) => { });
         var project = new Project { Uri = new Uri("file:///project.bep") };
-        var tabItem = new EditorTabItem(new StubEditorContext());
-        editorService.TabItems.Add(tabItem);
+        var tabItem = new EditorTabItem(new StubEditorContext(editorService));
+        editorService.TryAddTabItem(tabItem);
         await tabItem.DisposeAsync();
 
         Assert.That(
@@ -259,8 +296,8 @@ public sealed class EditorServiceTests
     public void SuspendEditors_keeps_editors_disabled_until_the_outermost_handle_is_disposed()
     {
         var editorService = new EditorService(new ExtensionProvider(), (_, _) => { });
-        var context = new StubEditorContext();
-        editorService.TabItems.Add(new EditorTabItem(context));
+        var context = new StubEditorContext(editorService);
+        editorService.TryAddTabItem(new EditorTabItem(context));
 
         using (IDisposable outer = editorService.SuspendEditors())
         {
@@ -283,8 +320,8 @@ public sealed class EditorServiceTests
     public void SuspendEditors_supports_out_of_order_disposal()
     {
         var editorService = new EditorService(new ExtensionProvider(), (_, _) => { });
-        var context = new StubEditorContext();
-        editorService.TabItems.Add(new EditorTabItem(context));
+        var context = new StubEditorContext(editorService);
+        editorService.TryAddTabItem(new EditorTabItem(context));
 
         IDisposable first = editorService.SuspendEditors();
         IDisposable second = editorService.SuspendEditors();
@@ -300,10 +337,10 @@ public sealed class EditorServiceTests
     public void SuspendEditors_releases_every_context_when_one_restore_observer_fails()
     {
         var editorService = new EditorService(new ExtensionProvider(), (_, _) => { });
-        var first = new StubEditorContext();
-        var second = new StubEditorContext();
-        editorService.TabItems.Add(new EditorTabItem(first));
-        editorService.TabItems.Add(new EditorTabItem(second));
+        var first = new StubEditorContext(editorService);
+        var second = new StubEditorContext(editorService);
+        editorService.TryAddTabItem(new EditorTabItem(first));
+        editorService.TryAddTabItem(new EditorTabItem(second));
         IDisposable suspension = editorService.SuspendEditors();
         using IDisposable subscription = first.IsEnabled.Subscribe(value =>
         {
@@ -336,8 +373,8 @@ public sealed class EditorServiceTests
                 allowSerialization.Wait();
             });
         var project = new Project { Uri = new Uri("file:///project.bep") };
-        var context = new StubEditorContext();
-        editorService.TabItems.Add(new EditorTabItem(context));
+        var context = new StubEditorContext(editorService);
+        editorService.TryAddTabItem(new EditorTabItem(context));
         var outputContext = new StubOutputContext(context.Object);
         using var output = new OutputProfileItem(outputContext, context, editorService);
         Assert.That(output.TryStart(out Task? execution), Is.True);
@@ -374,8 +411,8 @@ public sealed class EditorServiceTests
     public async Task Output_dispose_defers_workspace_release_until_execution_finishes()
     {
         var editorService = new EditorService(new ExtensionProvider(), (_, _) => { });
-        var context = new StubEditorContext();
-        editorService.TabItems.Add(new EditorTabItem(context));
+        var context = new StubEditorContext(editorService);
+        editorService.TryAddTabItem(new EditorTabItem(context));
         var outputContext = new StubOutputContext(context.Object);
         var output = new OutputProfileItem(outputContext, context, editorService);
         Assert.That(output.TryStart(out Task? execution), Is.True);
@@ -406,8 +443,8 @@ public sealed class EditorServiceTests
     public void Output_started_during_a_worktree_mutation_is_rejected_without_leaking_a_lease()
     {
         var editorService = new EditorService(new ExtensionProvider(), (_, _) => { });
-        var context = new StubEditorContext();
-        editorService.TabItems.Add(new EditorTabItem(context));
+        var context = new StubEditorContext(editorService);
+        editorService.TryAddTabItem(new EditorTabItem(context));
         var outputContext = new StubOutputContext(context.Object);
         using var output = new OutputProfileItem(outputContext, context, editorService);
 
@@ -468,8 +505,10 @@ public sealed class EditorServiceTests
         }
     }
 
-    private sealed class StubEditorContext : IEditorContext
+    private sealed class StubEditorContext(IEditorContextCloseService closeService) : IEditorContext
     {
+        public IEditorContextCloseService CloseService => closeService;
+
         public int AsyncDisposeCount { get; private set; }
 
         public ValueTask DisposeAsync()
@@ -496,10 +535,11 @@ public sealed class EditorServiceTests
             where T : IToolContext
             => default;
 
-        public bool OpenToolTab(IToolContext item) => false;
+        public ValueTask<bool> OpenToolTabAsync(IToolContext item) => ValueTask.FromResult(false);
 
-        public void CloseToolTab(IToolContext item)
+        public ValueTask CloseToolTabAsync(IToolContext item)
         {
+            return ValueTask.CompletedTask;
         }
     }
 

--- a/tests/Beutl.HeadlessUITests/EditorTabItemLifetimeTests.cs
+++ b/tests/Beutl.HeadlessUITests/EditorTabItemLifetimeTests.cs
@@ -14,6 +14,146 @@ namespace Beutl.HeadlessUITests;
 public sealed class EditorTabItemLifetimeTests
 {
     [Test]
+    public async Task AddAndSelectIsLinearizedWithConcurrentDispose()
+    {
+        var service = new EditorService(new ExtensionProvider());
+        var context = new BlockingEditorContext(blockDispose: false);
+        var tab = new EditorTabItem(context);
+        var inserted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var shutdownRequested = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        int disposeRequested = 0;
+        context.OnDispose = () =>
+        {
+            shutdownRequested.TrySetResult();
+            if (Interlocked.Exchange(ref disposeRequested, 1) == 0)
+                service.RequestContextShutdown(context);
+            return ValueTask.CompletedTask;
+        };
+
+        Task<bool> publish = Task.Run(() => service.TryAddAndSelectTabItem(tab, () =>
+        {
+            inserted.TrySetResult();
+            release.Task.GetAwaiter().GetResult();
+        }));
+        await inserted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        // Context shutdown waits for the publication gate; once publication is released it must
+        // remove the tab and clear selection before completing.
+        Task dispose = Task.Run(async () =>
+        {
+            await context.DisposeAsync();
+        });
+        await shutdownRequested.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        release.TrySetResult();
+
+        Assert.That(await publish.WaitAsync(TimeSpan.FromSeconds(5)), Is.True);
+        await dispose.WaitAsync(TimeSpan.FromSeconds(5));
+        await tab.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(service.TabItems, Is.Empty);
+            Assert.That(service.SelectedTabItem.Value, Is.Null);
+            Assert.That(tab.Context.Value, Is.Null);
+        });
+    }
+
+    [Test]
+    public async Task RemovingAnAlreadyAbsentTabClearsStaleSelection()
+    {
+        var service = new EditorService(new ExtensionProvider());
+        var tab = new EditorTabItem(new BlockingEditorContext(blockDispose: false));
+        service.AddTabItem(tab);
+        service.SelectedTabItem.Value = tab;
+        service.ClearTabItems();
+
+        Assert.That(service.SelectedTabItem.Value, Is.Null);
+        Assert.That(service.RemoveTabItem(tab), Is.False);
+        Assert.That(service.SelectedTabItem.Value, Is.Null);
+        await tab.DisposeAsync();
+    }
+
+    [Test]
+    public async Task SelectionAndRemovalDoNotInvertContextPublicationGate()
+    {
+        var service = new EditorService(new ExtensionProvider());
+        var scene = new Scene(16, 16, string.Empty)
+        {
+            Uri = new Uri(Path.Combine(Path.GetTempPath(), "publication-gate.scene"))
+        };
+        var context = new GatedEditorContext(scene);
+        var tab = new EditorTabItem(context);
+        service.AddTabItem(tab);
+        service.SelectedTabItem.Value = tab;
+        context.PauseNextPublication();
+
+        ((System.Collections.Specialized.INotifyCollectionChanged)service.TabItems).CollectionChanged += (_, args) =>
+        {
+            if (args.Action == System.Collections.Specialized.NotifyCollectionChangedAction.Remove)
+            {
+                context.EnterGate();
+                context.ExitGate();
+            }
+        };
+
+        Task activate = Task.Run(() => service.ActivateTabItem(scene));
+        await context.PublicationPaused.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Task remove = Task.Run(() => service.RemoveTabItem(tab));
+        context.ReleasePublication();
+
+        await Task.WhenAll(
+            activate.WaitAsync(TimeSpan.FromSeconds(5)),
+            remove.WaitAsync(TimeSpan.FromSeconds(5)));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(service.TabItems, Is.Empty);
+            Assert.That(service.SelectedTabItem.Value, Is.Null);
+        });
+        await tab.DisposeAsync();
+    }
+
+    [Test]
+    public async Task ReplacementAndRemovalDoNotInvertContextPublicationGate()
+    {
+        var service = new EditorService(new ExtensionProvider());
+        var tab = new EditorTabItem(new BlockingEditorContext(blockDispose: false));
+        service.AddTabItem(tab);
+        var replacement = new GatedEditorContext(new Scene(16, 16, string.Empty));
+        using IDisposable contextSubscription = tab.Context.Subscribe(value =>
+        {
+            if (ReferenceEquals(value, replacement))
+                tab.MutateLifetime(static () => { });
+        });
+        replacement.PauseNextPublication();
+
+        ((System.Collections.Specialized.INotifyCollectionChanged)service.TabItems).CollectionChanged += (_, args) =>
+        {
+            if (args.Action == System.Collections.Specialized.NotifyCollectionChangedAction.Remove)
+            {
+                replacement.EnterGate();
+                replacement.ExitGate();
+            }
+        };
+
+        Task<bool> replace = Task.Run(async () => await tab.ReplaceContextAsync(replacement));
+        await replacement.PublicationPaused.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Task remove = Task.Run(() => service.RemoveTabItem(tab));
+        replacement.ReleasePublication();
+
+        Assert.That(await replace.WaitAsync(TimeSpan.FromSeconds(5)), Is.True);
+        await remove.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Multiple(() =>
+        {
+            Assert.That(service.TabItems, Is.Empty);
+            Assert.That(service.SelectedTabItem.Value, Is.Null);
+        });
+        await tab.DisposeAsync();
+        Assert.That(replacement.DisposeCount, Is.EqualTo(1));
+    }
+
+    [Test]
     public async Task DisposeAsync_PublishesOneSharedTaskBeforeContextTeardown()
     {
         var context = new BlockingEditorContext();
@@ -325,7 +465,7 @@ public sealed class EditorTabItemLifetimeTests
                 throw new InvalidOperationException("observer failed");
         });
 
-        Assert.CatchAsync<Exception>(async () =>
+        Assert.CatchAsync<InvalidOperationException>(async () =>
             await tab.ReplaceContextAsync(replacement).AsTask().WaitAsync(TimeSpan.FromSeconds(5)));
         Assert.Multiple(() =>
         {
@@ -333,6 +473,30 @@ public sealed class EditorTabItemLifetimeTests
             Assert.That(replacement.DisposeCount, Is.EqualTo(1));
         });
         await tab.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task ThrowingReplacementSubscriberDisposesPublishedReplacement()
+    {
+        var oldContext = new BlockingEditorContext(blockDispose: false);
+        var replacement = new BlockingEditorContext(blockDispose: false);
+        var tab = new EditorTabItem(oldContext);
+        using IDisposable subscription = tab.Context.Subscribe(value =>
+        {
+            if (ReferenceEquals(value, replacement))
+                throw new InvalidOperationException("replacement observer failed");
+        });
+
+        Assert.CatchAsync<InvalidOperationException>(async () =>
+            await tab.ReplaceContextAsync(replacement).AsTask().WaitAsync(TimeSpan.FromSeconds(5)));
+        await tab.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(oldContext.DisposeCount, Is.EqualTo(1));
+            Assert.That(replacement.DisposeCount, Is.EqualTo(1));
+            Assert.That(tab.Context.Value, Is.Null);
+        });
     }
 
     [Test]
@@ -428,9 +592,10 @@ public sealed class EditorTabItemLifetimeTests
         private readonly bool _blockDispose;
         private readonly TaskCompletionSource _release = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        public BlockingEditorContext(bool blockDispose = true)
+        public BlockingEditorContext(bool blockDispose = true, CoreObject? obj = null)
         {
             _blockDispose = blockDispose;
+            Object = obj ?? new Scene(16, 16, string.Empty);
         }
 
         public TaskCompletionSource DisposeStarted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -441,7 +606,7 @@ public sealed class EditorTabItemLifetimeTests
 
         public Func<ValueTask>? OnDispose { get; set; }
 
-        public CoreObject Object { get; } = new Scene(16, 16, string.Empty);
+        public CoreObject Object { get; }
 
         public EditorExtension Extension { get; } = TestEditorExtension.Instance;
 
@@ -475,6 +640,39 @@ public sealed class EditorTabItemLifetimeTests
         }
 
         public object? GetService(Type serviceType) => null;
+    }
+
+    private sealed class GatedEditorContext(Scene scene) : BlockingEditorContext(false, scene), IEditorContextPublicationGate
+    {
+        private readonly object _gate = new();
+        private bool _pauseNext;
+        private readonly TaskCompletionSource _release = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource PublicationPaused { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public void PauseNextPublication() => _pauseNext = true;
+
+        public void ReleasePublication() => _release.TrySetResult();
+
+        public bool TryPublish(Action publish)
+        {
+            lock (_gate)
+            {
+                if (_pauseNext)
+                {
+                    _pauseNext = false;
+                    PublicationPaused.TrySetResult();
+                    _release.Task.GetAwaiter().GetResult();
+                }
+
+                publish();
+                return true;
+            }
+        }
+
+        public void EnterGate() => Monitor.Enter(_gate);
+
+        public void ExitGate() => Monitor.Exit(_gate);
     }
 
     private sealed class ThrowingEditorContext : BlockingEditorContext

--- a/tests/Beutl.HeadlessUITests/EditorTabItemLifetimeTests.cs
+++ b/tests/Beutl.HeadlessUITests/EditorTabItemLifetimeTests.cs
@@ -25,9 +25,9 @@ public sealed class EditorTabItemLifetimeTests
         int disposeRequested = 0;
         context.OnDispose = () =>
         {
-            shutdownRequested.TrySetResult();
             if (Interlocked.Exchange(ref disposeRequested, 1) == 0)
                 service.RequestContextShutdown(context);
+            shutdownRequested.TrySetResult();
             return ValueTask.CompletedTask;
         };
 
@@ -47,7 +47,7 @@ public sealed class EditorTabItemLifetimeTests
         await shutdownRequested.Task.WaitAsync(TimeSpan.FromSeconds(5));
         release.TrySetResult();
 
-        Assert.That(await publish.WaitAsync(TimeSpan.FromSeconds(5)), Is.True);
+        Assert.That(await publish.WaitAsync(TimeSpan.FromSeconds(5)), Is.False);
         await dispose.WaitAsync(TimeSpan.FromSeconds(5));
         await tab.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
 
@@ -72,6 +72,356 @@ public sealed class EditorTabItemLifetimeTests
         Assert.That(service.RemoveTabItem(tab), Is.False);
         Assert.That(service.SelectedTabItem.Value, Is.Null);
         await tab.DisposeAsync();
+    }
+
+    [Test]
+    public async Task SameTabCannotBeAttachedTwice()
+    {
+        var service = new EditorService(new ExtensionProvider());
+        var tab = new EditorTabItem(new BlockingEditorContext(blockDispose: false));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(service.TryAddTabItem(tab), Is.True);
+            Assert.That(service.TryAddTabItem(tab), Is.False);
+            Assert.That(service.TabItems.Count, Is.EqualTo(1));
+        });
+
+        await service.CloseTabItem(tab).AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task ConcurrentRemovalHasOnePhysicalExecutor()
+    {
+        var service = new EditorService(new ExtensionProvider());
+        var tab = new EditorTabItem(new BlockingEditorContext(blockDispose: false));
+        service.AddTabItem(tab);
+        int removeNotifications = 0;
+        ((INotifyCollectionChanged)service.TabItems).CollectionChanged += (_, args) =>
+        {
+            if (args.Action == NotifyCollectionChangedAction.Remove)
+                Interlocked.Increment(ref removeNotifications);
+        };
+        using var start = new ManualResetEventSlim();
+
+        Task<bool> first = Task.Run(() =>
+        {
+            start.Wait();
+            return service.RemoveTabItem(tab);
+        });
+        Task<bool> second = Task.Run(() =>
+        {
+            start.Wait();
+            return service.RemoveTabItem(tab);
+        });
+        start.Set();
+
+        bool[] results = await Task.WhenAll(first, second).WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Multiple(() =>
+        {
+            Assert.That(results.Count(static value => value), Is.EqualTo(1));
+            Assert.That(removeNotifications, Is.EqualTo(1));
+            Assert.That(service.TabItems, Is.Empty);
+        });
+        await tab.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task AddObserverCanWaitForCloseWithoutDeadlock()
+    {
+        var service = new EditorService(new ExtensionProvider());
+        var tab = new EditorTabItem(new BlockingEditorContext(blockDispose: false));
+        Task? close = null;
+        ((INotifyCollectionChanged)service.TabItems).CollectionChanged += (_, args) =>
+        {
+            if (args.Action == NotifyCollectionChangedAction.Add)
+            {
+                close = Task.Run(() => service.CloseTabItem(tab).AsTask());
+                close.GetAwaiter().GetResult();
+            }
+        };
+
+        bool added = await Task.Run(() => service.TryAddTabItem(tab))
+            .WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.That(close, Is.Not.Null);
+        await close!.WaitAsync(TimeSpan.FromSeconds(5));
+        await tab.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(added, Is.False);
+            Assert.That(service.TabItems, Is.Empty);
+            Assert.That(service.SelectedTabItem.Value, Is.Null);
+        });
+    }
+
+    [Test]
+    public async Task RemovalBeforePhysicalAddCannotLeaveAClosedTabPublished()
+    {
+        var service = new EditorService(new ExtensionProvider());
+        var context = new BlockingEditorContext(blockDispose: false);
+        var tab = new EditorTabItem(context);
+        var beforeAdd = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseAdd = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        Task<bool> add = Task.Run(() => service.TryAddTabItem(tab, () =>
+        {
+            beforeAdd.TrySetResult();
+            releaseAdd.Task.GetAwaiter().GetResult();
+        }));
+        await beforeAdd.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.That(service.RemoveTabItem(tab), Is.False);
+        releaseAdd.TrySetResult();
+
+        Assert.That(await add.WaitAsync(TimeSpan.FromSeconds(5)), Is.False);
+        await tab.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Multiple(() =>
+        {
+            Assert.That(service.TabItems, Is.Empty);
+            Assert.That(service.SelectedTabItem.Value, Is.Null);
+            Assert.That(context.DisposeCount, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public async Task ThrowingLateAddReconciliationCannotLeakContext()
+    {
+        var service = new EditorService(new ExtensionProvider());
+        var context = new BlockingEditorContext(blockDispose: false);
+        var tab = new EditorTabItem(context);
+        var beforeAdd = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseAdd = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        ((INotifyCollectionChanged)service.TabItems).CollectionChanged += (_, args) =>
+        {
+            if (args.Action == NotifyCollectionChangedAction.Remove)
+                throw new InvalidOperationException("reconciliation observer failed");
+        };
+
+        Task<bool> add = Task.Run(() => service.TryAddTabItem(tab, () =>
+        {
+            beforeAdd.TrySetResult();
+            releaseAdd.Task.GetAwaiter().GetResult();
+        }));
+        await beforeAdd.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.That(service.RemoveTabItem(tab), Is.False);
+        releaseAdd.TrySetResult();
+
+        Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await add.WaitAsync(TimeSpan.FromSeconds(5)));
+        await tab.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Multiple(() =>
+        {
+            Assert.That(service.TabItems, Is.Empty);
+            Assert.That(context.DisposeCount, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public async Task RemoveObserverCanWaitForCloseWithoutDeadlock()
+    {
+        var service = new EditorService(new ExtensionProvider());
+        var tab = new EditorTabItem(new BlockingEditorContext(blockDispose: false));
+        service.AddTabItem(tab);
+        Task? nestedClose = null;
+        ((INotifyCollectionChanged)service.TabItems).CollectionChanged += (_, args) =>
+        {
+            if (args.Action == NotifyCollectionChangedAction.Remove)
+            {
+                nestedClose = Task.Run(() => service.CloseTabItem(tab).AsTask());
+                nestedClose.GetAwaiter().GetResult();
+            }
+        };
+
+        bool removed = await Task.Run(() => service.RemoveTabItem(tab))
+            .WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.That(nestedClose, Is.Not.Null);
+        await nestedClose!.WaitAsync(TimeSpan.FromSeconds(5));
+        await tab.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(removed, Is.True);
+            Assert.That(service.TabItems, Is.Empty);
+            Assert.That(service.SelectedTabItem.Value, Is.Null);
+        });
+    }
+
+    [Test]
+    public async Task IsSelectedObserverClosingTabCannotLeaveStaleSelection()
+    {
+        var service = new EditorService(new ExtensionProvider());
+        var context = new BlockingEditorContext(blockDispose: false);
+        var tab = new EditorTabItem(context);
+        using IDisposable selectionObserver = tab.IsSelected.Subscribe(isSelected =>
+        {
+            if (isSelected)
+                service.CloseTabItem(tab).AsTask().GetAwaiter().GetResult();
+        });
+
+        Assert.That(service.TryAddAndSelectTabItem(tab), Is.False);
+        await tab.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Multiple(() =>
+        {
+            Assert.That(service.TabItems, Is.Empty);
+            Assert.That(service.SelectedTabItem.Value, Is.Null);
+            Assert.That(tab.Context.Value, Is.Null);
+        });
+    }
+
+    [Test]
+    public async Task ThrowingSelectionObserverCannotLeakNewTabContext()
+    {
+        var service = new EditorService(new ExtensionProvider());
+        var context = new BlockingEditorContext(blockDispose: false);
+        var tab = new EditorTabItem(context);
+        using IDisposable observer = tab.IsSelected.Subscribe(value =>
+        {
+            if (value)
+                throw new InvalidOperationException("selection observer failed");
+        });
+
+        Assert.Throws<InvalidOperationException>(() => service.TryAddAndSelectTabItem(tab));
+        await tab.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(service.TabItems, Is.Empty);
+            Assert.That(service.SelectedTabItem.Value, Is.Null);
+            Assert.That(context.DisposeCount, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public async Task ExistingTabSelectionObserverCanWaitForCloseWithoutDeadlock()
+    {
+        var service = new EditorService(new ExtensionProvider());
+        var scene = new Scene(16, 16, string.Empty)
+        {
+            Uri = new Uri(Path.Combine(Path.GetTempPath(), "existing-selection-close.scene"))
+        };
+        var tab = new EditorTabItem(new BlockingEditorContext(blockDispose: false, scene));
+        service.AddTabItem(tab);
+        Task? close = null;
+        using IDisposable observer = tab.IsSelected.Subscribe(value =>
+        {
+            if (value)
+            {
+                close = Task.Run(() => service.CloseTabItem(tab).AsTask());
+                close.GetAwaiter().GetResult();
+            }
+        });
+
+        await Task.Run(() => service.ActivateTabItem(scene))
+            .WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.That(close, Is.Not.Null);
+        await close!.WaitAsync(TimeSpan.FromSeconds(5));
+        await tab.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Multiple(() =>
+        {
+            Assert.That(service.TabItems, Is.Empty);
+            Assert.That(service.SelectedTabItem.Value, Is.Null);
+        });
+    }
+
+    [Test]
+    public async Task ExistingTabSelectionObserverCloseCannotReexposeStaleSelection()
+    {
+        var service = new EditorService(new ExtensionProvider());
+        var scene = new Scene(16, 16, string.Empty)
+        {
+            Uri = new Uri(Path.Combine(Path.GetTempPath(), "existing-selection-fire-and-forget.scene"))
+        };
+        var tab = new EditorTabItem(new BlockingEditorContext(blockDispose: false, scene));
+        service.AddTabItem(tab);
+        Task? close = null;
+        using IDisposable observer = tab.IsSelected.Subscribe(value =>
+        {
+            if (value)
+                close = service.CloseTabItem(tab).AsTask();
+        });
+
+        service.ActivateTabItem(scene);
+        Assert.That(close, Is.Not.Null);
+        await close!.WaitAsync(TimeSpan.FromSeconds(5));
+        await tab.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Multiple(() =>
+        {
+            Assert.That(service.TabItems, Is.Empty);
+            Assert.That(service.SelectedTabItem.Value, Is.Null);
+        });
+    }
+
+    [Test]
+    public async Task DelayedSelectionObserverChildUsesNormalDisposeSemantics()
+    {
+        var service = new EditorService(new ExtensionProvider());
+        var scene = new Scene(16, 16, string.Empty)
+        {
+            Uri = new Uri(Path.Combine(Path.GetTempPath(), "delayed-selection-close.scene"))
+        };
+        var context = new BlockingEditorContext(obj: scene);
+        var tab = new EditorTabItem(context);
+        service.AddTabItem(tab);
+        var releaseChild = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        Task? delayedClose = null;
+        using IDisposable observer = tab.IsSelected.Subscribe(value =>
+        {
+            if (value)
+            {
+                delayedClose = Task.Run(async () =>
+                {
+                    await releaseChild.Task;
+                    await service.CloseTabItem(tab);
+                });
+            }
+        });
+
+        service.ActivateTabItem(scene);
+        Assert.That(delayedClose, Is.Not.Null);
+        releaseChild.TrySetResult();
+        await context.DisposeStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.That(delayedClose!.IsCompleted, Is.False);
+
+        context.ReleaseDispose();
+        await delayedClose.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.That(service.TabItems, Is.Empty);
+    }
+
+    [Test]
+    public async Task SelectionObserverCannotStartACompetingReplacement()
+    {
+        var service = new EditorService(new ExtensionProvider());
+        var scene = new Scene(16, 16, string.Empty)
+        {
+            Uri = new Uri(Path.Combine(Path.GetTempPath(), "selection-replacement.scene"))
+        };
+        var original = new BlockingEditorContext(blockDispose: false, scene);
+        var replacement = new BlockingEditorContext(blockDispose: false);
+        var tab = new EditorTabItem(original);
+        service.AddTabItem(tab);
+        bool? replaced = null;
+        using IDisposable observer = tab.IsSelected.Subscribe(value =>
+        {
+            if (value)
+            {
+                replaced = tab.ReplaceContextAsync(replacement)
+                    .AsTask()
+                    .GetAwaiter()
+                    .GetResult();
+            }
+        });
+
+        await Task.Run(() => service.ActivateTabItem(scene))
+            .WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(replaced, Is.False);
+            Assert.That(tab.Context.Value, Is.SameAs(original));
+            Assert.That(replacement.DisposeCount, Is.EqualTo(1));
+            Assert.That(service.SelectedTabItem.Value, Is.SameAs(tab));
+        });
+        await service.CloseTabItem(tab).AsTask().WaitAsync(TimeSpan.FromSeconds(5));
     }
 
     [Test]
@@ -124,7 +474,7 @@ public sealed class EditorTabItemLifetimeTests
         using IDisposable contextSubscription = tab.Context.Subscribe(value =>
         {
             if (ReferenceEquals(value, replacement))
-                tab.MutateLifetime(static () => { });
+                _ = tab.IsPublicationCurrent();
         });
         replacement.PauseNextPublication();
 
@@ -140,9 +490,12 @@ public sealed class EditorTabItemLifetimeTests
         Task<bool> replace = Task.Run(async () => await tab.ReplaceContextAsync(replacement));
         await replacement.PublicationPaused.Task.WaitAsync(TimeSpan.FromSeconds(5));
         Task remove = Task.Run(() => service.RemoveTabItem(tab));
+        Assert.That(
+            SpinWait.SpinUntil(() => !service.ContainsTabItem(tab), TimeSpan.FromSeconds(5)),
+            Is.True);
         replacement.ReleasePublication();
 
-        Assert.That(await replace.WaitAsync(TimeSpan.FromSeconds(5)), Is.True);
+        Assert.That(await replace.WaitAsync(TimeSpan.FromSeconds(5)), Is.False);
         await remove.WaitAsync(TimeSpan.FromSeconds(5));
         Assert.Multiple(() =>
         {
@@ -316,6 +669,36 @@ public sealed class EditorTabItemLifetimeTests
     }
 
     [Test]
+    public async Task ContextSubscriberCanSynchronouslyWaitForCloseWhenReplacementPublishesNull()
+    {
+        var oldContext = new BlockingEditorContext(blockDispose: false);
+        var replacement = new BlockingEditorContext(blockDispose: false);
+        var tab = new EditorTabItem(oldContext);
+        bool closeReturned = false;
+        using IDisposable subscription = tab.Context.Subscribe(value =>
+        {
+            if (value is null)
+            {
+                Task close = Task.Run(() => tab.DisposeAsync().AsTask());
+                close.GetAwaiter().GetResult();
+                closeReturned = true;
+            }
+        });
+
+        bool replaced = await Task.Run(async () => await tab.ReplaceContextAsync(replacement))
+            .WaitAsync(TimeSpan.FromSeconds(5));
+        await tab.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(replaced, Is.False);
+            Assert.That(closeReturned, Is.True);
+            Assert.That(oldContext.DisposeCount, Is.EqualTo(1));
+            Assert.That(replacement.DisposeCount, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
     public async Task CloseStartedByReplacementPublicationWinsTheResult()
     {
         var oldContext = new BlockingEditorContext(blockDispose: false);
@@ -364,6 +747,37 @@ public sealed class EditorTabItemLifetimeTests
             Assert.That(tab.Context.Value!, Is.SameAs(replacement));
         });
         await tab.DisposeAsync();
+    }
+
+    [Test]
+    public async Task DelayedOwnedDisposalChildUsesNormalDisposeSemanticsAfterScopeEnds()
+    {
+        var oldContext = new BlockingEditorContext(blockDispose: false);
+        var replacement = new BlockingEditorContext();
+        var tab = new EditorTabItem(oldContext);
+        var releaseChild = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        Task? delayedClose = null;
+        oldContext.OnDispose = () =>
+        {
+            delayedClose = Task.Run(async () =>
+            {
+                await releaseChild.Task;
+                await tab.DisposeAsync();
+            });
+            return ValueTask.CompletedTask;
+        };
+
+        Assert.That(
+            await tab.ReplaceContextAsync(replacement).AsTask().WaitAsync(TimeSpan.FromSeconds(5)),
+            Is.True);
+        Assert.That(delayedClose, Is.Not.Null);
+        releaseChild.TrySetResult();
+        await replacement.DisposeStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.That(delayedClose!.IsCompleted, Is.False);
+
+        replacement.ReleaseDispose();
+        await delayedClose.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.That(replacement.DisposeCount, Is.EqualTo(1));
     }
 
     [Test]
@@ -664,10 +1078,10 @@ public sealed class EditorTabItemLifetimeTests
                     PublicationPaused.TrySetResult();
                     _release.Task.GetAwaiter().GetResult();
                 }
-
-                publish();
-                return true;
             }
+
+            publish();
+            return true;
         }
 
         public void EnterGate() => Monitor.Enter(_gate);

--- a/tests/Beutl.HeadlessUITests/EditorTabItemLifetimeTests.cs
+++ b/tests/Beutl.HeadlessUITests/EditorTabItemLifetimeTests.cs
@@ -391,7 +391,7 @@ public sealed class EditorTabItemLifetimeTests
     {
         var foreign = new EditorService(new ExtensionProvider());
         var provider = new ExtensionProvider();
-        var extension = new ForeignContextEditorExtension(foreign);
+        var extension = new ForeignContextEditorExtension(foreign, blockDispose: true);
         provider.AddExtensions(1, [extension]);
         var service = new EditorService(provider);
         var scene = new Scene(16, 16, string.Empty)
@@ -403,7 +403,21 @@ public sealed class EditorTabItemLifetimeTests
 
         BlockingEditorContext context = await extension.CreatedContext.Task
             .WaitAsync(TimeSpan.FromSeconds(5));
+        await context.DisposeStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.That(
+            foreign.HostToken.TryAcquireContext(
+                context,
+                out EditorContextOwnershipLease? competing),
+            Is.False);
+        Assert.That(competing, Is.Null);
+        context.ReleaseDispose();
         await context.Disposed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.That(
+            foreign.HostToken.TryAcquireContext(
+                context,
+                out EditorContextOwnershipLease? successor),
+            Is.True);
+        successor!.Dispose();
 
         Assert.Multiple(() =>
         {
@@ -418,7 +432,7 @@ public sealed class EditorTabItemLifetimeTests
     {
         var provider = new ExtensionProvider();
         var service = new EditorService(provider);
-        var extension = new TransferredContextEditorExtension(service);
+        var extension = new TransferredContextEditorExtension(service, blockDispose: true);
         provider.AddExtensions(2, [extension]);
         service.BeforeActivationTabConstruction =
             _ => throw new InvalidOperationException("Tab creation failed.");
@@ -431,12 +445,117 @@ public sealed class EditorTabItemLifetimeTests
 
         BlockingEditorContext context = await extension.CreatedContext.Task
             .WaitAsync(TimeSpan.FromSeconds(5));
+        await context.DisposeStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.That(
+            service.HostToken.TryAcquireContext(
+                context,
+                out EditorContextOwnershipLease? competing),
+            Is.False);
+        Assert.That(competing, Is.Null);
+        context.ReleaseDispose();
+        await context.Disposed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.That(
+            service.HostToken.TryAcquireContext(
+                context,
+                out EditorContextOwnershipLease? successor),
+            Is.True);
+        successor!.Dispose();
+        Assert.Multiple(() =>
+        {
+            Assert.That(service.TabItems, Is.Empty);
+            Assert.That(context.DisposeCount, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public async Task ActivationDisposesTransferredContextWhenOwnershipInspectionThrows()
+    {
+        var provider = new ExtensionProvider();
+        var service = new EditorService(provider);
+        var extension = new ThrowingActivationContextEditorExtension();
+        provider.AddExtensions(3, [extension]);
+        var scene = new Scene(16, 16, string.Empty)
+        {
+            Uri = new Uri(Path.Combine(Path.GetTempPath(), "activation-host-token.activation-fault"))
+        };
+
+        Assert.Throws<InvalidOperationException>(() => service.ActivateTabItem(scene));
+
+        BlockingEditorContext context = await extension.CreatedContext.Task
+            .WaitAsync(TimeSpan.FromSeconds(5));
         await context.Disposed.Task.WaitAsync(TimeSpan.FromSeconds(5));
         Assert.Multiple(() =>
         {
             Assert.That(service.TabItems, Is.Empty);
             Assert.That(context.DisposeCount, Is.EqualTo(1));
         });
+    }
+
+    [Test]
+    public async Task ActivationDoesNotDisposeAlreadyOwnedSameHostContext()
+    {
+        var provider = new ExtensionProvider();
+        var service = new EditorService(provider);
+        var ownedScene = new Scene(16, 16, string.Empty);
+        var ownedContext = new BlockingEditorContext(
+            blockDispose: false,
+            ownedScene,
+            new ForwardingCloseService(service));
+        var ownedTab = new EditorTabItem(ownedContext);
+        service.AddTabItem(ownedTab);
+        var extension = new ActivationExistingContextEditorExtension(ownedContext);
+        provider.AddExtensions(1, [extension]);
+        var activationScene = new Scene(16, 16, string.Empty)
+        {
+            Uri = new Uri(Path.Combine(Path.GetTempPath(), "activation-same-owned.activation"))
+        };
+
+        service.ActivateTabItem(activationScene);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(extension.CreationCount, Is.EqualTo(1));
+            Assert.That(service.TabItems, Does.Contain(ownedTab));
+            Assert.That(service.TabItems.Count, Is.EqualTo(1));
+            Assert.That(ownedTab.Context.Value, Is.SameAs(ownedContext));
+            Assert.That(ownedContext.DisposeCount, Is.Zero);
+        });
+
+        await service.CloseTabItem(ownedTab).AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task ActivationDoesNotDisposeAlreadyOwnedForeignForwardedContext()
+    {
+        var foreign = new EditorService(new ExtensionProvider());
+        var provider = new ExtensionProvider();
+        var service = new EditorService(provider);
+        var ownedScene = new Scene(16, 16, string.Empty);
+        var ownedContext = new BlockingEditorContext(
+            blockDispose: false,
+            ownedScene,
+            new ForwardingCloseService(foreign));
+        var ownedTab = new EditorTabItem(ownedContext);
+        foreign.AddTabItem(ownedTab);
+        var extension = new ActivationExistingContextEditorExtension(ownedContext);
+        provider.AddExtensions(1, [extension]);
+        var activationScene = new Scene(16, 16, string.Empty)
+        {
+            Uri = new Uri(Path.Combine(Path.GetTempPath(), "activation-foreign-owned.activation"))
+        };
+
+        service.ActivateTabItem(activationScene);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(extension.CreationCount, Is.EqualTo(1));
+            Assert.That(service.TabItems, Is.Empty);
+            Assert.That(foreign.TabItems, Does.Contain(ownedTab));
+            Assert.That(ownedTab.Context.Value, Is.SameAs(ownedContext));
+            Assert.That(ownedContext.DisposeCount, Is.Zero);
+        });
+
+        await foreign.CloseTabItem(ownedTab).AsTask().WaitAsync(TimeSpan.FromSeconds(5));
     }
 
     [Test]
@@ -557,6 +676,94 @@ public sealed class EditorTabItemLifetimeTests
             Assert.That(service.TabItems, Does.Contain(tab));
         });
         await service.CloseTabItem(tab).AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task HostMediatedReplacementDoesNotInvokeFactoryAfterAdmissionCloses()
+    {
+        var service = new EditorService(new ExtensionProvider());
+        var current = new BlockingEditorContext(blockDispose: false, closeService: service);
+        var tab = new EditorTabItem(current);
+        service.AddTabItem(tab);
+        var blocking = new BlockingReplacementExtension();
+        var rejected = new HostMediatedReplacementExtension();
+
+        Task<EditorContextReplacementStatus> first = Task.Run(
+            () => service.ReplaceContextAsync(tab, blocking).AsTask());
+        await blocking.Entered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        var admissionClosed = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        service.AfterTabAdmissionClosed = () => admissionClosed.TrySetResult();
+        Task reconcile = service.ClearTabItemsAsync().AsTask();
+        await admissionClosed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        EditorContextReplacementStatus status = await service.ReplaceContextAsync(tab, rejected);
+        Assert.Multiple(() =>
+        {
+            Assert.That(status, Is.EqualTo(EditorContextReplacementStatus.Busy));
+            Assert.That(rejected.CreationCount, Is.Zero);
+            Assert.That(reconcile.IsCompleted, Is.False);
+        });
+
+        blocking.Release.TrySetResult();
+        Assert.That(
+            await first.WaitAsync(TimeSpan.FromSeconds(5)),
+            Is.EqualTo(EditorContextReplacementStatus.Succeeded));
+        await reconcile.WaitAsync(TimeSpan.FromSeconds(5));
+        service.AfterTabAdmissionClosed = null;
+    }
+
+    [Test]
+    public async Task ReconciliationWaitsForBlockedReplacementFactoryAndCleansUp()
+    {
+        var service = new EditorService(new ExtensionProvider());
+        var current = new BlockingEditorContext(blockDispose: false, closeService: service);
+        var tab = new EditorTabItem(current);
+        service.AddTabItem(tab);
+        var blocking = new BlockingReplacementExtension();
+        var admissionClosed = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        service.AfterTabAdmissionClosed = () => admissionClosed.TrySetResult();
+
+        Task<EditorContextReplacementStatus> replacement = Task.Run(
+            () => service.ReplaceContextAsync(tab, blocking).AsTask());
+        await blocking.Entered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Task reconcile = service.ClearTabItemsAsync().AsTask();
+        await admissionClosed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.That(reconcile.IsCompleted, Is.False);
+        blocking.Release.TrySetResult();
+
+        Assert.That(
+            await replacement.WaitAsync(TimeSpan.FromSeconds(5)),
+            Is.EqualTo(EditorContextReplacementStatus.Succeeded));
+        await reconcile.WaitAsync(TimeSpan.FromSeconds(5));
+        service.AfterTabAdmissionClosed = null;
+
+        Assert.That(service.TabItems, Is.Empty);
+        Assert.That(blocking.CreatedContext!.DisposeCount, Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task ThrowingAdmissionClosedObserverDoesNotStrandAdmissionOrReconciliation()
+    {
+        var service = new EditorService(new ExtensionProvider());
+        var current = new BlockingEditorContext(blockDispose: false, closeService: service);
+        var tab = new EditorTabItem(current);
+        service.AddTabItem(tab);
+        service.AfterTabAdmissionClosed = () => throw new InvalidOperationException("admission observer failed");
+
+        Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await service.ClearTabItemsAsync());
+        service.AfterTabAdmissionClosed = null;
+
+        var extension = new HostMediatedReplacementExtension();
+        EditorContextReplacementStatus status = await service.ReplaceContextAsync(tab, extension);
+        Assert.That(status, Is.EqualTo(EditorContextReplacementStatus.Succeeded));
+
+        await service.ClearTabItemsAsync();
+        Assert.That(service.TabItems, Is.Empty);
     }
 
     [Test]
@@ -1626,6 +1833,34 @@ public sealed class EditorTabItemLifetimeTests
     }
 
     [Test]
+    public async Task ThrowingHostCloseStartStillCompletesTerminalCleanup()
+    {
+        var service = new EditorService(new ExtensionProvider());
+        var context = new BlockingEditorContext(blockDispose: false, closeService: service);
+        var tab = new EditorTabItem(context);
+        service.AddTabItem(tab);
+        service.BeforeHostCloseStart = () => throw new InvalidOperationException("close start failed");
+
+        EditorContextCloseRequest request = service.RequestClose(context);
+        InvalidOperationException exception = Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await request.Completion.WaitAsync(TimeSpan.FromSeconds(5)))!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(exception.Message, Is.EqualTo("close start failed"));
+            Assert.That(request.Status, Is.EqualTo(EditorContextCloseRequestStatus.Accepted));
+            Assert.That(context.DisposeCount, Is.EqualTo(1));
+            Assert.That(service.TabItems, Is.Empty);
+        });
+        Assert.That(
+            service.HostToken.TryAcquireContext(
+                context,
+                out EditorContextOwnershipLease? successor),
+            Is.True);
+        successor!.Dispose();
+    }
+
+    [Test]
     public async Task HostOwnedOutgoingDisposalDoesNotRequestTabClose()
     {
         var service = new EditorService(new ExtensionProvider());
@@ -2383,6 +2618,70 @@ public sealed class EditorTabItemLifetimeTests
         }
     }
 
+    private sealed class ActivationExistingContextEditorExtension(IEditorContext existingContext)
+        : EditorExtension
+    {
+        public int CreationCount { get; private set; }
+
+        public override FilePickerFileType GetFilePickerFileType() => new("ActivationExisting");
+
+        public override IconSource? GetIcon() => null;
+
+        public override bool TryCreateEditor(
+            CoreObject obj,
+            [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Control? editor)
+        {
+            editor = null;
+            return false;
+        }
+
+        public override bool MatchFileExtension(string ext) => true;
+
+        public override bool TryCreateContext(
+            CoreObject obj,
+            IEditorContextServices services,
+            [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out IEditorContext? context)
+        {
+            CreationCount++;
+            context = existingContext;
+            return true;
+        }
+    }
+
+    private sealed class ThrowingActivationContextEditorExtension : EditorExtension
+    {
+        public TaskCompletionSource<BlockingEditorContext> CreatedContext { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public override FilePickerFileType GetFilePickerFileType() => new("ActivationThrowing");
+
+        public override IconSource? GetIcon() => null;
+
+        public override bool TryCreateEditor(
+            CoreObject obj,
+            [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Control? editor)
+        {
+            editor = null;
+            return false;
+        }
+
+        public override bool MatchFileExtension(string ext) => ext == ".activation-fault";
+
+        public override bool TryCreateContext(
+            CoreObject obj,
+            IEditorContextServices services,
+            [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out IEditorContext? context)
+        {
+            var created = new BlockingEditorContext(
+                blockDispose: false,
+                obj,
+                new ThrowingHostTokenCloseService());
+            CreatedContext.TrySetResult(created);
+            context = created;
+            return true;
+        }
+    }
+
     private sealed class ForwardingCloseService(IEditorContextCloseService inner)
         : IEditorContextCloseService
     {
@@ -2473,7 +2772,9 @@ public sealed class EditorTabItemLifetimeTests
         }
     }
 
-    private sealed class ForeignContextEditorExtension(EditorService foreignHost) : EditorExtension
+    private sealed class ForeignContextEditorExtension(
+        EditorService foreignHost,
+        bool blockDispose = false) : EditorExtension
     {
         public TaskCompletionSource<BlockingEditorContext> CreatedContext { get; } =
             new(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -2497,14 +2798,16 @@ public sealed class EditorTabItemLifetimeTests
             IEditorContextServices services,
             [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out IEditorContext? context)
         {
-            var created = new BlockingEditorContext(blockDispose: false, obj, foreignHost);
+            var created = new BlockingEditorContext(blockDispose, obj, foreignHost);
             CreatedContext.TrySetResult(created);
             context = created;
             return true;
         }
     }
 
-    private sealed class TransferredContextEditorExtension(EditorService host) : EditorExtension
+    private sealed class TransferredContextEditorExtension(
+        EditorService host,
+        bool blockDispose = false) : EditorExtension
     {
         public TaskCompletionSource<BlockingEditorContext> CreatedContext { get; } =
             new(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -2528,7 +2831,7 @@ public sealed class EditorTabItemLifetimeTests
             IEditorContextServices services,
             [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out IEditorContext? context)
         {
-            var created = new BlockingEditorContext(blockDispose: false, obj, host);
+            var created = new BlockingEditorContext(blockDispose, obj, host);
             CreatedContext.TrySetResult(created);
             context = created;
             return true;

--- a/tests/Beutl.HeadlessUITests/EditorTabItemLifetimeTests.cs
+++ b/tests/Beutl.HeadlessUITests/EditorTabItemLifetimeTests.cs
@@ -528,6 +528,547 @@ public sealed class EditorTabItemLifetimeTests
     }
 
     [Test]
+    public async Task FinalReconciliationDrainJoinsSiblingAddedAfterInitialClaim()
+    {
+        var provider = new ExtensionProvider();
+        var service = new EditorService(provider);
+        var foreign = new EditorService(new ExtensionProvider());
+        (Scene parentScene, Scene siblingScene) = CreateSiblingDrainScenes("joined");
+        var sibling = new BlockingEditorContext(obj: siblingScene, closeService: service);
+        var siblingRequested = new TaskCompletionSource<EditorContextCloseRequest>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var context = new ClaimAwareEditorContext(service, parentScene, foreign)
+        {
+            AfterClaim = () =>
+            {
+                siblingRequested.TrySetResult(service.RequestClose(sibling));
+                return ValueTask.CompletedTask;
+            }
+        };
+        provider.AddExtensions(
+            1,
+            [
+                new MatchedContextEditorExtension(".parent-drain", context),
+                new MatchedContextEditorExtension(".sibling-drain", sibling)
+            ]);
+
+        Task reconciliation = service.ReconcileTabItemsAsync([parentScene, siblingScene]).AsTask();
+        await context.Claimed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        EditorContextCloseRequest request = await siblingRequested.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        bool siblingWasClaimed = false;
+        bool completedWhileSiblingBlocked = false;
+        Exception? reconciliationFailure;
+        try
+        {
+            await sibling.DisposeStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            siblingWasClaimed = IsLifecycleTeardownTaken(service, request.Completion);
+            completedWhileSiblingBlocked = reconciliation.IsCompleted;
+        }
+        finally
+        {
+            sibling.ReleaseDispose();
+            reconciliationFailure = await CaptureFailureAsync(reconciliation);
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(request.Status, Is.EqualTo(EditorContextCloseRequestStatus.Accepted));
+            Assert.That(siblingWasClaimed, Is.True);
+            Assert.That(completedWhileSiblingBlocked, Is.False);
+            Assert.That(reconciliationFailure, Is.Null);
+            Assert.That(context.DisposeCount, Is.EqualTo(1));
+            Assert.That(sibling.DisposeCount, Is.EqualTo(1));
+            Assert.That(service.TabItems, Is.Empty);
+        });
+    }
+
+    [Test]
+    public async Task FinalReconciliationDrainReportsLateSiblingFailureOnce()
+    {
+        var provider = new ExtensionProvider();
+        var service = new EditorService(provider);
+        var foreign = new EditorService(new ExtensionProvider());
+        (Scene parentScene, Scene siblingScene) = CreateSiblingDrainScenes("failure");
+        var sibling = new ThrowingEditorContext(service, siblingScene);
+        var siblingRequested = new TaskCompletionSource<EditorContextCloseRequest>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var context = new ClaimAwareEditorContext(service, parentScene, foreign)
+        {
+            AfterClaim = () =>
+            {
+                siblingRequested.TrySetResult(service.RequestClose(sibling));
+                return ValueTask.CompletedTask;
+            }
+        };
+        provider.AddExtensions(
+            1,
+            [
+                new MatchedContextEditorExtension(".parent-drain", context),
+                new MatchedContextEditorExtension(".sibling-drain", sibling)
+            ]);
+
+        Exception? firstFailure = await CaptureFailureAsync(
+            service.ReconcileTabItemsAsync([parentScene, siblingScene]).AsTask());
+        EditorContextCloseRequest request = await siblingRequested.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Exception? secondFailure = await CaptureFailureAsync(service.ClearTabItemsAsync().AsTask());
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(request.Status, Is.EqualTo(EditorContextCloseRequestStatus.Accepted));
+            Assert.That(firstFailure, Is.TypeOf<InvalidOperationException>());
+            Assert.That(firstFailure?.Message, Is.EqualTo("dispose failed"));
+            Assert.That(secondFailure, Is.Null);
+            Assert.That(context.DisposeCount, Is.EqualTo(1));
+            Assert.That(sibling.DisposeCount, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public async Task FinalReconciliationDrainAdoptsAlreadyClosingSibling()
+    {
+        var provider = new ExtensionProvider();
+        var service = new EditorService(provider);
+        var foreign = new EditorService(new ExtensionProvider());
+        (Scene parentScene, Scene siblingScene) = CreateSiblingDrainScenes("already-closing");
+        var sibling = new BlockingEditorContext(obj: siblingScene, closeService: service);
+        var allowCausalRequest = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var causalRequestCreated = new TaskCompletionSource<EditorContextCloseRequest>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var context = new ClaimAwareEditorContext(service, parentScene, foreign)
+        {
+            AfterClaim = async () =>
+            {
+                await allowCausalRequest.Task.ConfigureAwait(false);
+                causalRequestCreated.TrySetResult(service.RequestClose(sibling));
+            }
+        };
+        provider.AddExtensions(
+            1,
+            [
+                new MatchedContextEditorExtension(".parent-drain", context),
+                new MatchedContextEditorExtension(".sibling-drain", sibling)
+            ]);
+
+        Task reconciliation = service.ReconcileTabItemsAsync([parentScene, siblingScene]).AsTask();
+        await context.Claimed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        EditorContextCloseRequest firstRequest = service.RequestClose(sibling);
+        EditorContextCloseRequest causalRequest = default;
+        bool takenBeforeAdoption = false;
+        bool takenAfterAdoption = false;
+        bool completedWhileSiblingBlocked = false;
+        Exception? reconciliationFailure;
+        try
+        {
+            await sibling.DisposeStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            takenBeforeAdoption = IsLifecycleTeardownTaken(service, firstRequest.Completion);
+
+            allowCausalRequest.TrySetResult();
+            causalRequest = await causalRequestCreated.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            takenAfterAdoption = IsLifecycleTeardownTaken(service, firstRequest.Completion);
+            completedWhileSiblingBlocked = reconciliation.IsCompleted;
+        }
+        finally
+        {
+            allowCausalRequest.TrySetResult();
+            sibling.ReleaseDispose();
+            reconciliationFailure = await CaptureFailureAsync(reconciliation);
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(firstRequest.Status, Is.EqualTo(EditorContextCloseRequestStatus.Accepted));
+            Assert.That(causalRequest.Status, Is.EqualTo(EditorContextCloseRequestStatus.AlreadyClosing));
+            Assert.That(causalRequest.Completion, Is.SameAs(firstRequest.Completion));
+            Assert.That(takenBeforeAdoption, Is.False);
+            Assert.That(takenAfterAdoption, Is.True);
+            Assert.That(completedWhileSiblingBlocked, Is.False);
+            Assert.That(reconciliationFailure, Is.Null);
+            Assert.That(sibling.DisposeCount, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public async Task FinalReconciliationDrainDoesNotJoinUnrelatedLateClose()
+    {
+        var provider = new ExtensionProvider();
+        var service = new EditorService(provider);
+        var foreign = new EditorService(new ExtensionProvider());
+        (Scene parentScene, Scene siblingScene) = CreateSiblingDrainScenes("unrelated");
+        var unrelated = new BlockingEditorContext(obj: siblingScene, closeService: service);
+        var allowParentCompletion = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var context = new ClaimAwareEditorContext(service, parentScene, foreign)
+        {
+            AfterClaim = async () => await allowParentCompletion.Task.ConfigureAwait(false)
+        };
+        provider.AddExtensions(
+            1,
+            [
+                new MatchedContextEditorExtension(".parent-drain", context),
+                new MatchedContextEditorExtension(".sibling-drain", unrelated)
+            ]);
+
+        Task reconciliation = service.ReconcileTabItemsAsync([parentScene, siblingScene]).AsTask();
+        await context.Claimed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        EditorContextCloseRequest unrelatedRequest = service.RequestClose(unrelated);
+        bool unrelatedWasClaimed = false;
+        Exception? reconciliationFailure = null;
+        try
+        {
+            await unrelated.DisposeStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            unrelatedWasClaimed = IsLifecycleTeardownTaken(service, unrelatedRequest.Completion);
+            allowParentCompletion.TrySetResult();
+            await reconciliation.WaitAsync(TimeSpan.FromSeconds(5));
+        }
+        catch (Exception ex)
+        {
+            reconciliationFailure = ex;
+        }
+        finally
+        {
+            allowParentCompletion.TrySetResult();
+            unrelated.ReleaseDispose();
+            await unrelatedRequest.Completion.WaitAsync(TimeSpan.FromSeconds(5));
+            if (!reconciliation.IsCompleted)
+            {
+                try
+                {
+                    await reconciliation.WaitAsync(TimeSpan.FromSeconds(5));
+                }
+                catch
+                {
+                }
+            }
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(unrelatedRequest.Status, Is.EqualTo(EditorContextCloseRequestStatus.Accepted));
+            Assert.That(unrelatedWasClaimed, Is.False);
+            Assert.That(reconciliationFailure, Is.Null);
+            Assert.That(context.DisposeCount, Is.EqualTo(1));
+            Assert.That(unrelated.DisposeCount, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public async Task FinalReconciliationDrainDefersUnrelatedLateFailure()
+    {
+        var provider = new ExtensionProvider();
+        var service = new EditorService(provider);
+        var foreign = new EditorService(new ExtensionProvider());
+        (Scene parentScene, Scene siblingScene) = CreateSiblingDrainScenes("unrelated-failure");
+        var unrelated = new ThrowingEditorContext(service, siblingScene);
+        var allowParentCompletion = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var context = new ClaimAwareEditorContext(service, parentScene, foreign)
+        {
+            AfterClaim = async () => await allowParentCompletion.Task.ConfigureAwait(false)
+        };
+        provider.AddExtensions(
+            1,
+            [
+                new MatchedContextEditorExtension(".parent-drain", context),
+                new MatchedContextEditorExtension(".sibling-drain", unrelated)
+            ]);
+
+        Task reconciliation = service.ReconcileTabItemsAsync([parentScene, siblingScene]).AsTask();
+        await context.Claimed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        EditorContextCloseRequest unrelatedRequest = service.RequestClose(unrelated);
+        Exception? directFailure = await CaptureFailureAsync(unrelatedRequest.Completion);
+
+        allowParentCompletion.TrySetResult();
+        Exception? reconciliationFailure = await CaptureFailureAsync(reconciliation);
+        Exception? nextDrainFailure = await CaptureFailureAsync(service.ClearTabItemsAsync().AsTask());
+        Exception? finalDrainFailure = await CaptureFailureAsync(service.ClearTabItemsAsync().AsTask());
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(unrelatedRequest.Status, Is.EqualTo(EditorContextCloseRequestStatus.Accepted));
+            Assert.That(directFailure, Is.TypeOf<InvalidOperationException>());
+            Assert.That(reconciliationFailure, Is.Null);
+            Assert.That(nextDrainFailure, Is.TypeOf<InvalidOperationException>());
+            Assert.That(nextDrainFailure?.Message, Is.EqualTo("dispose failed"));
+            Assert.That(finalDrainFailure, Is.Null);
+            Assert.That(unrelated.DisposeCount, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public async Task FinalReconciliationDrainAdoptsPreexistingSiblingDescendants()
+    {
+        var provider = new ExtensionProvider();
+        var service = new EditorService(provider);
+        var foreign = new EditorService(new ExtensionProvider());
+        (Scene parentScene, Scene firstScene) = CreateSiblingDrainScenes("transitive");
+        var secondScene = new Scene(16, 16, string.Empty)
+        {
+            Uri = new Uri(Path.Combine(Path.GetTempPath(), "final-drain-transitive.descendant-drain"))
+        };
+        var second = new BlockingEditorContext(obj: secondScene, closeService: service);
+        var secondRequestCreated = new TaskCompletionSource<EditorContextCloseRequest>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var first = new BlockingEditorContext(obj: firstScene, closeService: service)
+        {
+            OnDispose = () =>
+            {
+                secondRequestCreated.TrySetResult(service.RequestClose(second));
+                return ValueTask.CompletedTask;
+            }
+        };
+        var allowCausalRequest = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var causalRequestCreated = new TaskCompletionSource<EditorContextCloseRequest>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var context = new ClaimAwareEditorContext(service, parentScene, foreign)
+        {
+            AfterClaim = async () =>
+            {
+                await allowCausalRequest.Task.ConfigureAwait(false);
+                causalRequestCreated.TrySetResult(service.RequestClose(first));
+            }
+        };
+        provider.AddExtensions(
+            1,
+            [
+                new MatchedContextEditorExtension(".parent-drain", context),
+                new MatchedContextEditorExtension(".sibling-drain", first),
+                new MatchedContextEditorExtension(".descendant-drain", second)
+            ]);
+
+        Task reconciliation = service.ReconcileTabItemsAsync(
+            [parentScene, firstScene, secondScene]).AsTask();
+        await context.Claimed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        EditorContextCloseRequest firstRequest = service.RequestClose(first);
+        EditorContextCloseRequest secondRequest = default;
+        EditorContextCloseRequest causalRequest = default;
+        bool firstTakenBeforeAdoption = false;
+        bool secondTakenBeforeAdoption = false;
+        bool firstTakenAfterAdoption = false;
+        bool secondTakenAfterAdoption = false;
+        bool completedWhileDescendantsBlocked = false;
+        Exception? reconciliationFailure;
+        try
+        {
+            secondRequest = await secondRequestCreated.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            await second.DisposeStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            firstTakenBeforeAdoption = IsLifecycleTeardownTaken(service, firstRequest.Completion);
+            secondTakenBeforeAdoption = IsLifecycleTeardownTaken(service, secondRequest.Completion);
+
+            allowCausalRequest.TrySetResult();
+            causalRequest = await causalRequestCreated.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            firstTakenAfterAdoption = IsLifecycleTeardownTaken(service, firstRequest.Completion);
+            secondTakenAfterAdoption = IsLifecycleTeardownTaken(service, secondRequest.Completion);
+            completedWhileDescendantsBlocked = reconciliation.IsCompleted;
+        }
+        finally
+        {
+            allowCausalRequest.TrySetResult();
+            first.ReleaseDispose();
+            second.ReleaseDispose();
+            reconciliationFailure = await CaptureFailureAsync(reconciliation);
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(firstRequest.Status, Is.EqualTo(EditorContextCloseRequestStatus.Accepted));
+            Assert.That(secondRequest.Status, Is.EqualTo(EditorContextCloseRequestStatus.Accepted));
+            Assert.That(causalRequest.Status, Is.EqualTo(EditorContextCloseRequestStatus.AlreadyClosing));
+            Assert.That(firstTakenBeforeAdoption, Is.False);
+            Assert.That(secondTakenBeforeAdoption, Is.False);
+            Assert.That(firstTakenAfterAdoption, Is.True);
+            Assert.That(secondTakenAfterAdoption, Is.True);
+            Assert.That(completedWhileDescendantsBlocked, Is.False);
+            Assert.That(reconciliationFailure, Is.Null);
+            Assert.That(first.DisposeCount, Is.EqualTo(1));
+            Assert.That(second.DisposeCount, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public async Task FinalReconciliationDrainAdoptsPreexistingAlreadyClosingDependency()
+    {
+        var provider = new ExtensionProvider();
+        var service = new EditorService(provider);
+        var foreign = new EditorService(new ExtensionProvider());
+        (Scene parentScene, Scene firstScene) = CreateSiblingDrainScenes("dependency");
+        var secondScene = new Scene(16, 16, string.Empty)
+        {
+            Uri = new Uri(Path.Combine(Path.GetTempPath(), "final-drain-dependency.descendant-drain"))
+        };
+        var second = new BlockingEditorContext(obj: secondScene, closeService: service);
+        var dependencyRequestCreated = new TaskCompletionSource<EditorContextCloseRequest>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var first = new BlockingEditorContext(obj: firstScene, closeService: service)
+        {
+            OnDispose = () =>
+            {
+                dependencyRequestCreated.TrySetResult(service.RequestClose(second));
+                return ValueTask.CompletedTask;
+            }
+        };
+        var allowCausalRequest = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var causalRequestCreated = new TaskCompletionSource<EditorContextCloseRequest>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var context = new ClaimAwareEditorContext(service, parentScene, foreign)
+        {
+            AfterClaim = async () =>
+            {
+                await allowCausalRequest.Task.ConfigureAwait(false);
+                causalRequestCreated.TrySetResult(service.RequestClose(first));
+            }
+        };
+        provider.AddExtensions(
+            1,
+            [
+                new MatchedContextEditorExtension(".parent-drain", context),
+                new MatchedContextEditorExtension(".sibling-drain", first),
+                new MatchedContextEditorExtension(".descendant-drain", second)
+            ]);
+
+        Task reconciliation = service.ReconcileTabItemsAsync(
+            [parentScene, firstScene, secondScene]).AsTask();
+        await context.Claimed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        EditorContextCloseRequest secondRequest = service.RequestClose(second);
+        EditorContextCloseRequest firstRequest = default;
+        EditorContextCloseRequest dependencyRequest = default;
+        EditorContextCloseRequest causalRequest = default;
+        bool firstTakenBeforeAdoption = false;
+        bool secondTakenBeforeAdoption = false;
+        bool firstTakenAfterAdoption = false;
+        bool secondTakenAfterAdoption = false;
+        bool completedWhileDependenciesBlocked = false;
+        Exception? reconciliationFailure;
+        try
+        {
+            await second.DisposeStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            firstRequest = service.RequestClose(first);
+            dependencyRequest = await dependencyRequestCreated.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            firstTakenBeforeAdoption = IsLifecycleTeardownTaken(service, firstRequest.Completion);
+            secondTakenBeforeAdoption = IsLifecycleTeardownTaken(service, secondRequest.Completion);
+
+            allowCausalRequest.TrySetResult();
+            causalRequest = await causalRequestCreated.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            firstTakenAfterAdoption = IsLifecycleTeardownTaken(service, firstRequest.Completion);
+            secondTakenAfterAdoption = IsLifecycleTeardownTaken(service, secondRequest.Completion);
+            completedWhileDependenciesBlocked = reconciliation.IsCompleted;
+        }
+        finally
+        {
+            allowCausalRequest.TrySetResult();
+            first.ReleaseDispose();
+            second.ReleaseDispose();
+            reconciliationFailure = await CaptureFailureAsync(reconciliation);
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(secondRequest.Status, Is.EqualTo(EditorContextCloseRequestStatus.Accepted));
+            Assert.That(firstRequest.Status, Is.EqualTo(EditorContextCloseRequestStatus.Accepted));
+            Assert.That(dependencyRequest.Status, Is.EqualTo(EditorContextCloseRequestStatus.AlreadyClosing));
+            Assert.That(causalRequest.Status, Is.EqualTo(EditorContextCloseRequestStatus.AlreadyClosing));
+            Assert.That(firstTakenBeforeAdoption, Is.False);
+            Assert.That(secondTakenBeforeAdoption, Is.False);
+            Assert.That(firstTakenAfterAdoption, Is.True);
+            Assert.That(secondTakenAfterAdoption, Is.True);
+            Assert.That(completedWhileDependenciesBlocked, Is.False);
+            Assert.That(reconciliationFailure, Is.Null);
+            Assert.That(first.DisposeCount, Is.EqualTo(1));
+            Assert.That(second.DisposeCount, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public async Task FinalReconciliationDrainAdoptsLateRequestFromCompletedRootOperation()
+    {
+        var provider = new ExtensionProvider();
+        var service = new EditorService(provider);
+        var foreign = new EditorService(new ExtensionProvider());
+        (Scene parentScene, Scene targetScene) = CreateSiblingDrainScenes("completed-root");
+        var keeperScene = new Scene(16, 16, string.Empty)
+        {
+            Uri = new Uri(Path.Combine(Path.GetTempPath(), "final-drain-completed-root.keeper-drain"))
+        };
+        var target = new BlockingEditorContext(obj: targetScene, closeService: service);
+        var keeper = new BlockingEditorContext(obj: keeperScene, closeService: service);
+        var allowParentCompletion = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var keeperRequestCreated = new TaskCompletionSource<EditorContextCloseRequest>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var lateRequestCreated = new TaskCompletionSource<Task<EditorContextCloseRequest>>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        ClaimAwareEditorContext? context = null;
+        context = new ClaimAwareEditorContext(service, parentScene, foreign)
+        {
+            AfterClaim = async () =>
+            {
+                await allowParentCompletion.Task.ConfigureAwait(false);
+                keeperRequestCreated.TrySetResult(service.RequestClose(keeper));
+                object entry = context!.Entry!;
+                lateRequestCreated.TrySetResult(Task.Run(() =>
+                {
+                    bool unmapped = SpinWait.SpinUntil(
+                        () => !IsLifecycleTeardownOperationMapped(service, entry),
+                        TimeSpan.FromSeconds(5));
+                    if (!unmapped)
+                        throw new TimeoutException("The completed root operation remained mapped.");
+                    return service.RequestClose(target);
+                }));
+            }
+        };
+        provider.AddExtensions(
+            1,
+            [
+                new MatchedContextEditorExtension(".parent-drain", context),
+                new MatchedContextEditorExtension(".sibling-drain", target),
+                new MatchedContextEditorExtension(".keeper-drain", keeper)
+            ]);
+
+        Task reconciliation = service.ReconcileTabItemsAsync(
+            [parentScene, targetScene, keeperScene]).AsTask();
+        await context.Claimed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        EditorContextCloseRequest targetRequest = service.RequestClose(target);
+        EditorContextCloseRequest keeperRequest = default;
+        EditorContextCloseRequest lateRequest = default;
+        bool targetTakenAfterLateRequest = false;
+        bool completedWhileTargetBlocked = false;
+        Exception? reconciliationFailure;
+        try
+        {
+            await target.DisposeStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            allowParentCompletion.TrySetResult();
+            keeperRequest = await keeperRequestCreated.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            await keeper.DisposeStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            Task<EditorContextCloseRequest> lateRequestTask = await lateRequestCreated.Task
+                .WaitAsync(TimeSpan.FromSeconds(5));
+            lateRequest = await lateRequestTask.WaitAsync(TimeSpan.FromSeconds(5));
+            targetTakenAfterLateRequest = IsLifecycleTeardownTaken(service, targetRequest.Completion);
+            completedWhileTargetBlocked = reconciliation.IsCompleted;
+        }
+        finally
+        {
+            allowParentCompletion.TrySetResult();
+            target.ReleaseDispose();
+            keeper.ReleaseDispose();
+            reconciliationFailure = await CaptureFailureAsync(reconciliation);
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(targetRequest.Status, Is.EqualTo(EditorContextCloseRequestStatus.Accepted));
+            Assert.That(keeperRequest.Status, Is.EqualTo(EditorContextCloseRequestStatus.Accepted));
+            Assert.That(lateRequest.Status, Is.EqualTo(EditorContextCloseRequestStatus.AlreadyClosing));
+            Assert.That(targetTakenAfterLateRequest, Is.True);
+            Assert.That(completedWhileTargetBlocked, Is.False);
+            Assert.That(reconciliationFailure, Is.Null);
+            Assert.That(target.DisposeCount, Is.EqualTo(1));
+            Assert.That(keeper.DisposeCount, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
     public async Task ReconciliationReportsHostCloseFailureOnce()
     {
         var service = new EditorService(new ExtensionProvider());
@@ -2824,8 +3365,10 @@ public sealed class EditorTabItemLifetimeTests
         public void ExitGate() => Monitor.Exit(_gate);
     }
 
-    private sealed class ThrowingEditorContext(IEditorContextCloseService? closeService = null)
-        : BlockingEditorContext(closeService: closeService)
+    private sealed class ThrowingEditorContext(
+        IEditorContextCloseService? closeService = null,
+        CoreObject? obj = null)
+        : BlockingEditorContext(obj: obj, closeService: closeService)
     {
         private bool _throw = true;
 
@@ -3032,6 +3575,189 @@ public sealed class EditorTabItemLifetimeTests
             await Task.Yield();
             if (AfterAwait is { } callback)
                 await callback();
+        }
+    }
+
+    private sealed class ClaimAwareEditorContext(
+        EditorService tracker,
+        CoreObject obj,
+        IEditorContextCloseService closeService)
+        : BlockingEditorContext(blockDispose: false, obj, closeService)
+    {
+        public TaskCompletionSource Claimed { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public object? Entry { get; private set; }
+
+        public Func<ValueTask>? AfterClaim { get; set; }
+
+        public override async ValueTask DisposeAsync()
+        {
+            object entry = Entry = CaptureOnlyActiveLifecycleTeardown(tracker);
+            DisposeCount++;
+            DisposeStarted.TrySetResult();
+            bool taken = await Task.Run(() => SpinWait.SpinUntil(
+                () => IsLifecycleTeardownTaken(tracker, entry),
+                TimeSpan.FromSeconds(5)));
+            if (!taken)
+                throw new TimeoutException("The lifecycle teardown was not claimed.");
+
+            Claimed.TrySetResult();
+            if (AfterClaim is { } callback)
+                await callback();
+            Disposed.TrySetResult();
+        }
+    }
+
+    private sealed class MatchedContextEditorExtension(
+        string fileExtension,
+        IEditorContext context) : EditorExtension
+    {
+        public override FilePickerFileType GetFilePickerFileType() => new("Sibling");
+
+        public override IconSource? GetIcon() => null;
+
+        public override bool TryCreateEditor(
+            CoreObject obj,
+            [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Control? editor)
+        {
+            editor = null;
+            return false;
+        }
+
+        public override bool MatchFileExtension(string ext) => ext == fileExtension;
+
+        public override bool TryCreateContext(
+            CoreObject obj,
+            IEditorContextServices services,
+            [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out IEditorContext? result)
+        {
+            result = context;
+            return true;
+        }
+    }
+
+    private static (Scene Parent, Scene Sibling) CreateSiblingDrainScenes(string suffix)
+    {
+        var parent = new Scene(16, 16, string.Empty)
+        {
+            Uri = new Uri(Path.Combine(
+                Path.GetTempPath(),
+                $"final-drain-{suffix}.parent-drain"))
+        };
+        var sibling = new Scene(16, 16, string.Empty)
+        {
+            Uri = new Uri(Path.Combine(
+                Path.GetTempPath(),
+                $"final-drain-{suffix}.sibling-drain"))
+        };
+        return (parent, sibling);
+    }
+
+    private static object CaptureOnlyActiveLifecycleTeardown(EditorService service)
+    {
+        var gateField = typeof(EditorService).GetField(
+            "_lifecycleTeardownGate",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
+        var activeField = typeof(EditorService).GetField(
+            "_activeLifecycleTeardowns",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
+        object gate = gateField.GetValue(service)!;
+        lock (gate)
+        {
+            var active = (System.Collections.IEnumerable)activeField.GetValue(service)!;
+            return active.Cast<object>().Single();
+        }
+    }
+
+    private static bool IsLifecycleTeardownTaken(EditorService service, Task completion)
+    {
+        var gateField = typeof(EditorService).GetField(
+            "_lifecycleTeardownGate",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
+        var mapField = typeof(EditorService).GetField(
+            "_lifecycleTeardownsByTask",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+        object gate = gateField.GetValue(service)!;
+        lock (gate)
+        {
+            object? entry = null;
+            if (mapField?.GetValue(service) is System.Collections.IDictionary map)
+                entry = map[completion];
+
+            if (entry is null)
+            {
+                var activeField = typeof(EditorService).GetField(
+                    "_activeLifecycleTeardowns",
+                    System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
+                var active = (System.Collections.IEnumerable)activeField.GetValue(service)!;
+                entry = active.Cast<object>().FirstOrDefault(candidate =>
+                    ReferenceEquals(GetLifecycleTeardownTask(candidate), completion));
+            }
+
+            return entry is not null && ReadLifecycleTeardownTaken(entry);
+        }
+    }
+
+    private static bool IsLifecycleTeardownTaken(EditorService service, object entry)
+    {
+        var gateField = typeof(EditorService).GetField(
+            "_lifecycleTeardownGate",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
+        object gate = gateField.GetValue(service)!;
+        lock (gate)
+        {
+            return ReadLifecycleTeardownTaken(entry);
+        }
+    }
+
+    private static bool ReadLifecycleTeardownTaken(object entry)
+        => (bool)entry.GetType().GetProperty(nameof(DeferredLifecycleTeardownView.Taken))!
+            .GetValue(entry)!;
+
+    private static bool IsLifecycleTeardownOperationMapped(EditorService service, object entry)
+    {
+        var gateField = typeof(EditorService).GetField(
+            "_lifecycleTeardownGate",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
+        var mapField = typeof(EditorService).GetField(
+            "_lifecycleTeardownsByOperation",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+        if (mapField is null)
+            return false;
+        object operation = entry.GetType().GetProperty(nameof(DeferredLifecycleTeardownView.Operation))!
+            .GetValue(entry)!;
+        object gate = gateField.GetValue(service)!;
+        lock (gate)
+        {
+            var map = (System.Collections.IDictionary)mapField.GetValue(service)!;
+            return map.Contains(operation);
+        }
+    }
+
+    private static Task GetLifecycleTeardownTask(object entry)
+        => (Task)entry.GetType().GetProperty(nameof(DeferredLifecycleTeardownView.Task))!
+            .GetValue(entry)!;
+
+    private sealed class DeferredLifecycleTeardownView
+    {
+        public Task Task { get; } = Task.CompletedTask;
+
+        public object Operation { get; } = new();
+
+        public bool Taken { get; }
+    }
+
+    private static async Task<Exception?> CaptureFailureAsync(Task task)
+    {
+        try
+        {
+            await task.WaitAsync(TimeSpan.FromSeconds(5));
+            return null;
+        }
+        catch (Exception ex)
+        {
+            return ex;
         }
     }
 

--- a/tests/Beutl.HeadlessUITests/EditorTabItemLifetimeTests.cs
+++ b/tests/Beutl.HeadlessUITests/EditorTabItemLifetimeTests.cs
@@ -91,6 +91,150 @@ public sealed class EditorTabItemLifetimeTests
     }
 
     [Test]
+    public async Task CloseRequestReportsOwnershipAndSharesTerminalCompletion()
+    {
+        var service = new EditorService(new ExtensionProvider());
+        var context = new BlockingEditorContext();
+        var tab = new EditorTabItem(context);
+        service.AddTabItem(tab);
+
+        EditorContextCloseRequest accepted = service.RequestClose(context);
+        EditorContextCloseRequest repeated = service.RequestClose(context);
+        var unknown = new BlockingEditorContext(blockDispose: false);
+        EditorContextCloseRequest notOwned = service.RequestClose(unknown);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(accepted.Status, Is.EqualTo(EditorContextCloseRequestStatus.Accepted));
+            Assert.That(repeated.Status, Is.EqualTo(EditorContextCloseRequestStatus.AlreadyClosing));
+            Assert.That(repeated.Completion, Is.SameAs(accepted.Completion));
+            Assert.That(accepted.Completion.IsCompleted, Is.False);
+            Assert.That(notOwned.Status, Is.EqualTo(EditorContextCloseRequestStatus.NotOwned));
+            Assert.That(notOwned.Completion.IsCompletedSuccessfully, Is.True);
+        });
+
+        context.ReleaseDispose();
+        await accepted.Completion.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.That(service.TabItems, Is.Empty);
+    }
+
+    [Test]
+    public void CloseRequestCompletionPropagatesTerminalFailure()
+    {
+        var service = new EditorService(new ExtensionProvider());
+        var context = new ThrowingEditorContext();
+        var tab = new EditorTabItem(context);
+        service.AddTabItem(tab);
+
+        EditorContextCloseRequest request = service.RequestClose(context);
+
+        Assert.That(request.Status, Is.EqualTo(EditorContextCloseRequestStatus.Accepted));
+        Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await request.Completion.WaitAsync(TimeSpan.FromSeconds(5)));
+        Assert.That(context.DisposeCount, Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task DisposingHostOwnedTabUsesAuthoritativeHostClose()
+    {
+        var service = new EditorService(new ExtensionProvider());
+        var context = new BlockingEditorContext(blockDispose: false);
+        var tab = new EditorTabItem(context);
+        service.AddTabItem(tab);
+        service.SelectedTabItem.Value = tab;
+
+        await tab.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(service.TabItems, Is.Empty);
+            Assert.That(service.SelectedTabItem.Value, Is.Null);
+            Assert.That(context.DisposeCount, Is.EqualTo(1));
+            Assert.That(service.RequestClose(context).Status, Is.EqualTo(EditorContextCloseRequestStatus.NotOwned));
+        });
+    }
+
+    [Test]
+    public async Task ContextIdentityCannotBeOwnedByTwoTabs()
+    {
+        var service = new EditorService(new ExtensionProvider());
+        var context = new BlockingEditorContext(blockDispose: false);
+        var first = new EditorTabItem(context);
+        var second = new EditorTabItem(context);
+
+        Assert.That(service.TryAddTabItem(first), Is.True);
+        Assert.That(service.TryAddTabItem(second), Is.False);
+        Assert.Multiple(() =>
+        {
+            Assert.That(service.TabItems.Count, Is.EqualTo(1));
+            Assert.That(context.DisposeCount, Is.Zero);
+        });
+
+        await service.CloseTabItem(first).AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.That(context.DisposeCount, Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task InitialClaimIsNotVisibleBeforeItemAcceptsOwnership()
+    {
+        var service = new EditorService(new ExtensionProvider());
+        var context = new BlockingEditorContext(blockDispose: false);
+        var tab = new EditorTabItem(context);
+        var claimAttached = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var publishClaim = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        service.BeforeInitialContextClaimPublish = () =>
+        {
+            claimAttached.TrySetResult();
+            publishClaim.Task.GetAwaiter().GetResult();
+        };
+
+        Task<bool> add = Task.Run(() => service.TryAddTabItem(tab));
+        await claimAttached.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Task<EditorContextCloseRequest> close = Task.Run(() => service.RequestClose(context));
+        Assert.That(close.Wait(TimeSpan.FromMilliseconds(100)), Is.False);
+        publishClaim.TrySetResult();
+
+        _ = await add.WaitAsync(TimeSpan.FromSeconds(5));
+        EditorContextCloseRequest request = await close.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.That(request.Status, Is.EqualTo(EditorContextCloseRequestStatus.Accepted));
+        await request.Completion.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.That(service.RequestClose(context).Status, Is.EqualTo(EditorContextCloseRequestStatus.NotOwned));
+    }
+
+    [Test]
+    public async Task SameTabCanBeClaimedByOnlyOneEditorService()
+    {
+        var firstService = new EditorService(new ExtensionProvider());
+        var secondService = new EditorService(new ExtensionProvider());
+        var context = new BlockingEditorContext(blockDispose: false);
+        var tab = new EditorTabItem(context);
+        using var beforeAttach = new Barrier(2);
+        firstService.BeforeInitialOwnerAttach = WaitForBothServices;
+        secondService.BeforeInitialOwnerAttach = WaitForBothServices;
+
+        Task<bool> first = Task.Run(() => firstService.TryAddTabItem(tab));
+        Task<bool> second = Task.Run(() => secondService.TryAddTabItem(tab));
+        bool[] results = await Task.WhenAll(first, second).WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.That(results.Count(static value => value), Is.EqualTo(1));
+        EditorService owner = results[0] ? firstService : secondService;
+        EditorService loser = results[0] ? secondService : firstService;
+        Assert.Multiple(() =>
+        {
+            Assert.That(owner.TabItems, Does.Contain(tab));
+            Assert.That(loser.TabItems, Is.Empty);
+            Assert.That(loser.RequestClose(context).Status, Is.EqualTo(EditorContextCloseRequestStatus.NotOwned));
+        });
+        await owner.CloseTabItem(tab).AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+
+        void WaitForBothServices()
+        {
+            if (!beforeAttach.SignalAndWait(TimeSpan.FromSeconds(5)))
+                throw new TimeoutException("Both services did not reach owner attachment.");
+        }
+    }
+
+    [Test]
     public async Task ConcurrentRemovalHasOnePhysicalExecutor()
     {
         var service = new EditorService(new ExtensionProvider());
@@ -131,27 +275,59 @@ public sealed class EditorTabItemLifetimeTests
     {
         var service = new EditorService(new ExtensionProvider());
         var tab = new EditorTabItem(new BlockingEditorContext(blockDispose: false));
-        Task? close = null;
+        EditorContextCloseRequest closeRequest = default;
         ((INotifyCollectionChanged)service.TabItems).CollectionChanged += (_, args) =>
         {
             if (args.Action == NotifyCollectionChangedAction.Add)
-            {
-                close = Task.Run(() => service.CloseTabItem(tab).AsTask());
-                close.GetAwaiter().GetResult();
-            }
+                closeRequest = service.RequestClose(tab.Context.Value!);
         };
 
         bool added = await Task.Run(() => service.TryAddTabItem(tab))
             .WaitAsync(TimeSpan.FromSeconds(5));
-        Assert.That(close, Is.Not.Null);
-        await close!.WaitAsync(TimeSpan.FromSeconds(5));
-        await tab.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.That(closeRequest.Status, Is.EqualTo(EditorContextCloseRequestStatus.Accepted));
+        await closeRequest.Completion.WaitAsync(TimeSpan.FromSeconds(5));
 
         Assert.Multiple(() =>
         {
             Assert.That(added, Is.False);
             Assert.That(service.TabItems, Is.Empty);
             Assert.That(service.SelectedTabItem.Value, Is.Null);
+        });
+    }
+
+    [Test]
+    public async Task RemovalObserverCanWaitForRejectedAddToReturn()
+    {
+        var service = new EditorService(new ExtensionProvider());
+        var tab = new EditorTabItem(new BlockingEditorContext(blockDispose: false));
+        var addReturned = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        bool removalObservedAddReturn = false;
+        ((INotifyCollectionChanged)service.TabItems).CollectionChanged += (_, args) =>
+        {
+            if (args.Action == NotifyCollectionChangedAction.Add)
+            {
+                _ = service.RequestClose(tab.Context.Value!);
+            }
+            else if (args.Action == NotifyCollectionChangedAction.Remove)
+            {
+                removalObservedAddReturn = addReturned.Task.Wait(TimeSpan.FromSeconds(2));
+                if (!removalObservedAddReturn)
+                    throw new TimeoutException("Removal waited on an Add that joined removal completion.");
+            }
+        };
+
+        bool added = await Task.Run(() =>
+        {
+            try { return service.TryAddTabItem(tab); }
+            finally { addReturned.TrySetResult(); }
+        }).WaitAsync(TimeSpan.FromSeconds(5));
+        await tab.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(added, Is.False);
+            Assert.That(removalObservedAddReturn, Is.True);
+            Assert.That(service.TabItems, Is.Empty);
         });
     }
 
@@ -163,6 +339,12 @@ public sealed class EditorTabItemLifetimeTests
         var tab = new EditorTabItem(context);
         var beforeAdd = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var releaseAdd = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        int addNotifications = 0;
+        ((INotifyCollectionChanged)service.TabItems).CollectionChanged += (_, args) =>
+        {
+            if (args.Action == NotifyCollectionChangedAction.Add)
+                Interlocked.Increment(ref addNotifications);
+        };
 
         Task<bool> add = Task.Run(() => service.TryAddTabItem(tab, () =>
         {
@@ -170,7 +352,7 @@ public sealed class EditorTabItemLifetimeTests
             releaseAdd.Task.GetAwaiter().GetResult();
         }));
         await beforeAdd.Task.WaitAsync(TimeSpan.FromSeconds(5));
-        Assert.That(service.RemoveTabItem(tab), Is.False);
+        Assert.That(service.RemoveTabItem(tab), Is.True);
         releaseAdd.TrySetResult();
 
         Assert.That(await add.WaitAsync(TimeSpan.FromSeconds(5)), Is.False);
@@ -180,63 +362,28 @@ public sealed class EditorTabItemLifetimeTests
             Assert.That(service.TabItems, Is.Empty);
             Assert.That(service.SelectedTabItem.Value, Is.Null);
             Assert.That(context.DisposeCount, Is.EqualTo(1));
+            Assert.That(addNotifications, Is.Zero);
         });
     }
 
     [Test]
-    public async Task ThrowingLateAddReconciliationCannotLeakContext()
+    public async Task RemoveObserverCanRequestCloseWithoutDeadlock()
     {
         var service = new EditorService(new ExtensionProvider());
         var context = new BlockingEditorContext(blockDispose: false);
         var tab = new EditorTabItem(context);
-        var beforeAdd = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        var releaseAdd = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        ((INotifyCollectionChanged)service.TabItems).CollectionChanged += (_, args) =>
-        {
-            if (args.Action == NotifyCollectionChangedAction.Remove)
-                throw new InvalidOperationException("reconciliation observer failed");
-        };
-
-        Task<bool> add = Task.Run(() => service.TryAddTabItem(tab, () =>
-        {
-            beforeAdd.TrySetResult();
-            releaseAdd.Task.GetAwaiter().GetResult();
-        }));
-        await beforeAdd.Task.WaitAsync(TimeSpan.FromSeconds(5));
-        Assert.That(service.RemoveTabItem(tab), Is.False);
-        releaseAdd.TrySetResult();
-
-        Assert.ThrowsAsync<InvalidOperationException>(async () =>
-            await add.WaitAsync(TimeSpan.FromSeconds(5)));
-        await tab.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
-        Assert.Multiple(() =>
-        {
-            Assert.That(service.TabItems, Is.Empty);
-            Assert.That(context.DisposeCount, Is.EqualTo(1));
-        });
-    }
-
-    [Test]
-    public async Task RemoveObserverCanWaitForCloseWithoutDeadlock()
-    {
-        var service = new EditorService(new ExtensionProvider());
-        var tab = new EditorTabItem(new BlockingEditorContext(blockDispose: false));
         service.AddTabItem(tab);
-        Task? nestedClose = null;
+        EditorContextCloseRequest nestedClose = default;
         ((INotifyCollectionChanged)service.TabItems).CollectionChanged += (_, args) =>
         {
             if (args.Action == NotifyCollectionChangedAction.Remove)
-            {
-                nestedClose = Task.Run(() => service.CloseTabItem(tab).AsTask());
-                nestedClose.GetAwaiter().GetResult();
-            }
+                nestedClose = service.RequestClose(context);
         };
 
         bool removed = await Task.Run(() => service.RemoveTabItem(tab))
             .WaitAsync(TimeSpan.FromSeconds(5));
-        Assert.That(nestedClose, Is.Not.Null);
-        await nestedClose!.WaitAsync(TimeSpan.FromSeconds(5));
-        await tab.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.That(nestedClose.Status, Is.EqualTo(EditorContextCloseRequestStatus.Accepted));
+        await nestedClose.Completion.WaitAsync(TimeSpan.FromSeconds(5));
 
         Assert.Multiple(() =>
         {
@@ -252,14 +399,15 @@ public sealed class EditorTabItemLifetimeTests
         var service = new EditorService(new ExtensionProvider());
         var context = new BlockingEditorContext(blockDispose: false);
         var tab = new EditorTabItem(context);
+        EditorContextCloseRequest closeRequest = default;
         using IDisposable selectionObserver = tab.IsSelected.Subscribe(isSelected =>
         {
             if (isSelected)
-                service.CloseTabItem(tab).AsTask().GetAwaiter().GetResult();
+                closeRequest = service.RequestClose(context);
         });
 
         Assert.That(service.TryAddAndSelectTabItem(tab), Is.False);
-        await tab.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+        await closeRequest.Completion.WaitAsync(TimeSpan.FromSeconds(5));
         Assert.Multiple(() =>
         {
             Assert.That(service.TabItems, Is.Empty);
@@ -299,23 +447,20 @@ public sealed class EditorTabItemLifetimeTests
         {
             Uri = new Uri(Path.Combine(Path.GetTempPath(), "existing-selection-close.scene"))
         };
-        var tab = new EditorTabItem(new BlockingEditorContext(blockDispose: false, scene));
+        var context = new BlockingEditorContext(blockDispose: false, scene);
+        var tab = new EditorTabItem(context);
         service.AddTabItem(tab);
-        Task? close = null;
+        EditorContextCloseRequest close = default;
         using IDisposable observer = tab.IsSelected.Subscribe(value =>
         {
             if (value)
-            {
-                close = Task.Run(() => service.CloseTabItem(tab).AsTask());
-                close.GetAwaiter().GetResult();
-            }
+                close = service.RequestClose(context);
         });
 
         await Task.Run(() => service.ActivateTabItem(scene))
             .WaitAsync(TimeSpan.FromSeconds(5));
-        Assert.That(close, Is.Not.Null);
-        await close!.WaitAsync(TimeSpan.FromSeconds(5));
-        await tab.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.That(close.Status, Is.EqualTo(EditorContextCloseRequestStatus.Accepted));
+        await close.Completion.WaitAsync(TimeSpan.FromSeconds(5));
         Assert.Multiple(() =>
         {
             Assert.That(service.TabItems, Is.Empty);
@@ -331,19 +476,19 @@ public sealed class EditorTabItemLifetimeTests
         {
             Uri = new Uri(Path.Combine(Path.GetTempPath(), "existing-selection-fire-and-forget.scene"))
         };
-        var tab = new EditorTabItem(new BlockingEditorContext(blockDispose: false, scene));
+        var context = new BlockingEditorContext(blockDispose: false, scene);
+        var tab = new EditorTabItem(context);
         service.AddTabItem(tab);
-        Task? close = null;
+        EditorContextCloseRequest close = default;
         using IDisposable observer = tab.IsSelected.Subscribe(value =>
         {
             if (value)
-                close = service.CloseTabItem(tab).AsTask();
+                close = service.RequestClose(context);
         });
 
         service.ActivateTabItem(scene);
-        Assert.That(close, Is.Not.Null);
-        await close!.WaitAsync(TimeSpan.FromSeconds(5));
-        await tab.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.That(close.Status, Is.EqualTo(EditorContextCloseRequestStatus.Accepted));
+        await close.Completion.WaitAsync(TimeSpan.FromSeconds(5));
         Assert.Multiple(() =>
         {
             Assert.That(service.TabItems, Is.Empty);
@@ -449,7 +594,7 @@ public sealed class EditorTabItemLifetimeTests
 
         Task activate = Task.Run(() => service.ActivateTabItem(scene));
         await context.PublicationPaused.Task.WaitAsync(TimeSpan.FromSeconds(5));
-        Task remove = Task.Run(() => service.RemoveTabItem(tab));
+        Task<bool> remove = Task.Run(() => service.RemoveTabItem(tab));
         context.ReleasePublication();
 
         await Task.WhenAll(
@@ -489,14 +634,14 @@ public sealed class EditorTabItemLifetimeTests
 
         Task<bool> replace = Task.Run(async () => await tab.ReplaceContextAsync(replacement));
         await replacement.PublicationPaused.Task.WaitAsync(TimeSpan.FromSeconds(5));
-        Task remove = Task.Run(() => service.RemoveTabItem(tab));
-        Assert.That(
-            SpinWait.SpinUntil(() => !service.ContainsTabItem(tab), TimeSpan.FromSeconds(5)),
-            Is.True);
+        Task<bool> remove = Task.Run(() => service.RemoveTabItem(tab));
+        Assert.That(await remove.WaitAsync(TimeSpan.FromSeconds(5)), Is.True);
+        Assert.That(service.ContainsTabItem(tab), Is.True,
+            "Physical removal waits for the admitted replacement publication to drain.");
         replacement.ReleasePublication();
 
         Assert.That(await replace.WaitAsync(TimeSpan.FromSeconds(5)), Is.False);
-        await remove.WaitAsync(TimeSpan.FromSeconds(5));
+        await tab.GetRemovalCompletion().WaitAsync(TimeSpan.FromSeconds(5));
         Assert.Multiple(() =>
         {
             Assert.That(service.TabItems, Is.Empty);
@@ -507,7 +652,7 @@ public sealed class EditorTabItemLifetimeTests
     }
 
     [Test]
-    public async Task DisposeAsync_PublishesOneSharedTaskBeforeContextTeardown()
+    public async Task DisposeAsyncPublishesOneSharedTerminalTask()
     {
         var context = new BlockingEditorContext();
         var tab = new EditorTabItem(context);
@@ -516,11 +661,16 @@ public sealed class EditorTabItemLifetimeTests
         Task second = tab.DisposeAsync().AsTask();
 
         Assert.That(second, Is.SameAs(first));
+        Assert.That(first.IsCompleted, Is.False);
         Assert.That(context.DisposeStarted.Task.IsCompleted, Is.True);
 
         context.ReleaseDispose();
         await first.WaitAsync(TimeSpan.FromSeconds(5));
-        Assert.That(context.DisposeCount, Is.EqualTo(1));
+        Assert.Multiple(() =>
+        {
+            Assert.That(tab.DisposeAsync().AsTask(), Is.SameAs(first));
+            Assert.That(context.DisposeCount, Is.EqualTo(1));
+        });
     }
 
     [Test]
@@ -539,6 +689,207 @@ public sealed class EditorTabItemLifetimeTests
 
         await close.WaitAsync(TimeSpan.FromSeconds(5));
         Assert.That(newContext.DisposeCount, Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task SameInstanceReplacementIsRejectedWithoutConsumption()
+    {
+        var service = new EditorService(new ExtensionProvider());
+        var context = new BlockingEditorContext(blockDispose: false);
+        var tab = new EditorTabItem(context);
+        service.AddTabItem(tab);
+
+        bool replaced = await tab.ReplaceContextAsync(context)
+            .AsTask()
+            .WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(replaced, Is.False);
+            Assert.That(tab.Context.Value, Is.SameAs(context));
+            Assert.That(context.DisposeCount, Is.Zero);
+        });
+        await service.CloseTabItem(tab).AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task StandaloneSameInstanceReplacementIsRejectedWithoutConsumption()
+    {
+        var context = new BlockingEditorContext(blockDispose: false);
+        var tab = new EditorTabItem(context);
+
+        bool replaced = await tab.ReplaceContextAsync(context)
+            .AsTask()
+            .WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(replaced, Is.False);
+            Assert.That(tab.Context.Value, Is.SameAs(context));
+            Assert.That(context.DisposeCount, Is.Zero);
+        });
+        await tab.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.That(context.DisposeCount, Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task CrossTabReplacementIsRejectedWithoutConsumption()
+    {
+        var service = new EditorService(new ExtensionProvider());
+        var firstContext = new BlockingEditorContext(blockDispose: false);
+        var secondContext = new BlockingEditorContext(blockDispose: false);
+        var first = new EditorTabItem(firstContext);
+        var second = new EditorTabItem(secondContext);
+        service.AddTabItem(first);
+        service.AddTabItem(second);
+
+        bool replaced = await first.ReplaceContextAsync(secondContext)
+            .AsTask()
+            .WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(replaced, Is.False);
+            Assert.That(first.Context.Value, Is.SameAs(firstContext));
+            Assert.That(second.Context.Value, Is.SameAs(secondContext));
+            Assert.That(firstContext.DisposeCount, Is.Zero);
+            Assert.That(secondContext.DisposeCount, Is.Zero);
+        });
+        await service.CloseTabItem(first).AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+        await service.CloseTabItem(second).AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task ClosingTabCannotConsumeAnotherTabsContext()
+    {
+        var service = new EditorService(new ExtensionProvider());
+        var closingContext = new BlockingEditorContext();
+        var otherContext = new BlockingEditorContext(blockDispose: false);
+        var closing = new EditorTabItem(closingContext);
+        var other = new EditorTabItem(otherContext);
+        service.AddTabItem(closing);
+        service.AddTabItem(other);
+
+        Task close = service.CloseTabItem(closing).AsTask();
+        await closingContext.DisposeStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        bool replaced = await closing.ReplaceContextAsync(otherContext)
+            .AsTask()
+            .WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.That(replaced, Is.False);
+        Assert.That(otherContext.DisposeCount, Is.Zero);
+        closingContext.ReleaseDispose();
+        await close.WaitAsync(TimeSpan.FromSeconds(5));
+        await service.CloseTabItem(other).AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task RejectedReplacementReservationRemainsInvisibleUntilDisposalCompletes()
+    {
+        var service = new EditorService(new ExtensionProvider());
+        var closingContext = new BlockingEditorContext();
+        var rejectedContext = new BlockingEditorContext();
+        var closing = new EditorTabItem(closingContext);
+        service.AddTabItem(closing);
+
+        Task close = service.CloseTabItem(closing).AsTask();
+        await closingContext.DisposeStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Task<bool> replace = closing.ReplaceContextAsync(rejectedContext).AsTask();
+        await rejectedContext.DisposeStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.That(
+            service.RequestClose(rejectedContext).Status,
+            Is.EqualTo(EditorContextCloseRequestStatus.NotOwned));
+        var competing = new EditorTabItem(rejectedContext);
+        Assert.That(service.TryAddTabItem(competing), Is.False);
+
+        rejectedContext.ReleaseDispose();
+        Assert.That(await replace.WaitAsync(TimeSpan.FromSeconds(5)), Is.False);
+        closingContext.ReleaseDispose();
+        await close.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.That(rejectedContext.DisposeCount, Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task TransitioningTabCannotConsumeAnotherTabsContext()
+    {
+        var service = new EditorService(new ExtensionProvider());
+        var oldContext = new BlockingEditorContext();
+        var replacement = new BlockingEditorContext(blockDispose: false);
+        var otherContext = new BlockingEditorContext(blockDispose: false);
+        var transitioning = new EditorTabItem(oldContext);
+        var other = new EditorTabItem(otherContext);
+        service.AddTabItem(transitioning);
+        service.AddTabItem(other);
+
+        Task<bool> firstReplacement = transitioning.ReplaceContextAsync(replacement).AsTask();
+        await oldContext.DisposeStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        bool rejected = await transitioning.ReplaceContextAsync(otherContext)
+            .AsTask()
+            .WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.That(rejected, Is.False);
+        Assert.That(otherContext.DisposeCount, Is.Zero);
+        oldContext.ReleaseDispose();
+        Assert.That(await firstReplacement.WaitAsync(TimeSpan.FromSeconds(5)), Is.True);
+        await service.CloseTabItem(transitioning).AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+        await service.CloseTabItem(other).AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task ReservedReplacementIdentityCanRequestOwningTabClose()
+    {
+        var service = new EditorService(new ExtensionProvider());
+        var oldContext = new BlockingEditorContext(blockDispose: false);
+        var replacement = new BlockingEditorContext(blockDispose: false);
+        var tab = new EditorTabItem(oldContext);
+        service.AddTabItem(tab);
+        EditorContextCloseRequest closeRequest = default;
+        using IDisposable subscription = tab.Context.Subscribe(value =>
+        {
+            if (value is null)
+                closeRequest = service.RequestClose(replacement);
+        });
+
+        bool replaced = await tab.ReplaceContextAsync(replacement)
+            .AsTask()
+            .WaitAsync(TimeSpan.FromSeconds(5));
+        await closeRequest.Completion.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(replaced, Is.False);
+            Assert.That(closeRequest.Status, Is.EqualTo(EditorContextCloseRequestStatus.Accepted));
+            Assert.That(oldContext.DisposeCount, Is.EqualTo(1));
+            Assert.That(replacement.DisposeCount, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public async Task HostOwnedOutgoingDisposalDoesNotRequestTabClose()
+    {
+        var service = new EditorService(new ExtensionProvider());
+        var oldContext = new BlockingEditorContext(blockDispose: false);
+        var replacement = new BlockingEditorContext(blockDispose: false);
+        var tab = new EditorTabItem(oldContext);
+        service.AddTabItem(tab);
+        oldContext.OnDispose = () =>
+        {
+            service.RequestContextShutdown(oldContext);
+            return ValueTask.CompletedTask;
+        };
+
+        bool replaced = await tab.ReplaceContextAsync(replacement)
+            .AsTask()
+            .WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(replaced, Is.True);
+            Assert.That(service.TabItems, Does.Contain(tab));
+            Assert.That(tab.Context.Value, Is.SameAs(replacement));
+        });
+        await service.CloseTabItem(tab).AsTask().WaitAsync(TimeSpan.FromSeconds(5));
     }
 
     [Test]
@@ -568,12 +919,19 @@ public sealed class EditorTabItemLifetimeTests
         var oldContext = new BlockingEditorContext(blockDispose: false);
         var newContext = new BlockingEditorContext(blockDispose: false);
         var tab = new EditorTabItem(oldContext);
-        oldContext.OnDispose = () => tab.DisposeAsync();
+        var service = new EditorService(new ExtensionProvider());
+        service.AddTabItem(tab);
+        EditorContextCloseRequest closeRequest = default;
+        oldContext.OnDispose = () =>
+        {
+            closeRequest = service.RequestClose(oldContext);
+            return ValueTask.CompletedTask;
+        };
 
         bool replaced = await tab.ReplaceContextAsync(newContext)
             .AsTask()
             .WaitAsync(TimeSpan.FromSeconds(5));
-        await tab.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+        await closeRequest.Completion.WaitAsync(TimeSpan.FromSeconds(5));
 
         Assert.Multiple(() =>
         {
@@ -669,30 +1027,29 @@ public sealed class EditorTabItemLifetimeTests
     }
 
     [Test]
-    public async Task ContextSubscriberCanSynchronouslyWaitForCloseWhenReplacementPublishesNull()
+    public async Task ContextSubscriberCanRequestHostCloseWhenReplacementPublishesNull()
     {
         var oldContext = new BlockingEditorContext(blockDispose: false);
         var replacement = new BlockingEditorContext(blockDispose: false);
         var tab = new EditorTabItem(oldContext);
-        bool closeReturned = false;
+        var service = new EditorService(new ExtensionProvider());
+        service.AddTabItem(tab);
+        EditorContextCloseRequest closeRequest = default;
         using IDisposable subscription = tab.Context.Subscribe(value =>
         {
             if (value is null)
-            {
-                Task close = Task.Run(() => tab.DisposeAsync().AsTask());
-                close.GetAwaiter().GetResult();
-                closeReturned = true;
-            }
+                closeRequest = service.RequestClose(oldContext);
         });
 
-        bool replaced = await Task.Run(async () => await tab.ReplaceContextAsync(replacement))
+        bool replaced = await tab.ReplaceContextAsync(replacement)
+            .AsTask()
             .WaitAsync(TimeSpan.FromSeconds(5));
-        await tab.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+        await closeRequest.Completion.WaitAsync(TimeSpan.FromSeconds(5));
 
         Assert.Multiple(() =>
         {
             Assert.That(replaced, Is.False);
-            Assert.That(closeReturned, Is.True);
+            Assert.That(closeRequest.Status, Is.EqualTo(EditorContextCloseRequestStatus.Accepted));
             Assert.That(oldContext.DisposeCount, Is.EqualTo(1));
             Assert.That(replacement.DisposeCount, Is.EqualTo(1));
         });
@@ -820,15 +1177,23 @@ public sealed class EditorTabItemLifetimeTests
         var oldContext = new BlockingEditorContext();
         var replacement = new BlockingEditorContext(blockDispose: false);
         var tab = new EditorTabItem(oldContext);
-        replacement.OnDispose = () => tab.DisposeAsync();
+        var service = new EditorService(new ExtensionProvider());
+        service.AddTabItem(tab);
+        EditorContextCloseRequest nestedClose = default;
+        replacement.OnDispose = () =>
+        {
+            nestedClose = service.RequestClose(oldContext);
+            return ValueTask.CompletedTask;
+        };
 
         Task<bool> replace = tab.ReplaceContextAsync(replacement).AsTask();
         await oldContext.DisposeStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
-        Task close = tab.DisposeAsync().AsTask();
+        Task close = service.CloseTabItem(tab).AsTask();
         oldContext.ReleaseDispose();
 
         Assert.That(await replace.WaitAsync(TimeSpan.FromSeconds(5)), Is.False);
         await close.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.That(nestedClose.Status, Is.EqualTo(EditorContextCloseRequestStatus.AlreadyClosing));
         Assert.Multiple(() =>
         {
             Assert.That(oldContext.DisposeCount, Is.EqualTo(1));
@@ -843,8 +1208,15 @@ public sealed class EditorTabItemLifetimeTests
         var replacement = new BlockingEditorContext(blockDispose: false);
         var nested = new BlockingEditorContext(blockDispose: false);
         var tab = new EditorTabItem(oldContext);
+        var service = new EditorService(new ExtensionProvider());
+        service.AddTabItem(tab);
         Task<bool>? nestedReplacement = null;
-        nested.OnDispose = () => tab.DisposeAsync();
+        EditorContextCloseRequest closeRequest = default;
+        nested.OnDispose = () =>
+        {
+            closeRequest = service.RequestClose(oldContext);
+            return ValueTask.CompletedTask;
+        };
         oldContext.OnDispose = async () =>
         {
             nestedReplacement = tab.ReplaceContextAsync(nested).AsTask();
@@ -854,7 +1226,7 @@ public sealed class EditorTabItemLifetimeTests
         bool replaced = await tab.ReplaceContextAsync(replacement)
             .AsTask()
             .WaitAsync(TimeSpan.FromSeconds(5));
-        await tab.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+        await closeRequest.Completion.WaitAsync(TimeSpan.FromSeconds(5));
 
         Assert.Multiple(() =>
         {
@@ -965,9 +1337,15 @@ public sealed class EditorTabItemLifetimeTests
         var second = new EditorTabItem(secondContext);
         service.AddTabItem(first);
         service.AddTabItem(second);
-        firstContext.OnDispose = () => service.CloseTabItem(second);
+        EditorContextCloseRequest secondClose = default;
+        firstContext.OnDispose = () =>
+        {
+            secondClose = service.RequestClose(secondContext);
+            return ValueTask.CompletedTask;
+        };
 
         await service.CloseTabItem(first).AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+        await secondClose.Completion.WaitAsync(TimeSpan.FromSeconds(5));
 
         Assert.Multiple(() =>
         {
@@ -987,17 +1365,28 @@ public sealed class EditorTabItemLifetimeTests
         var second = new EditorTabItem(secondContext);
         service.AddTabItem(first);
         service.AddTabItem(second);
-        firstContext.OnDispose = () => service.CloseTabItem(second);
-        secondContext.OnDispose = () => service.CloseTabItem(first);
+        EditorContextCloseRequest secondClose = default;
+        EditorContextCloseRequest firstReentrantClose = default;
+        firstContext.OnDispose = () =>
+        {
+            secondClose = service.RequestClose(secondContext);
+            return ValueTask.CompletedTask;
+        };
+        secondContext.OnDispose = () =>
+        {
+            firstReentrantClose = service.RequestClose(firstContext);
+            return ValueTask.CompletedTask;
+        };
 
         await service.CloseTabItem(first).AsTask().WaitAsync(TimeSpan.FromSeconds(5));
-        await second.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+        await secondClose.Completion.WaitAsync(TimeSpan.FromSeconds(5));
 
         Assert.Multiple(() =>
         {
             Assert.That(firstContext.DisposeCount, Is.EqualTo(1));
             Assert.That(secondContext.DisposeCount, Is.EqualTo(1));
             Assert.That(service.TabItems, Is.Empty);
+            Assert.That(firstReentrantClose.Status, Is.EqualTo(EditorContextCloseRequestStatus.AlreadyClosing));
         });
     }
 

--- a/tests/Beutl.HeadlessUITests/EditorTabItemLifetimeTests.cs
+++ b/tests/Beutl.HeadlessUITests/EditorTabItemLifetimeTests.cs
@@ -428,6 +428,171 @@ public sealed class EditorTabItemLifetimeTests
     }
 
     [Test]
+    public async Task DeferredActivationCleanupPreservesImmediateFailureForReconciliation()
+    {
+        var foreign = new EditorService(new ExtensionProvider());
+        var provider = new ExtensionProvider();
+        var service = new EditorService(provider);
+        var context = new ImmediateFaultEditorContext(
+            new Scene(16, 16, string.Empty),
+            foreign);
+        provider.AddExtensions(1, [new SuppliedContextEditorExtension(context)]);
+        var scene = new Scene(16, 16, string.Empty)
+        {
+            Uri = new Uri(Path.Combine(Path.GetTempPath(), "activation-immediate-fault.activation"))
+        };
+
+        service.ActivateTabItem(scene);
+        Assert.That(context.DisposeStarted.Task.IsCompleted, Is.True);
+
+        Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await service.ClearTabItemsAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5)));
+        await service.ClearTabItemsAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task DeferredActivationCleanupDrainsDelayedFailureOnce()
+    {
+        var foreign = new EditorService(new ExtensionProvider());
+        var provider = new ExtensionProvider();
+        var service = new EditorService(provider);
+        var context = new DelayedFaultEditorContext(
+            new Scene(16, 16, string.Empty),
+            foreign);
+        provider.AddExtensions(1, [new SuppliedContextEditorExtension(context)]);
+        var scene = new Scene(16, 16, string.Empty)
+        {
+            Uri = new Uri(Path.Combine(Path.GetTempPath(), "activation-delayed-fault.activation"))
+        };
+
+        service.ActivateTabItem(scene);
+        await context.DisposeStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Task drain = service.ClearTabItemsAsync().AsTask();
+        Assert.That(drain.IsCompleted, Is.False);
+
+        context.Release.TrySetResult();
+        Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await drain.WaitAsync(TimeSpan.FromSeconds(5)));
+        Assert.That(context.DisposeCount, Is.EqualTo(1));
+        await service.ClearTabItemsAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task DeferredActivationCleanupSuccessIsConsumedByReconciliation()
+    {
+        var foreign = new EditorService(new ExtensionProvider());
+        var provider = new ExtensionProvider();
+        var service = new EditorService(provider);
+        var context = new BlockingEditorContext(
+            blockDispose: false,
+            new Scene(16, 16, string.Empty),
+            foreign);
+        provider.AddExtensions(1, [new SuppliedContextEditorExtension(context)]);
+        var scene = new Scene(16, 16, string.Empty)
+        {
+            Uri = new Uri(Path.Combine(Path.GetTempPath(), "activation-success.activation"))
+        };
+
+        service.ActivateTabItem(scene);
+        await service.ClearTabItemsAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+        await service.ClearTabItemsAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.That(context.DisposeCount, Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task DeferredActivationCleanupPostAwaitCallbackRejectsReconciliation()
+    {
+        var foreign = new EditorService(new ExtensionProvider());
+        var provider = new ExtensionProvider();
+        var service = new EditorService(provider);
+        var context = new ReentrantDisposeEditorContext(
+            new Scene(16, 16, string.Empty),
+            foreign);
+        context.AfterAwait = () =>
+        {
+            Assert.Throws<InvalidOperationException>(() =>
+                service.ClearTabItemsAsync().AsTask().GetAwaiter().GetResult());
+            return ValueTask.CompletedTask;
+        };
+        provider.AddExtensions(1, [new SuppliedContextEditorExtension(context)]);
+        var scene = new Scene(16, 16, string.Empty)
+        {
+            Uri = new Uri(Path.Combine(Path.GetTempPath(), "activation-post-await.activation"))
+        };
+
+        service.ActivateTabItem(scene);
+        await context.DisposeStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await service.ClearTabItemsAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.That(context.DisposeCount, Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task ReconciliationReportsHostCloseFailureOnce()
+    {
+        var service = new EditorService(new ExtensionProvider());
+        var context = new ThrowingEditorContext(service);
+        var tab = new EditorTabItem(context);
+        service.AddTabItem(tab);
+
+        Exception? failure = null;
+        try
+        {
+            await service.ClearTabItemsAsync();
+        }
+        catch (Exception ex)
+        {
+            failure = ex;
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(failure, Is.TypeOf<InvalidOperationException>());
+            Assert.That(failure!.Message, Is.EqualTo("dispose failed"));
+            Assert.That(context.DisposeCount, Is.EqualTo(1));
+            Assert.That(service.TabItems, Is.Empty);
+        });
+        await service.ClearTabItemsAsync();
+    }
+
+    [Test]
+    public async Task FailedActivationDoesNotDuplicateHostOwnedTeardownFailure()
+    {
+        var provider = new ExtensionProvider();
+        var service = new EditorService(provider);
+        var context = new ThrowingEditorContext(service);
+        provider.AddExtensions(1, [new SuppliedContextEditorExtension(context)]);
+        service.BeforePhysicalAdd = () => throw new InvalidOperationException("publication failed");
+        var scene = new Scene(16, 16, string.Empty)
+        {
+            Uri = new Uri(Path.Combine(Path.GetTempPath(), "activation-host-fault.activation"))
+        };
+
+        Assert.Throws<InvalidOperationException>(() => service.ActivateTabItem(scene));
+        await context.DisposeStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Exception? failure = null;
+        try
+        {
+            await service.ClearTabItemsAsync();
+        }
+        catch (Exception ex)
+        {
+            failure = ex;
+        }
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(failure, Is.TypeOf<InvalidOperationException>());
+            Assert.That(failure!.Message, Is.EqualTo("dispose failed"));
+            Assert.That(context.DisposeCount, Is.EqualTo(1));
+            Assert.That(service.TabItems, Is.Empty);
+        });
+        service.BeforePhysicalAdd = null;
+        await service.ClearTabItemsAsync();
+    }
+
+    [Test]
     public async Task ActivationDisposesTransferredContextWhenTabConstructionFails()
     {
         var provider = new ExtensionProvider();
@@ -2793,6 +2958,80 @@ public sealed class EditorTabItemLifetimeTests
             CreationCount++;
             context = existingContext;
             return true;
+        }
+    }
+
+    private sealed class SuppliedContextEditorExtension(IEditorContext suppliedContext)
+        : EditorExtension
+    {
+        public override FilePickerFileType GetFilePickerFileType() => new("Supplied");
+
+        public override IconSource? GetIcon() => null;
+
+        public override bool TryCreateEditor(
+            CoreObject obj,
+            [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Control? editor)
+        {
+            editor = null;
+            return false;
+        }
+
+        public override bool MatchFileExtension(string ext) => true;
+
+        public override bool TryCreateContext(
+            CoreObject obj,
+            IEditorContextServices services,
+            [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out IEditorContext? context)
+        {
+            context = suppliedContext;
+            return true;
+        }
+    }
+
+    private sealed class ImmediateFaultEditorContext(
+        CoreObject obj,
+        IEditorContextCloseService closeService)
+        : BlockingEditorContext(blockDispose: false, obj, closeService)
+    {
+        public override ValueTask DisposeAsync()
+        {
+            DisposeCount++;
+            DisposeStarted.TrySetResult();
+            return ValueTask.FromException(new InvalidOperationException("immediate teardown failure"));
+        }
+    }
+
+    private sealed class DelayedFaultEditorContext(
+        CoreObject obj,
+        IEditorContextCloseService closeService)
+        : BlockingEditorContext(blockDispose: false, obj, closeService)
+    {
+        public TaskCompletionSource Release { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public override async ValueTask DisposeAsync()
+        {
+            DisposeCount++;
+            DisposeStarted.TrySetResult();
+            await Release.Task.ConfigureAwait(false);
+            throw new InvalidOperationException("delayed teardown failure");
+        }
+    }
+
+    private sealed class ReentrantDisposeEditorContext(
+        CoreObject obj,
+        IEditorContextCloseService closeService)
+        : BlockingEditorContext(blockDispose: false, obj, closeService)
+    {
+        public Func<ValueTask>? AfterAwait { get; set; }
+
+        public override async ValueTask DisposeAsync()
+        {
+            DisposeCount++;
+            DisposeStarted.TrySetResult();
+            await Task.Yield();
+            if (AfterAwait is { } callback)
+                await callback();
         }
     }
 

--- a/tests/Beutl.HeadlessUITests/EditorTabItemLifetimeTests.cs
+++ b/tests/Beutl.HeadlessUITests/EditorTabItemLifetimeTests.cs
@@ -1,0 +1,196 @@
+﻿using Avalonia.Controls;
+using Avalonia.Platform.Storage;
+using Beutl.Api.Services;
+using Beutl.Extensibility;
+using Beutl.ProjectSystem;
+using Beutl.Services;
+using FluentAvalonia.UI.Controls;
+using Reactive.Bindings;
+
+namespace Beutl.HeadlessUITests;
+
+[TestFixture]
+public sealed class EditorTabItemLifetimeTests
+{
+    [Test]
+    public async Task DisposeAsync_PublishesOneSharedTaskBeforeContextTeardown()
+    {
+        var context = new BlockingEditorContext();
+        var tab = new EditorTabItem(context);
+
+        Task first = tab.DisposeAsync().AsTask();
+        Task second = tab.DisposeAsync().AsTask();
+
+        Assert.That(second, Is.SameAs(first));
+        Assert.That(context.DisposeStarted.Task.IsCompleted, Is.True);
+
+        context.ReleaseDispose();
+        await first.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.That(context.DisposeCount, Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task ReplaceContextAsync_RejectsAndDisposesNewContextWhenCloseWins()
+    {
+        var oldContext = new BlockingEditorContext();
+        var newContext = new BlockingEditorContext(blockDispose: false);
+        var tab = new EditorTabItem(oldContext);
+
+        Task close = tab.DisposeAsync().AsTask();
+        Task<bool> replacement = tab.ReplaceContextAsync(newContext).AsTask();
+
+        oldContext.ReleaseDispose();
+        Assert.That(await replacement.WaitAsync(TimeSpan.FromSeconds(5)), Is.False);
+        await newContext.Disposed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await close.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.That(newContext.DisposeCount, Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task ReplacementContextDisposalCanReenterTabCloseWithoutDeadlock()
+    {
+        var oldContext = new BlockingEditorContext(blockDispose: false);
+        var newContext = new BlockingEditorContext(blockDispose: false);
+        var tab = new EditorTabItem(oldContext);
+        oldContext.OnDispose = () => tab.DisposeAsync();
+
+        bool replaced = await tab.ReplaceContextAsync(newContext)
+            .AsTask()
+            .WaitAsync(TimeSpan.FromSeconds(5));
+        await tab.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(replaced, Is.False);
+            Assert.That(oldContext.DisposeCount, Is.EqualTo(1));
+            Assert.That(newContext.DisposeCount, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public async Task ClosingOneTabWaitsForSiblingCloseStartedByItsContext()
+    {
+        var service = new EditorService(new ExtensionProvider());
+        var firstContext = new BlockingEditorContext(blockDispose: false);
+        var secondContext = new BlockingEditorContext(blockDispose: false);
+        var first = new EditorTabItem(firstContext);
+        var second = new EditorTabItem(secondContext);
+        service.AddTabItem(first);
+        service.AddTabItem(second);
+        firstContext.OnDispose = () => service.CloseTabItem(second);
+
+        await service.CloseTabItem(first).AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(firstContext.DisposeCount, Is.EqualTo(1));
+            Assert.That(secondContext.DisposeCount, Is.EqualTo(1));
+            Assert.That(service.TabItems, Is.Empty);
+        });
+    }
+
+    [Test]
+    public async Task MutualSiblingCloseUsesAncestorIdentityWithoutCycle()
+    {
+        var service = new EditorService(new ExtensionProvider());
+        var firstContext = new BlockingEditorContext(blockDispose: false);
+        var secondContext = new BlockingEditorContext(blockDispose: false);
+        var first = new EditorTabItem(firstContext);
+        var second = new EditorTabItem(secondContext);
+        service.AddTabItem(first);
+        service.AddTabItem(second);
+        firstContext.OnDispose = () => service.CloseTabItem(second);
+        secondContext.OnDispose = () => service.CloseTabItem(first);
+
+        await service.CloseTabItem(first).AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+        await second.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(firstContext.DisposeCount, Is.EqualTo(1));
+            Assert.That(secondContext.DisposeCount, Is.EqualTo(1));
+            Assert.That(service.TabItems, Is.Empty);
+        });
+    }
+
+    private sealed class BlockingEditorContext : IEditorContext
+    {
+        private readonly bool _blockDispose;
+        private readonly TaskCompletionSource _release = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public BlockingEditorContext(bool blockDispose = true)
+        {
+            _blockDispose = blockDispose;
+        }
+
+        public TaskCompletionSource DisposeStarted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource Disposed { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public int DisposeCount { get; private set; }
+
+        public Func<ValueTask>? OnDispose { get; set; }
+
+        public CoreObject Object { get; } = new Scene(16, 16, string.Empty);
+
+        public EditorExtension Extension { get; } = TestEditorExtension.Instance;
+
+        public IReactiveProperty<bool> IsEnabled { get; } = new ReactivePropertySlim<bool>(true);
+
+        public IKnownEditorCommands? Commands => null;
+
+        public async ValueTask DisposeAsync()
+        {
+            DisposeCount++;
+            DisposeStarted.TrySetResult();
+            if (OnDispose is { } onDispose)
+                await onDispose();
+            if (_blockDispose)
+                await _release.Task.ConfigureAwait(false);
+
+            Disposed.TrySetResult();
+        }
+
+        public void ReleaseDispose() => _release.TrySetResult();
+
+        public T? FindToolTab<T>(Func<T, bool> condition) where T : IToolContext => default;
+
+        public T? FindToolTab<T>() where T : IToolContext => default;
+
+        public ValueTask<bool> OpenToolTabAsync(IToolContext item) => new(false);
+
+        public ValueTask CloseToolTabAsync(IToolContext item)
+        {
+            return ValueTask.CompletedTask;
+        }
+
+        public object? GetService(Type serviceType) => null;
+    }
+
+    private sealed class TestEditorExtension : EditorExtension
+    {
+        public static readonly TestEditorExtension Instance = new();
+
+        public override FilePickerFileType GetFilePickerFileType() => new("Test");
+
+        public override IconSource? GetIcon() => null;
+
+        public override bool TryCreateEditor(CoreObject obj, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Control? editor)
+        {
+            editor = null;
+            return false;
+        }
+
+        public override bool MatchFileExtension(string ext) => false;
+
+        public override bool TryCreateContext(
+            CoreObject obj,
+            IEditorContextServices services,
+            [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out IEditorContext? context)
+        {
+            context = null;
+            return false;
+        }
+    }
+}

--- a/tests/Beutl.HeadlessUITests/EditorTabItemLifetimeTests.cs
+++ b/tests/Beutl.HeadlessUITests/EditorTabItemLifetimeTests.cs
@@ -1,4 +1,5 @@
-﻿using Avalonia.Controls;
+﻿using System.Collections.Specialized;
+using Avalonia.Controls;
 using Avalonia.Platform.Storage;
 using Beutl.Api.Services;
 using Beutl.Extensibility;
@@ -9,7 +10,7 @@ using Reactive.Bindings;
 
 namespace Beutl.HeadlessUITests;
 
-[TestFixture]
+[TestFixture, NonParallelizable]
 public sealed class EditorTabItemLifetimeTests
 {
     [Test]
@@ -48,6 +49,27 @@ public sealed class EditorTabItemLifetimeTests
     }
 
     [Test]
+    public async Task RejectedReplacementDisposalFailureIsReportedAfterCleanup()
+    {
+        var oldContext = new BlockingEditorContext();
+        var replacement = new ThrowingEditorContext();
+        var tab = new EditorTabItem(oldContext);
+
+        Task close = tab.DisposeAsync().AsTask();
+        Task<bool> replace = tab.ReplaceContextAsync(replacement).AsTask();
+
+        Assert.CatchAsync<InvalidOperationException>(async () =>
+            await replace.WaitAsync(TimeSpan.FromSeconds(5)));
+        oldContext.ReleaseDispose();
+        await close.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Multiple(() =>
+        {
+            Assert.That(oldContext.DisposeCount, Is.EqualTo(1));
+            Assert.That(replacement.DisposeCount, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
     public async Task ReplacementContextDisposalCanReenterTabCloseWithoutDeadlock()
     {
         var oldContext = new BlockingEditorContext(blockDispose: false);
@@ -65,6 +87,293 @@ public sealed class EditorTabItemLifetimeTests
             Assert.That(replaced, Is.False);
             Assert.That(oldContext.DisposeCount, Is.EqualTo(1));
             Assert.That(newContext.DisposeCount, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public async Task ContextPropertyPublishesNullOnlyAfterTerminalClose()
+    {
+        var oldContext = new BlockingEditorContext(blockDispose: false);
+        var newContext = new BlockingEditorContext(blockDispose: false);
+        var tab = new EditorTabItem(oldContext);
+        var values = new List<IEditorContext?>();
+        using IDisposable subscription = tab.Context.Subscribe(values.Add);
+
+        Assert.That(await tab.ReplaceContextAsync(newContext).AsTask(), Is.True);
+        await tab.DisposeAsync();
+
+        Assert.That(values, Does.Contain(null));
+    }
+
+    [Test]
+    public async Task FailedReplacementTerminallyRemovesTabAndClearsSelection()
+    {
+        var oldContext = new ThrowingEditorContext();
+        var tab = new EditorTabItem(oldContext);
+        var service = new EditorService(new ExtensionProvider());
+        service.AddTabItem(tab);
+        service.SelectedTabItem.Value = tab;
+        var replacement = new BlockingEditorContext(blockDispose: false);
+        var values = new List<IEditorContext?>();
+        using IDisposable subscription = tab.Context.Subscribe(values.Add);
+
+        Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await tab.ReplaceContextAsync(replacement).AsTask());
+        Assert.That(service.TabItems, Is.Empty);
+        Assert.That(service.SelectedTabItem.Value, Is.Null);
+        Assert.That(values, Does.Contain(null));
+        Assert.That(oldContext.DisposeCount, Is.EqualTo(1));
+        Assert.That(replacement.DisposeCount, Is.EqualTo(1));
+        await tab.DisposeAsync();
+    }
+
+    [Test]
+    public async Task ConcurrentCloseJoinsThrowingReplacementWithoutDeadlock()
+    {
+        var oldContext = new BlockingEditorContext();
+        var fail = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        oldContext.OnDispose = async () =>
+        {
+            await fail.Task;
+            throw new InvalidOperationException("dispose failed");
+        };
+        var tab = new EditorTabItem(oldContext);
+        var service = new EditorService(new ExtensionProvider());
+        service.AddTabItem(tab);
+        service.SelectedTabItem.Value = tab;
+
+        Task replacement = tab.ReplaceContextAsync(new BlockingEditorContext(blockDispose: false)).AsTask();
+        await oldContext.DisposeStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Task close = tab.DisposeAsync().AsTask();
+        fail.TrySetResult();
+        oldContext.ReleaseDispose();
+
+        Assert.ThrowsAsync<InvalidOperationException>(async () => await replacement.WaitAsync(TimeSpan.FromSeconds(5)));
+        Assert.That(close.IsCompleted, Is.True,
+            "The public replacement failure must not complete before terminal close cleanup.");
+        await close.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.That(service.TabItems, Is.Empty);
+    }
+
+    [Test]
+    public async Task ContextSubscriberCanReenterCloseWhenReplacementPublishesNull()
+    {
+        var oldContext = new BlockingEditorContext(blockDispose: false);
+        var tab = new EditorTabItem(oldContext);
+        Task? reentrantClose = null;
+        using IDisposable subscription = tab.Context.Subscribe(value =>
+        {
+            if (value is null)
+                reentrantClose = tab.DisposeAsync().AsTask();
+        });
+
+        bool replaced = await tab.ReplaceContextAsync(new BlockingEditorContext(blockDispose: false))
+            .AsTask()
+            .WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.That(replaced, Is.False);
+        if (reentrantClose is not null)
+            await reentrantClose.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task CloseStartedByReplacementPublicationWinsTheResult()
+    {
+        var oldContext = new BlockingEditorContext(blockDispose: false);
+        var replacement = new BlockingEditorContext(blockDispose: false);
+        var tab = new EditorTabItem(oldContext);
+        Task? close = null;
+        using IDisposable subscription = tab.Context.Subscribe(value =>
+        {
+            if (ReferenceEquals(value, replacement))
+                close = tab.DisposeAsync().AsTask();
+        });
+
+        bool replaced = await tab.ReplaceContextAsync(replacement)
+            .AsTask()
+            .WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.That(replaced, Is.False);
+        Assert.That(close, Is.Not.Null);
+        await close!.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.That(replacement.DisposeCount, Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task ContextSubscriberCannotStartACompetingReplacement()
+    {
+        var oldContext = new BlockingEditorContext(blockDispose: false);
+        var replacement = new BlockingEditorContext(blockDispose: false);
+        var nested = new BlockingEditorContext(blockDispose: false);
+        var tab = new EditorTabItem(oldContext);
+        Task<bool>? nestedReplacement = null;
+        using IDisposable subscription = tab.Context.Subscribe(value =>
+        {
+            if (value is null && nestedReplacement is null)
+                nestedReplacement = tab.ReplaceContextAsync(nested).AsTask();
+        });
+
+        bool replaced = await tab.ReplaceContextAsync(replacement)
+            .AsTask()
+            .WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.That(replaced, Is.True);
+        Assert.That(nestedReplacement, Is.Not.Null);
+        Assert.That(await nestedReplacement!.WaitAsync(TimeSpan.FromSeconds(5)), Is.False);
+        Assert.Multiple(() =>
+        {
+            Assert.That(oldContext.DisposeCount, Is.EqualTo(1));
+            Assert.That(nested.DisposeCount, Is.EqualTo(1));
+            Assert.That(tab.Context.Value!, Is.SameAs(replacement));
+        });
+        await tab.DisposeAsync();
+    }
+
+    [Test]
+    public async Task ContextPublicationDoesNotRunRejectedPluginTeardownUnderTheHostGate()
+    {
+        var oldContext = new BlockingEditorContext(blockDispose: false);
+        var replacement = new BlockingEditorContext(blockDispose: false);
+        var nested = new BlockingEditorContext(blockDispose: false);
+        var third = new BlockingEditorContext(blockDispose: false);
+        var tab = new EditorTabItem(oldContext);
+        Task<bool>? nestedReplacement = null;
+        nested.OnDispose = () =>
+        {
+            Task competing = Task.Run(() =>
+                tab.ReplaceContextAsync(third).AsTask().GetAwaiter().GetResult());
+            if (!competing.Wait(TimeSpan.FromSeconds(2)))
+                throw new TimeoutException("The tab lifetime gate was held by Context publication.");
+            return ValueTask.CompletedTask;
+        };
+        using IDisposable subscription = tab.Context.Subscribe(value =>
+        {
+            if (value is null && nestedReplacement is null)
+                nestedReplacement = tab.ReplaceContextAsync(nested).AsTask();
+        });
+
+        Assert.That(await tab.ReplaceContextAsync(replacement).AsTask()
+            .WaitAsync(TimeSpan.FromSeconds(5)), Is.True);
+        Assert.That(await nestedReplacement!.WaitAsync(TimeSpan.FromSeconds(5)), Is.False);
+        Assert.Multiple(() =>
+        {
+            Assert.That(nested.DisposeCount, Is.EqualTo(1));
+            Assert.That(third.DisposeCount, Is.EqualTo(1));
+        });
+        await tab.DisposeAsync();
+    }
+
+    [Test]
+    public async Task RejectedReplacementCanReenterCloseWithoutDeadlock()
+    {
+        var oldContext = new BlockingEditorContext();
+        var replacement = new BlockingEditorContext(blockDispose: false);
+        var tab = new EditorTabItem(oldContext);
+        replacement.OnDispose = () => tab.DisposeAsync();
+
+        Task<bool> replace = tab.ReplaceContextAsync(replacement).AsTask();
+        await oldContext.DisposeStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Task close = tab.DisposeAsync().AsTask();
+        oldContext.ReleaseDispose();
+
+        Assert.That(await replace.WaitAsync(TimeSpan.FromSeconds(5)), Is.False);
+        await close.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Multiple(() =>
+        {
+            Assert.That(oldContext.DisposeCount, Is.EqualTo(1));
+            Assert.That(replacement.DisposeCount, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public async Task ImmediateRejectedReplacementUsesTheOwnedDisposalFence()
+    {
+        var oldContext = new BlockingEditorContext(blockDispose: false);
+        var replacement = new BlockingEditorContext(blockDispose: false);
+        var nested = new BlockingEditorContext(blockDispose: false);
+        var tab = new EditorTabItem(oldContext);
+        Task<bool>? nestedReplacement = null;
+        nested.OnDispose = () => tab.DisposeAsync();
+        oldContext.OnDispose = async () =>
+        {
+            nestedReplacement = tab.ReplaceContextAsync(nested).AsTask();
+            await nestedReplacement;
+        };
+
+        bool replaced = await tab.ReplaceContextAsync(replacement)
+            .AsTask()
+            .WaitAsync(TimeSpan.FromSeconds(5));
+        await tab.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(replaced, Is.False);
+            Assert.That(nestedReplacement, Is.Not.Null);
+            Assert.That(nestedReplacement!.Result, Is.False);
+            Assert.That(oldContext.DisposeCount, Is.EqualTo(1));
+            Assert.That(replacement.DisposeCount, Is.EqualTo(1));
+            Assert.That(nested.DisposeCount, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public async Task ThrowingContextSubscriberCannotStrandReplacement()
+    {
+        var oldContext = new BlockingEditorContext(blockDispose: false);
+        var replacement = new BlockingEditorContext(blockDispose: false);
+        var tab = new EditorTabItem(oldContext);
+        using IDisposable subscription = tab.Context.Subscribe(value =>
+        {
+            if (value is null)
+                throw new InvalidOperationException("observer failed");
+        });
+
+        Assert.CatchAsync<Exception>(async () =>
+            await tab.ReplaceContextAsync(replacement).AsTask().WaitAsync(TimeSpan.FromSeconds(5)));
+        Assert.Multiple(() =>
+        {
+            Assert.That(oldContext.DisposeCount, Is.EqualTo(1));
+            Assert.That(replacement.DisposeCount, Is.EqualTo(1));
+        });
+        await tab.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task ThrowingContextSubscriberCannotSkipDirectDispose()
+    {
+        var context = new BlockingEditorContext(blockDispose: false);
+        var tab = new EditorTabItem(context);
+        using IDisposable subscription = tab.Context.Subscribe(value =>
+        {
+            if (value is null)
+                throw new InvalidOperationException("observer failed");
+        });
+
+        Assert.CatchAsync<Exception>(async () =>
+            await tab.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5)));
+        Assert.That(context.DisposeCount, Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task ThrowingRemovalObserversCannotSkipTabCleanup()
+    {
+        var context = new BlockingEditorContext(blockDispose: false);
+        var tab = new EditorTabItem(context);
+        var service = new EditorService(new ExtensionProvider());
+        service.AddTabItem(tab);
+        service.SelectedTabItem.Value = tab;
+        ((INotifyCollectionChanged)service.TabItems).CollectionChanged += (_, _) =>
+            throw new InvalidOperationException("collection observer failed");
+        using IDisposable selected = service.SelectedTabItem.Subscribe(value =>
+        {
+            if (value is null)
+                throw new InvalidOperationException("selection observer failed");
+        });
+
+        Assert.CatchAsync<Exception>(async () =>
+            await service.CloseTabItem(tab).AsTask().WaitAsync(TimeSpan.FromSeconds(5)));
+        Assert.Multiple(() =>
+        {
+            Assert.That(service.TabItems, Is.Empty);
+            Assert.That(service.SelectedTabItem.Value, Is.Null);
+            Assert.That(context.DisposeCount, Is.EqualTo(1));
         });
     }
 
@@ -114,7 +423,7 @@ public sealed class EditorTabItemLifetimeTests
         });
     }
 
-    private sealed class BlockingEditorContext : IEditorContext
+    private class BlockingEditorContext : IEditorContext
     {
         private readonly bool _blockDispose;
         private readonly TaskCompletionSource _release = new(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -128,7 +437,7 @@ public sealed class EditorTabItemLifetimeTests
 
         public TaskCompletionSource Disposed { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        public int DisposeCount { get; private set; }
+        public int DisposeCount { get; protected set; }
 
         public Func<ValueTask>? OnDispose { get; set; }
 
@@ -140,7 +449,7 @@ public sealed class EditorTabItemLifetimeTests
 
         public IKnownEditorCommands? Commands => null;
 
-        public async ValueTask DisposeAsync()
+        public virtual async ValueTask DisposeAsync()
         {
             DisposeCount++;
             DisposeStarted.TrySetResult();
@@ -166,6 +475,25 @@ public sealed class EditorTabItemLifetimeTests
         }
 
         public object? GetService(Type serviceType) => null;
+    }
+
+    private sealed class ThrowingEditorContext : BlockingEditorContext
+    {
+        private bool _throw = true;
+
+        public override async ValueTask DisposeAsync()
+        {
+            DisposeCount++;
+            DisposeStarted.TrySetResult();
+            if (!_throw)
+            {
+                Disposed.TrySetResult();
+                return;
+            }
+            _throw = false;
+            await Task.Yield();
+            throw new InvalidOperationException("dispose failed");
+        }
     }
 
     private sealed class TestEditorExtension : EditorExtension

--- a/tests/Beutl.HeadlessUITests/EditorTabItemLifetimeTests.cs
+++ b/tests/Beutl.HeadlessUITests/EditorTabItemLifetimeTests.cs
@@ -14,6 +14,47 @@ namespace Beutl.HeadlessUITests;
 public sealed class EditorTabItemLifetimeTests
 {
     [Test]
+    public async Task EditorContextOwnershipLeaseIsExclusiveAndGenerationSafe()
+    {
+        var closeService = new UnownedCloseService();
+        var context = new BlockingEditorContext(blockDispose: false, closeService: closeService);
+
+        Assert.That(
+            new EditorContextHostToken().TryAcquireContext(
+                context,
+                out EditorContextOwnershipLease? wrongHostLease),
+            Is.False);
+        Assert.That(wrongHostLease, Is.Null);
+        Assert.That(
+            closeService.HostToken.TryAcquireContext(
+                context,
+                out EditorContextOwnershipLease? first),
+            Is.True);
+        Assert.That(
+            closeService.HostToken.TryAcquireContext(
+                context,
+                out EditorContextOwnershipLease? competing),
+            Is.False);
+        Assert.That(competing, Is.Null);
+
+        first!.Dispose();
+        Assert.That(
+            closeService.HostToken.TryAcquireContext(
+                context,
+                out EditorContextOwnershipLease? successor),
+            Is.True);
+        first.Dispose();
+        Assert.That(
+            closeService.HostToken.TryAcquireContext(
+                context,
+                out competing),
+            Is.False);
+
+        successor!.Dispose();
+        await context.DisposeAsync();
+    }
+
+    [Test]
     public async Task AddAndSelectIsLinearizedWithConcurrentDispose()
     {
         var service = new EditorService(new ExtensionProvider());
@@ -330,13 +371,13 @@ public sealed class EditorTabItemLifetimeTests
         var tab = new EditorTabItem(current);
         owner.AddTabItem(tab);
 
-        bool replaced = await tab.ReplaceContextAsync(replacement)
+        EditorContextReplacementResult replaced = await tab.ReplaceContextAsync(replacement)
             .AsTask()
             .WaitAsync(TimeSpan.FromSeconds(5));
 
         Assert.Multiple(() =>
         {
-            Assert.That(replaced, Is.False);
+            Assert.That(replaced.Succeeded, Is.False);
             Assert.That(tab.Context.Value, Is.SameAs(current));
             Assert.That(current.DisposeCount, Is.Zero);
             Assert.That(replacement.DisposeCount, Is.Zero);
@@ -411,13 +452,13 @@ public sealed class EditorTabItemLifetimeTests
         var targetTab = new EditorTabItem(currentContext);
         secondHost.AddTabItem(targetTab);
 
-        bool replaced = await targetTab.ReplaceContextAsync(foreignContext)
+        EditorContextReplacementResult replaced = await targetTab.ReplaceContextAsync(foreignContext)
             .AsTask()
             .WaitAsync(TimeSpan.FromSeconds(5));
 
         Assert.Multiple(() =>
         {
-            Assert.That(replaced, Is.False);
+            Assert.That(replaced.Succeeded, Is.False);
             Assert.That(foreignTab.Context.Value, Is.SameAs(foreignContext));
             Assert.That(targetTab.Context.Value, Is.SameAs(currentContext));
             Assert.That(foreignContext.DisposeCount, Is.Zero);
@@ -429,6 +470,320 @@ public sealed class EditorTabItemLifetimeTests
         Assert.That(foreignClose.Status, Is.EqualTo(EditorContextCloseRequestStatus.Accepted));
         await foreignClose.Completion.WaitAsync(TimeSpan.FromSeconds(5));
         await secondHost.CloseTabItem(targetTab).AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task UnownedTabCannotReplaceContextOwnedByAnotherHost()
+    {
+        var owner = new EditorService(new ExtensionProvider());
+        var foreign = new EditorService(new ExtensionProvider());
+        var ownerContext = new BlockingEditorContext(blockDispose: false, closeService: owner);
+        var ownerTab = new EditorTabItem(ownerContext);
+        owner.AddTabItem(ownerTab);
+
+        var unownedCurrent = new BlockingEditorContext(blockDispose: false, closeService: foreign);
+        var unownedTab = new EditorTabItem(unownedCurrent);
+
+        EditorContextReplacementResult result = await unownedTab.ReplaceContextAsync(ownerContext)
+            .AsTask()
+            .WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Status, Is.EqualTo(EditorContextReplacementStatus.NotOwned));
+            Assert.That(result.InputConsumed, Is.False);
+            Assert.That(ownerTab.Context.Value, Is.SameAs(ownerContext));
+            Assert.That(unownedTab.Context.Value, Is.SameAs(unownedCurrent));
+            Assert.That(ownerContext.DisposeCount, Is.Zero);
+            Assert.That(unownedCurrent.DisposeCount, Is.Zero);
+        });
+
+        await owner.CloseTabItem(ownerTab).AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+        await unownedTab.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task InitialAddAndReplacementInterleavingCannotPublishUnownedReplacement()
+    {
+        var service = new EditorService(new ExtensionProvider());
+        var current = new BlockingEditorContext(blockDispose: false, closeService: service);
+        var replacement = new BlockingEditorContext(blockDispose: false, closeService: service);
+        var tab = new EditorTabItem(current);
+        using var attachEntered = new ManualResetEventSlim();
+        using var releaseAttach = new ManualResetEventSlim();
+        service.BeforeInitialContextClaimPublish = () =>
+        {
+            attachEntered.Set();
+            releaseAttach.Wait(TimeSpan.FromSeconds(5));
+        };
+
+        Task<bool> add = Task.Run(() => service.TryAddTabItem(tab));
+        Assert.That(attachEntered.Wait(TimeSpan.FromSeconds(5)), Is.True);
+        EditorContextReplacementResult replacementResult = await tab.ReplaceContextAsync(replacement)
+            .AsTask()
+            .WaitAsync(TimeSpan.FromSeconds(5));
+        releaseAttach.Set();
+
+        Assert.That(await add.WaitAsync(TimeSpan.FromSeconds(5)), Is.True);
+        Assert.Multiple(() =>
+        {
+            Assert.That(replacementResult.Status, Is.EqualTo(EditorContextReplacementStatus.NotOwned));
+            Assert.That(replacementResult.InputConsumed, Is.False);
+            Assert.That(tab.Context.Value, Is.SameAs(current));
+            Assert.That(service.TabItems, Does.Contain(tab));
+            Assert.That(replacement.DisposeCount, Is.Zero);
+        });
+
+        await tab.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+        await replacement.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task HostMediatedReplacementTransfersFactoryOwnership()
+    {
+        var service = new EditorService(new ExtensionProvider());
+        var current = new BlockingEditorContext(blockDispose: false, closeService: service);
+        var tab = new EditorTabItem(current);
+        service.AddTabItem(tab);
+        var extension = new HostMediatedReplacementExtension();
+
+        EditorContextReplacementStatus status = await service.ReplaceContextAsync(tab, extension);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(status, Is.EqualTo(EditorContextReplacementStatus.Succeeded));
+            Assert.That(tab.Context.Value, Is.SameAs(extension.CreatedContext));
+            Assert.That(extension.CreatedContext!.DisposeCount, Is.Zero);
+            Assert.That(service.TabItems, Does.Contain(tab));
+        });
+        await service.CloseTabItem(tab).AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task HostMediatedReplacementRejectsForeignTabBeforeCreatingContext()
+    {
+        var owner = new EditorService(new ExtensionProvider());
+        var foreign = new EditorService(new ExtensionProvider());
+        var current = new BlockingEditorContext(blockDispose: false, closeService: foreign);
+        var tab = new EditorTabItem(current);
+        foreign.AddTabItem(tab);
+        var extension = new HostMediatedReplacementExtension();
+
+        EditorContextReplacementStatus status = await owner.ReplaceContextAsync(tab, extension);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(status, Is.EqualTo(EditorContextReplacementStatus.NotOwned));
+            Assert.That(extension.CreationCount, Is.Zero);
+            Assert.That(tab.Context.Value, Is.SameAs(current));
+            Assert.That(current.DisposeCount, Is.Zero);
+            Assert.That(foreign.TabItems, Does.Contain(tab));
+        });
+        await foreign.CloseTabItem(tab).AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task HostMediatedReplacementDoesNotDisposeExistingOwnedFactoryResult()
+    {
+        var service = new EditorService(new ExtensionProvider());
+        var foreign = new EditorService(new ExtensionProvider());
+        var current = new BlockingEditorContext(
+            blockDispose: false,
+            closeService: new ForwardingCloseService(service));
+        var siblingContext = new BlockingEditorContext(
+            blockDispose: false,
+            closeService: new ForwardingCloseService(service));
+        var foreignContext = new BlockingEditorContext(
+            blockDispose: false,
+            closeService: new ForwardingCloseService(foreign));
+        var tab = new EditorTabItem(current);
+        var siblingTab = new EditorTabItem(siblingContext);
+        var foreignTab = new EditorTabItem(foreignContext);
+        service.AddTabItem(tab);
+        service.AddTabItem(siblingTab);
+        foreign.AddTabItem(foreignTab);
+
+        EditorContextReplacementStatus sameStatus = await service.ReplaceContextAsync(
+            tab,
+            new ExistingContextEditorExtension(current));
+        EditorContextReplacementStatus siblingStatus = await service.ReplaceContextAsync(
+            tab,
+            new ExistingContextEditorExtension(siblingContext));
+        EditorContextReplacementStatus foreignStatus = await service.ReplaceContextAsync(
+            tab,
+            new ExistingContextEditorExtension(foreignContext));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(sameStatus, Is.EqualTo(EditorContextReplacementStatus.AlreadyActive));
+            Assert.That(siblingStatus, Is.EqualTo(EditorContextReplacementStatus.NotOwned));
+            Assert.That(foreignStatus, Is.EqualTo(EditorContextReplacementStatus.NotOwned));
+            Assert.That(tab.Context.Value, Is.SameAs(current));
+            Assert.That(siblingTab.Context.Value, Is.SameAs(siblingContext));
+            Assert.That(foreignTab.Context.Value, Is.SameAs(foreignContext));
+            Assert.That(current.DisposeCount, Is.Zero);
+            Assert.That(siblingContext.DisposeCount, Is.Zero);
+            Assert.That(foreignContext.DisposeCount, Is.Zero);
+        });
+
+        await service.CloseTabItem(tab).AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+        await service.CloseTabItem(siblingTab).AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+        await foreign.CloseTabItem(foreignTab).AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task HostMediatedReplacementPreservesContextClaimedDuringFactoryCall()
+    {
+        var service = new EditorService(new ExtensionProvider());
+        var current = new BlockingEditorContext(blockDispose: false, closeService: service);
+        var tab = new EditorTabItem(current);
+        service.AddTabItem(tab);
+        var extension = new RegisteringContextEditorExtension(service);
+
+        EditorContextReplacementStatus status = await service.ReplaceContextAsync(tab, extension);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(status, Is.EqualTo(EditorContextReplacementStatus.NotOwned));
+            Assert.That(tab.Context.Value, Is.SameAs(current));
+            Assert.That(extension.CreatedTab, Is.Not.Null);
+            Assert.That(extension.CreatedContext, Is.SameAs(extension.CreatedTab!.Context.Value));
+            Assert.That(extension.CreatedContext!.DisposeCount, Is.Zero);
+            Assert.That(service.TabItems, Does.Contain(extension.CreatedTab));
+        });
+
+        await service.CloseTabItem(tab).AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+        await service.CloseTabItem(extension.CreatedTab!).AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task HostMediatedReplacementPreservesExternalHostOwnershipLease()
+    {
+        var service = new EditorService(new ExtensionProvider());
+        var current = new BlockingEditorContext(blockDispose: false, closeService: service);
+        var tab = new EditorTabItem(current);
+        service.AddTabItem(tab);
+
+        var externalCloseService = new UnownedCloseService();
+        var externalContext = new BlockingEditorContext(
+            blockDispose: false,
+            closeService: new ForwardingCloseService(externalCloseService));
+        Assert.That(
+            externalCloseService.HostToken.TryAcquireContext(
+                externalContext,
+                out EditorContextOwnershipLease? externalLease),
+            Is.True);
+
+        try
+        {
+            EditorContextReplacementStatus status = await service.ReplaceContextAsync(
+                tab,
+                new ExistingContextEditorExtension(externalContext));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(status, Is.EqualTo(EditorContextReplacementStatus.NotOwned));
+                Assert.That(tab.Context.Value, Is.SameAs(current));
+                Assert.That(externalContext.DisposeCount, Is.Zero);
+            });
+        }
+        finally
+        {
+            externalLease!.Dispose();
+            await externalContext.DisposeAsync();
+            await service.CloseTabItem(tab).AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+        }
+    }
+
+    [Test]
+    public async Task HostMediatedReplacementDisposesFactoryContextWhenTokenValidationThrows()
+    {
+        var service = new EditorService(new ExtensionProvider());
+        var current = new BlockingEditorContext(blockDispose: false, closeService: service);
+        var tab = new EditorTabItem(current);
+        service.AddTabItem(tab);
+        var extension = new HostMediatedReplacementExtension(throwOnHostToken: true);
+
+        InvalidOperationException? caught = null;
+        try
+        {
+            await service.ReplaceContextAsync(tab, extension);
+        }
+        catch (InvalidOperationException ex)
+        {
+            caught = ex;
+        }
+        Assert.That(caught, Is.Not.Null);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(tab.Context.Value, Is.SameAs(current));
+            Assert.That(current.DisposeCount, Is.Zero);
+            Assert.That(extension.CreatedContext!.DisposeCount, Is.EqualTo(1));
+            Assert.That(service.TabItems, Does.Contain(tab));
+        });
+        await service.CloseTabItem(tab).AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task HostMediatedReplacementRejectsStaleGenerationAfterFactoryReentry()
+    {
+        var service = new EditorService(new ExtensionProvider());
+        var current = new BlockingEditorContext(blockDispose: false, closeService: service);
+        var tab = new EditorTabItem(current);
+        service.AddTabItem(tab);
+        var extension = new BlockingReplacementExtension();
+
+        Task<EditorContextReplacementStatus> pending =
+            Task.Run(() => service.ReplaceContextAsync(tab, extension).AsTask());
+        await extension.Entered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        var intervening = new BlockingEditorContext(blockDispose: false, closeService: service);
+        EditorContextReplacementResult interveningResult = await tab.ReplaceContextAsync(intervening)
+            .AsTask()
+            .WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.That(interveningResult.Succeeded, Is.True);
+        EditorContextReplacementResult restoredResult = await tab.ReplaceContextAsync(current)
+            .AsTask()
+            .WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.That(restoredResult.Succeeded, Is.True);
+
+        extension.Release.TrySetResult();
+        EditorContextReplacementStatus staleStatus = await pending.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(staleStatus, Is.EqualTo(EditorContextReplacementStatus.Busy));
+            Assert.That(extension.CreatedContext!.DisposeCount, Is.EqualTo(1));
+            Assert.That(tab.Context.Value, Is.SameAs(current));
+        });
+        await service.CloseTabItem(tab).AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task HostMediatedReplacementDisposesFactoryContextWhenCloseWinsDuringCreation()
+    {
+        var service = new EditorService(new ExtensionProvider());
+        var current = new BlockingEditorContext(blockDispose: false, closeService: service);
+        var tab = new EditorTabItem(current);
+        service.AddTabItem(tab);
+        var extension = new BlockingReplacementExtension();
+
+        Task<EditorContextReplacementStatus> pending =
+            Task.Run(() => service.ReplaceContextAsync(tab, extension).AsTask());
+        await extension.Entered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await service.CloseTabItem(tab).AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+
+        extension.Release.TrySetResult();
+        EditorContextReplacementStatus status = await pending.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(status, Is.EqualTo(EditorContextReplacementStatus.Busy));
+            Assert.That(extension.CreatedContext!.DisposeCount, Is.EqualTo(1));
+            Assert.That(service.TabItems, Does.Not.Contain(tab));
+            Assert.That(tab.Context.Value, Is.Null);
+        });
     }
 
     [Test]
@@ -447,14 +802,14 @@ public sealed class EditorTabItemLifetimeTests
                 foreignAddNotifications++;
         };
 
-        Task<bool> replacing = tab.ReplaceContextAsync(replacement).AsTask();
+        Task<EditorContextReplacementResult> replacing = tab.ReplaceContextAsync(replacement).AsTask();
         await oldContext.DisposeStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
         Assert.That(tab.Context.Value, Is.Null);
 
         foreign.AddTabItem(tab);
         oldContext.ReleaseDispose();
 
-        Assert.That(await replacing.WaitAsync(TimeSpan.FromSeconds(5)), Is.True);
+        Assert.That((await replacing!.WaitAsync(TimeSpan.FromSeconds(5))).Succeeded, Is.True);
         Assert.Multiple(() =>
         {
             Assert.That(owner.TabItems, Does.Contain(tab));
@@ -476,13 +831,13 @@ public sealed class EditorTabItemLifetimeTests
         var tab = new EditorTabItem(current);
         owner.AddTabItem(tab);
 
-        bool replaced = await tab.ReplaceContextAsync(replacement)
+        EditorContextReplacementResult replaced = await tab.ReplaceContextAsync(replacement)
             .AsTask()
             .WaitAsync(TimeSpan.FromSeconds(5));
 
         Assert.Multiple(() =>
         {
-            Assert.That(replaced, Is.True);
+            Assert.That(replaced.Succeeded, Is.True);
             Assert.That(tab.Context.Value, Is.SameAs(replacement));
             Assert.That(current.DisposeCount, Is.EqualTo(1));
             Assert.That(replacement.DisposeCount, Is.Zero);
@@ -866,7 +1221,7 @@ public sealed class EditorTabItemLifetimeTests
         var replacement = new BlockingEditorContext(blockDispose: false, closeService: service);
         var tab = new EditorTabItem(original);
         service.AddTabItem(tab);
-        bool? replaced = null;
+        EditorContextReplacementResult? replaced = null;
         using IDisposable observer = tab.IsSelected.Subscribe(value =>
         {
             if (value)
@@ -883,7 +1238,7 @@ public sealed class EditorTabItemLifetimeTests
 
         Assert.Multiple(() =>
         {
-            Assert.That(replaced, Is.False);
+            Assert.That(replaced?.Succeeded, Is.False);
             Assert.That(tab.Context.Value, Is.SameAs(original));
             Assert.That(replacement.DisposeCount, Is.EqualTo(1));
             Assert.That(service.SelectedTabItem.Value, Is.SameAs(tab));
@@ -957,14 +1312,14 @@ public sealed class EditorTabItemLifetimeTests
             }
         };
 
-        Task<bool> replace = Task.Run(async () => await tab.ReplaceContextAsync(replacement));
+        Task<EditorContextReplacementResult> replace = Task.Run(async () => await tab.ReplaceContextAsync(replacement));
         await replacement.PublicationPaused.Task.WaitAsync(TimeSpan.FromSeconds(5));
         Assert.That(service.RequestTabRemoval(tab), Is.False);
         Assert.That(service.ContainsTabItem(tab), Is.True,
             "Physical removal waits for the admitted replacement publication to drain.");
         replacement.ReleasePublication();
 
-        Assert.That(await replace.WaitAsync(TimeSpan.FromSeconds(5)), Is.False);
+        Assert.That((await replace!.WaitAsync(TimeSpan.FromSeconds(5))).Succeeded, Is.False);
         await tab.GetRemovalCompletion().WaitAsync(TimeSpan.FromSeconds(5));
         Assert.Multiple(() =>
         {
@@ -1000,16 +1355,20 @@ public sealed class EditorTabItemLifetimeTests
     [Test]
     public async Task ReplaceContextAsync_RejectsAndDisposesNewContextWhenCloseWins()
     {
-        var oldContext = new BlockingEditorContext();
-        var newContext = new BlockingEditorContext(blockDispose: false);
+        var service = new EditorService(new ExtensionProvider());
+        var oldContext = new BlockingEditorContext(closeService: service);
+        var newContext = new BlockingEditorContext(blockDispose: false, closeService: service);
         var tab = new EditorTabItem(oldContext);
+        service.AddTabItem(tab);
 
         Task close = tab.DisposeAsync().AsTask();
-        Task<bool> replacement = tab.ReplaceContextAsync(newContext).AsTask();
+        Task<EditorContextReplacementResult> replacement = tab.ReplaceContextAsync(newContext).AsTask();
 
         oldContext.ReleaseDispose();
-        Assert.That(await replacement.WaitAsync(TimeSpan.FromSeconds(5)), Is.False);
-        await newContext.Disposed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        EditorContextReplacementResult replacementResult = await replacement!.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.That(replacementResult.Status, Is.EqualTo(EditorContextReplacementStatus.NotOwned));
+        Assert.That(replacementResult.InputConsumed, Is.False);
+        await newContext.DisposeAsync();
 
         await close.WaitAsync(TimeSpan.FromSeconds(5));
         Assert.That(newContext.DisposeCount, Is.EqualTo(1));
@@ -1023,13 +1382,13 @@ public sealed class EditorTabItemLifetimeTests
         var tab = new EditorTabItem(context);
         service.AddTabItem(tab);
 
-        bool replaced = await tab.ReplaceContextAsync(context)
+        EditorContextReplacementResult replaced = await tab.ReplaceContextAsync(context)
             .AsTask()
             .WaitAsync(TimeSpan.FromSeconds(5));
 
         Assert.Multiple(() =>
         {
-            Assert.That(replaced, Is.False);
+            Assert.That(replaced.Succeeded, Is.False);
             Assert.That(tab.Context.Value, Is.SameAs(context));
             Assert.That(context.DisposeCount, Is.Zero);
         });
@@ -1042,13 +1401,13 @@ public sealed class EditorTabItemLifetimeTests
         var context = new BlockingEditorContext(blockDispose: false);
         var tab = new EditorTabItem(context);
 
-        bool replaced = await tab.ReplaceContextAsync(context)
+        EditorContextReplacementResult replaced = await tab.ReplaceContextAsync(context)
             .AsTask()
             .WaitAsync(TimeSpan.FromSeconds(5));
 
         Assert.Multiple(() =>
         {
-            Assert.That(replaced, Is.False);
+            Assert.That(replaced.Succeeded, Is.False);
             Assert.That(tab.Context.Value, Is.SameAs(context));
             Assert.That(context.DisposeCount, Is.Zero);
         });
@@ -1067,13 +1426,13 @@ public sealed class EditorTabItemLifetimeTests
         service.AddTabItem(first);
         service.AddTabItem(second);
 
-        bool replaced = await first.ReplaceContextAsync(secondContext)
+        EditorContextReplacementResult replaced = await first.ReplaceContextAsync(secondContext)
             .AsTask()
             .WaitAsync(TimeSpan.FromSeconds(5));
 
         Assert.Multiple(() =>
         {
-            Assert.That(replaced, Is.False);
+            Assert.That(replaced.Succeeded, Is.False);
             Assert.That(first.Context.Value, Is.SameAs(firstContext));
             Assert.That(second.Context.Value, Is.SameAs(secondContext));
             Assert.That(firstContext.DisposeCount, Is.Zero);
@@ -1096,11 +1455,11 @@ public sealed class EditorTabItemLifetimeTests
 
         Task close = service.CloseTabItem(closing).AsTask();
         await closingContext.DisposeStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
-        bool replaced = await closing.ReplaceContextAsync(otherContext)
+        EditorContextReplacementResult replaced = await closing.ReplaceContextAsync(otherContext)
             .AsTask()
             .WaitAsync(TimeSpan.FromSeconds(5));
 
-        Assert.That(replaced, Is.False);
+        Assert.That(replaced.Succeeded, Is.False);
         Assert.That(otherContext.DisposeCount, Is.Zero);
         closingContext.ReleaseDispose();
         await close.WaitAsync(TimeSpan.FromSeconds(5));
@@ -1108,7 +1467,7 @@ public sealed class EditorTabItemLifetimeTests
     }
 
     [Test]
-    public async Task RejectedReplacementReservationRemainsInvisibleUntilDisposalCompletes()
+    public async Task RejectedReplacementClaimRemainsHeldUntilDisposalCompletes()
     {
         var service = new EditorService(new ExtensionProvider());
         var closingContext = new BlockingEditorContext(closeService: service);
@@ -1116,22 +1475,25 @@ public sealed class EditorTabItemLifetimeTests
         var closing = new EditorTabItem(closingContext);
         service.AddTabItem(closing);
 
-        Task close = service.CloseTabItem(closing).AsTask();
+        Task<EditorContextReplacementResult> replace = closing.ReplaceContextAsync(rejectedContext).AsTask();
         await closingContext.DisposeStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
-        Task<bool> replace = closing.ReplaceContextAsync(rejectedContext).AsTask();
+        Task close = service.CloseTabItem(closing).AsTask();
+        closingContext.ReleaseDispose();
         await rejectedContext.DisposeStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
-        Assert.That(
-            service.RequestClose(rejectedContext).Status,
-            Is.EqualTo(EditorContextCloseRequestStatus.NotOwned));
         var competing = new EditorTabItem(rejectedContext);
         Assert.That(service.TryAddTabItem(competing), Is.False);
 
         rejectedContext.ReleaseDispose();
-        Assert.That(await replace.WaitAsync(TimeSpan.FromSeconds(5)), Is.False);
-        closingContext.ReleaseDispose();
+        EditorContextReplacementResult replacementResult = await replace.WaitAsync(TimeSpan.FromSeconds(5));
         await close.WaitAsync(TimeSpan.FromSeconds(5));
-        Assert.That(rejectedContext.DisposeCount, Is.EqualTo(1));
+        Assert.Multiple(() =>
+        {
+            Assert.That(replacementResult.Status, Is.EqualTo(EditorContextReplacementStatus.Busy));
+            Assert.That(replacementResult.InputConsumed, Is.True);
+            Assert.That(rejectedContext.DisposeCount, Is.EqualTo(1));
+            Assert.That(service.TabItems, Does.Not.Contain(competing));
+        });
     }
 
     [Test]
@@ -1146,16 +1508,16 @@ public sealed class EditorTabItemLifetimeTests
         service.AddTabItem(transitioning);
         service.AddTabItem(other);
 
-        Task<bool> firstReplacement = transitioning.ReplaceContextAsync(replacement).AsTask();
+        Task<EditorContextReplacementResult> firstReplacement = transitioning.ReplaceContextAsync(replacement).AsTask();
         await oldContext.DisposeStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
-        bool rejected = await transitioning.ReplaceContextAsync(otherContext)
+        EditorContextReplacementResult rejected = await transitioning.ReplaceContextAsync(otherContext)
             .AsTask()
             .WaitAsync(TimeSpan.FromSeconds(5));
 
-        Assert.That(rejected, Is.False);
+        Assert.That(rejected.Succeeded, Is.False);
         Assert.That(otherContext.DisposeCount, Is.Zero);
         oldContext.ReleaseDispose();
-        Assert.That(await firstReplacement.WaitAsync(TimeSpan.FromSeconds(5)), Is.True);
+        Assert.That((await firstReplacement!.WaitAsync(TimeSpan.FromSeconds(5))).Succeeded, Is.True);
         await service.CloseTabItem(transitioning).AsTask().WaitAsync(TimeSpan.FromSeconds(5));
         await service.CloseTabItem(other).AsTask().WaitAsync(TimeSpan.FromSeconds(5));
     }
@@ -1175,14 +1537,14 @@ public sealed class EditorTabItemLifetimeTests
                 closeRequest = service.RequestClose(replacement);
         });
 
-        bool replaced = await tab.ReplaceContextAsync(replacement)
+        EditorContextReplacementResult replaced = await tab.ReplaceContextAsync(replacement)
             .AsTask()
             .WaitAsync(TimeSpan.FromSeconds(5));
         await closeRequest.Completion.WaitAsync(TimeSpan.FromSeconds(5));
 
         Assert.Multiple(() =>
         {
-            Assert.That(replaced, Is.False);
+            Assert.That(replaced.Succeeded, Is.False);
             Assert.That(closeRequest.Status, Is.EqualTo(EditorContextCloseRequestStatus.Accepted));
             Assert.That(oldContext.DisposeCount, Is.EqualTo(1));
             Assert.That(replacement.DisposeCount, Is.EqualTo(1));
@@ -1208,7 +1570,7 @@ public sealed class EditorTabItemLifetimeTests
         Task<EditorContextCloseRequest> staleClose = Task.Run(() => service.RequestClose(oldContext));
         await lookupCompleted.Task.WaitAsync(TimeSpan.FromSeconds(5));
         Assert.That(
-            await tab.ReplaceContextAsync(replacement).AsTask().WaitAsync(TimeSpan.FromSeconds(5)),
+            (await tab.ReplaceContextAsync(replacement).AsTask().WaitAsync(TimeSpan.FromSeconds(5))).Succeeded,
             Is.True);
         releaseAdmission.TrySetResult();
 
@@ -1244,10 +1606,10 @@ public sealed class EditorTabItemLifetimeTests
         Task<EditorContextCloseRequest> close = Task.Run(() => service.RequestClose(oldContext));
         await reservationCompleted.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
-        bool replaced = await tab.ReplaceContextAsync(replacement)
+        EditorContextReplacementResult replaced = await tab.ReplaceContextAsync(replacement)
             .AsTask()
             .WaitAsync(TimeSpan.FromSeconds(5));
-        Assert.That(replaced, Is.False);
+        Assert.That(replaced.Succeeded, Is.False);
         Assert.That(oldContext.DisposeCount, Is.Zero);
         Assert.That(replacement.DisposeCount, Is.EqualTo(1));
 
@@ -1277,13 +1639,13 @@ public sealed class EditorTabItemLifetimeTests
             return ValueTask.CompletedTask;
         };
 
-        bool replaced = await tab.ReplaceContextAsync(replacement)
+        EditorContextReplacementResult replaced = await tab.ReplaceContextAsync(replacement)
             .AsTask()
             .WaitAsync(TimeSpan.FromSeconds(5));
 
         Assert.Multiple(() =>
         {
-            Assert.That(replaced, Is.True);
+            Assert.That(replaced.Succeeded, Is.True);
             Assert.That(service.TabItems, Does.Contain(tab));
             Assert.That(tab.Context.Value, Is.SameAs(replacement));
         });
@@ -1293,15 +1655,19 @@ public sealed class EditorTabItemLifetimeTests
     [Test]
     public async Task RejectedReplacementDisposalFailureIsReportedAfterCleanup()
     {
-        var oldContext = new BlockingEditorContext();
-        var replacement = new ThrowingEditorContext();
+        var service = new EditorService(new ExtensionProvider());
+        var oldContext = new BlockingEditorContext(closeService: service);
+        var replacement = new ThrowingEditorContext(service);
         var tab = new EditorTabItem(oldContext);
+        service.AddTabItem(tab);
 
         Task close = tab.DisposeAsync().AsTask();
-        Task<bool> replace = tab.ReplaceContextAsync(replacement).AsTask();
+        Task<EditorContextReplacementResult> replace = tab.ReplaceContextAsync(replacement).AsTask();
 
-        Assert.CatchAsync<InvalidOperationException>(async () =>
-            await replace.WaitAsync(TimeSpan.FromSeconds(5)));
+        EditorContextReplacementResult replacementResult = await replace.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.That(replacementResult.Status, Is.EqualTo(EditorContextReplacementStatus.NotOwned));
+        Assert.That(replacementResult.InputConsumed, Is.False);
+        Assert.CatchAsync<InvalidOperationException>(async () => await replacement.DisposeAsync());
         oldContext.ReleaseDispose();
         await close.WaitAsync(TimeSpan.FromSeconds(5));
         Assert.Multiple(() =>
@@ -1326,14 +1692,14 @@ public sealed class EditorTabItemLifetimeTests
             return ValueTask.CompletedTask;
         };
 
-        bool replaced = await tab.ReplaceContextAsync(newContext)
+        EditorContextReplacementResult replaced = await tab.ReplaceContextAsync(newContext)
             .AsTask()
             .WaitAsync(TimeSpan.FromSeconds(5));
         await closeRequest.Completion.WaitAsync(TimeSpan.FromSeconds(5));
 
         Assert.Multiple(() =>
         {
-            Assert.That(replaced, Is.False);
+            Assert.That(replaced.Succeeded, Is.False);
             Assert.That(oldContext.DisposeCount, Is.EqualTo(1));
             Assert.That(newContext.DisposeCount, Is.EqualTo(1));
         });
@@ -1342,14 +1708,16 @@ public sealed class EditorTabItemLifetimeTests
     [Test]
     public async Task ContextPropertyPublishesNullOnlyAfterTerminalClose()
     {
-        var oldContext = new BlockingEditorContext(blockDispose: false);
-        var newContext = new BlockingEditorContext(blockDispose: false);
+        var service = new EditorService(new ExtensionProvider());
+        var oldContext = new BlockingEditorContext(blockDispose: false, closeService: service);
+        var newContext = new BlockingEditorContext(blockDispose: false, closeService: service);
         var tab = new EditorTabItem(oldContext);
+        service.AddTabItem(tab);
         var values = new List<IEditorContext?>();
         using IDisposable subscription = tab.Context.Subscribe(values.Add);
 
-        Assert.That(await tab.ReplaceContextAsync(newContext).AsTask(), Is.True);
-        await tab.DisposeAsync();
+        Assert.That((await tab.ReplaceContextAsync(newContext).AsTask()).Succeeded, Is.True);
+        await service.CloseTabItem(tab).AsTask().WaitAsync(TimeSpan.FromSeconds(5));
 
         Assert.That(values, Does.Contain(null));
     }
@@ -1407,8 +1775,11 @@ public sealed class EditorTabItemLifetimeTests
     [Test]
     public async Task ContextSubscriberCanReenterCloseWhenReplacementPublishesNull()
     {
-        var oldContext = new BlockingEditorContext(blockDispose: false);
+        var service = new EditorService(new ExtensionProvider());
+        var oldContext = new BlockingEditorContext(blockDispose: false, closeService: service);
+        var replacement = new BlockingEditorContext(blockDispose: false, closeService: service);
         var tab = new EditorTabItem(oldContext);
+        service.AddTabItem(tab);
         Task? reentrantClose = null;
         using IDisposable subscription = tab.Context.Subscribe(value =>
         {
@@ -1416,10 +1787,10 @@ public sealed class EditorTabItemLifetimeTests
                 reentrantClose = tab.DisposeAsync().AsTask();
         });
 
-        bool replaced = await tab.ReplaceContextAsync(new BlockingEditorContext(blockDispose: false))
+        EditorContextReplacementResult replaced = await tab.ReplaceContextAsync(replacement)
             .AsTask()
             .WaitAsync(TimeSpan.FromSeconds(5));
-        Assert.That(replaced, Is.False);
+        Assert.That(replaced.Succeeded, Is.False);
         if (reentrantClose is not null)
             await reentrantClose.WaitAsync(TimeSpan.FromSeconds(5));
     }
@@ -1439,14 +1810,14 @@ public sealed class EditorTabItemLifetimeTests
                 closeRequest = service.RequestClose(oldContext);
         });
 
-        bool replaced = await tab.ReplaceContextAsync(replacement)
+        EditorContextReplacementResult replaced = await tab.ReplaceContextAsync(replacement)
             .AsTask()
             .WaitAsync(TimeSpan.FromSeconds(5));
         await closeRequest.Completion.WaitAsync(TimeSpan.FromSeconds(5));
 
         Assert.Multiple(() =>
         {
-            Assert.That(replaced, Is.False);
+            Assert.That(replaced.Succeeded, Is.False);
             Assert.That(closeRequest.Status, Is.EqualTo(EditorContextCloseRequestStatus.Accepted));
             Assert.That(oldContext.DisposeCount, Is.EqualTo(1));
             Assert.That(replacement.DisposeCount, Is.EqualTo(1));
@@ -1456,9 +1827,11 @@ public sealed class EditorTabItemLifetimeTests
     [Test]
     public async Task CloseStartedByReplacementPublicationWinsTheResult()
     {
-        var oldContext = new BlockingEditorContext(blockDispose: false);
-        var replacement = new BlockingEditorContext(blockDispose: false);
+        var service = new EditorService(new ExtensionProvider());
+        var oldContext = new BlockingEditorContext(blockDispose: false, closeService: service);
+        var replacement = new BlockingEditorContext(blockDispose: false, closeService: service);
         var tab = new EditorTabItem(oldContext);
+        service.AddTabItem(tab);
         Task? close = null;
         using IDisposable subscription = tab.Context.Subscribe(value =>
         {
@@ -1466,10 +1839,10 @@ public sealed class EditorTabItemLifetimeTests
                 close = tab.DisposeAsync().AsTask();
         });
 
-        bool replaced = await tab.ReplaceContextAsync(replacement)
+        EditorContextReplacementResult replaced = await tab.ReplaceContextAsync(replacement)
             .AsTask()
             .WaitAsync(TimeSpan.FromSeconds(5));
-        Assert.That(replaced, Is.False);
+        Assert.That(replaced.Succeeded, Is.False);
         Assert.That(close, Is.Not.Null);
         await close!.WaitAsync(TimeSpan.FromSeconds(5));
         Assert.That(replacement.DisposeCount, Is.EqualTo(1));
@@ -1478,23 +1851,25 @@ public sealed class EditorTabItemLifetimeTests
     [Test]
     public async Task ContextSubscriberCannotStartACompetingReplacement()
     {
-        var oldContext = new BlockingEditorContext(blockDispose: false);
-        var replacement = new BlockingEditorContext(blockDispose: false);
-        var nested = new BlockingEditorContext(blockDispose: false);
+        var service = new EditorService(new ExtensionProvider());
+        var oldContext = new BlockingEditorContext(blockDispose: false, closeService: service);
+        var replacement = new BlockingEditorContext(blockDispose: false, closeService: service);
+        var nested = new BlockingEditorContext(blockDispose: false, closeService: service);
         var tab = new EditorTabItem(oldContext);
-        Task<bool>? nestedReplacement = null;
+        service.AddTabItem(tab);
+        Task<EditorContextReplacementResult>? nestedReplacement = null;
         using IDisposable subscription = tab.Context.Subscribe(value =>
         {
             if (value is null && nestedReplacement is null)
                 nestedReplacement = tab.ReplaceContextAsync(nested).AsTask();
         });
 
-        bool replaced = await tab.ReplaceContextAsync(replacement)
+        EditorContextReplacementResult replaced = await tab.ReplaceContextAsync(replacement)
             .AsTask()
             .WaitAsync(TimeSpan.FromSeconds(5));
-        Assert.That(replaced, Is.True);
+        Assert.That(replaced.Succeeded, Is.True);
         Assert.That(nestedReplacement, Is.Not.Null);
-        Assert.That(await nestedReplacement!.WaitAsync(TimeSpan.FromSeconds(5)), Is.False);
+        Assert.That((await nestedReplacement!.WaitAsync(TimeSpan.FromSeconds(5))).Succeeded, Is.False);
         Assert.Multiple(() =>
         {
             Assert.That(oldContext.DisposeCount, Is.EqualTo(1));
@@ -1507,9 +1882,11 @@ public sealed class EditorTabItemLifetimeTests
     [Test]
     public async Task DelayedOwnedDisposalChildUsesNormalDisposeSemanticsAfterScopeEnds()
     {
-        var oldContext = new BlockingEditorContext(blockDispose: false);
-        var replacement = new BlockingEditorContext();
+        var service = new EditorService(new ExtensionProvider());
+        var oldContext = new BlockingEditorContext(blockDispose: false, closeService: service);
+        var replacement = new BlockingEditorContext(closeService: service);
         var tab = new EditorTabItem(oldContext);
+        service.AddTabItem(tab);
         var releaseChild = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         Task? delayedClose = null;
         oldContext.OnDispose = () =>
@@ -1523,7 +1900,7 @@ public sealed class EditorTabItemLifetimeTests
         };
 
         Assert.That(
-            await tab.ReplaceContextAsync(replacement).AsTask().WaitAsync(TimeSpan.FromSeconds(5)),
+            (await tab.ReplaceContextAsync(replacement).AsTask().WaitAsync(TimeSpan.FromSeconds(5))).Succeeded,
             Is.True);
         Assert.That(delayedClose, Is.Not.Null);
         releaseChild.TrySetResult();
@@ -1538,12 +1915,14 @@ public sealed class EditorTabItemLifetimeTests
     [Test]
     public async Task ContextPublicationDoesNotRunRejectedPluginTeardownUnderTheHostGate()
     {
-        var oldContext = new BlockingEditorContext(blockDispose: false);
-        var replacement = new BlockingEditorContext(blockDispose: false);
-        var nested = new BlockingEditorContext(blockDispose: false);
-        var third = new BlockingEditorContext(blockDispose: false);
+        var service = new EditorService(new ExtensionProvider());
+        var oldContext = new BlockingEditorContext(blockDispose: false, closeService: service);
+        var replacement = new BlockingEditorContext(blockDispose: false, closeService: service);
+        var nested = new BlockingEditorContext(blockDispose: false, closeService: service);
+        var third = new BlockingEditorContext(blockDispose: false, closeService: service);
         var tab = new EditorTabItem(oldContext);
-        Task<bool>? nestedReplacement = null;
+        service.AddTabItem(tab);
+        Task<EditorContextReplacementResult>? nestedReplacement = null;
         nested.OnDispose = () =>
         {
             Task competing = Task.Run(() =>
@@ -1558,9 +1937,9 @@ public sealed class EditorTabItemLifetimeTests
                 nestedReplacement = tab.ReplaceContextAsync(nested).AsTask();
         });
 
-        Assert.That(await tab.ReplaceContextAsync(replacement).AsTask()
-            .WaitAsync(TimeSpan.FromSeconds(5)), Is.True);
-        Assert.That(await nestedReplacement!.WaitAsync(TimeSpan.FromSeconds(5)), Is.False);
+        Assert.That((await tab.ReplaceContextAsync(replacement).AsTask()
+            .WaitAsync(TimeSpan.FromSeconds(5))).Succeeded, Is.True);
+        Assert.That((await nestedReplacement!.WaitAsync(TimeSpan.FromSeconds(5))).Succeeded, Is.False);
         Assert.Multiple(() =>
         {
             Assert.That(nested.DisposeCount, Is.EqualTo(1));
@@ -1584,12 +1963,12 @@ public sealed class EditorTabItemLifetimeTests
             return ValueTask.CompletedTask;
         };
 
-        Task<bool> replace = tab.ReplaceContextAsync(replacement).AsTask();
+        Task<EditorContextReplacementResult> replace = tab.ReplaceContextAsync(replacement).AsTask();
         await oldContext.DisposeStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
         Task close = service.CloseTabItem(tab).AsTask();
         oldContext.ReleaseDispose();
 
-        Assert.That(await replace.WaitAsync(TimeSpan.FromSeconds(5)), Is.False);
+        Assert.That((await replace!.WaitAsync(TimeSpan.FromSeconds(5))).Succeeded, Is.False);
         await close.WaitAsync(TimeSpan.FromSeconds(5));
         Assert.That(nestedClose.Status, Is.EqualTo(EditorContextCloseRequestStatus.AlreadyClosing));
         Assert.Multiple(() =>
@@ -1608,7 +1987,7 @@ public sealed class EditorTabItemLifetimeTests
         var nested = new BlockingEditorContext(blockDispose: false, closeService: service);
         var tab = new EditorTabItem(oldContext);
         service.AddTabItem(tab);
-        Task<bool>? nestedReplacement = null;
+        Task<EditorContextReplacementResult>? nestedReplacement = null;
         EditorContextCloseRequest closeRequest = default;
         nested.OnDispose = () =>
         {
@@ -1621,16 +2000,16 @@ public sealed class EditorTabItemLifetimeTests
             await nestedReplacement;
         };
 
-        bool replaced = await tab.ReplaceContextAsync(replacement)
+        EditorContextReplacementResult replaced = await tab.ReplaceContextAsync(replacement)
             .AsTask()
             .WaitAsync(TimeSpan.FromSeconds(5));
         await closeRequest.Completion.WaitAsync(TimeSpan.FromSeconds(5));
 
         Assert.Multiple(() =>
         {
-            Assert.That(replaced, Is.False);
+            Assert.That(replaced.Succeeded, Is.False);
             Assert.That(nestedReplacement, Is.Not.Null);
-            Assert.That(nestedReplacement!.Result, Is.False);
+            Assert.That(nestedReplacement!.Result.Succeeded, Is.False);
             Assert.That(oldContext.DisposeCount, Is.EqualTo(1));
             Assert.That(replacement.DisposeCount, Is.EqualTo(1));
             Assert.That(nested.DisposeCount, Is.EqualTo(1));
@@ -1640,9 +2019,11 @@ public sealed class EditorTabItemLifetimeTests
     [Test]
     public async Task ThrowingContextSubscriberCannotStrandReplacement()
     {
-        var oldContext = new BlockingEditorContext(blockDispose: false);
-        var replacement = new BlockingEditorContext(blockDispose: false);
+        var service = new EditorService(new ExtensionProvider());
+        var oldContext = new BlockingEditorContext(blockDispose: false, closeService: service);
+        var replacement = new BlockingEditorContext(blockDispose: false, closeService: service);
         var tab = new EditorTabItem(oldContext);
+        service.AddTabItem(tab);
         using IDisposable subscription = tab.Context.Subscribe(value =>
         {
             if (value is null)
@@ -1662,9 +2043,11 @@ public sealed class EditorTabItemLifetimeTests
     [Test]
     public async Task ThrowingReplacementSubscriberDisposesPublishedReplacement()
     {
-        var oldContext = new BlockingEditorContext(blockDispose: false);
-        var replacement = new BlockingEditorContext(blockDispose: false);
+        var service = new EditorService(new ExtensionProvider());
+        var oldContext = new BlockingEditorContext(blockDispose: false, closeService: service);
+        var replacement = new BlockingEditorContext(blockDispose: false, closeService: service);
         var tab = new EditorTabItem(oldContext);
+        service.AddTabItem(tab);
         using IDisposable subscription = tab.Context.Subscribe(value =>
         {
             if (ReferenceEquals(value, replacement))
@@ -1936,6 +2319,157 @@ public sealed class EditorTabItemLifetimeTests
         {
             context = null;
             return false;
+        }
+    }
+
+    private sealed class HostMediatedReplacementExtension(bool throwOnHostToken = false) : EditorExtension
+    {
+        public BlockingEditorContext? CreatedContext { get; private set; }
+
+        public int CreationCount { get; private set; }
+
+        public override FilePickerFileType GetFilePickerFileType() => new("Replacement");
+
+        public override IconSource? GetIcon() => null;
+
+        public override bool TryCreateEditor(
+            CoreObject obj,
+            [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Control? editor)
+        {
+            editor = null;
+            return false;
+        }
+
+        public override bool MatchFileExtension(string ext) => false;
+
+        public override bool TryCreateContext(
+            CoreObject obj,
+            IEditorContextServices services,
+            [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out IEditorContext? context)
+        {
+            CreationCount++;
+            IEditorContextCloseService closeService = throwOnHostToken
+                ? new ThrowingHostTokenCloseService()
+                : services.CloseService;
+            CreatedContext = new BlockingEditorContext(blockDispose: false, obj, closeService);
+            context = CreatedContext;
+            return true;
+        }
+    }
+
+    private sealed class ExistingContextEditorExtension(IEditorContext existingContext) : EditorExtension
+    {
+        public override FilePickerFileType GetFilePickerFileType() => new("Existing");
+
+        public override IconSource? GetIcon() => null;
+
+        public override bool TryCreateEditor(
+            CoreObject obj,
+            [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Control? editor)
+        {
+            editor = null;
+            return false;
+        }
+
+        public override bool MatchFileExtension(string ext) => false;
+
+        public override bool TryCreateContext(
+            CoreObject obj,
+            IEditorContextServices services,
+            [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out IEditorContext? context)
+        {
+            context = existingContext;
+            return true;
+        }
+    }
+
+    private sealed class ForwardingCloseService(IEditorContextCloseService inner)
+        : IEditorContextCloseService
+    {
+        public EditorContextHostToken HostToken => inner.HostToken;
+
+        public EditorContextCloseRequest RequestClose(IEditorContext context)
+            => inner.RequestClose(context);
+    }
+
+    private sealed class RegisteringContextEditorExtension(EditorService service) : EditorExtension
+    {
+        public BlockingEditorContext? CreatedContext { get; private set; }
+
+        public EditorTabItem? CreatedTab { get; private set; }
+
+        public override FilePickerFileType GetFilePickerFileType() => new("Registering");
+
+        public override IconSource? GetIcon() => null;
+
+        public override bool TryCreateEditor(
+            CoreObject obj,
+            [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Control? editor)
+        {
+            editor = null;
+            return false;
+        }
+
+        public override bool MatchFileExtension(string ext) => false;
+
+        public override bool TryCreateContext(
+            CoreObject obj,
+            IEditorContextServices services,
+            [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out IEditorContext? context)
+        {
+            CreatedContext = new BlockingEditorContext(
+                blockDispose: false,
+                obj,
+                new ForwardingCloseService(service));
+            CreatedTab = new EditorTabItem(CreatedContext);
+            service.AddTabItem(CreatedTab);
+            context = CreatedContext;
+            return true;
+        }
+    }
+
+    private sealed class ThrowingHostTokenCloseService : IEditorContextCloseService
+    {
+        public EditorContextHostToken HostToken => throw new InvalidOperationException("Host token unavailable");
+
+        public EditorContextCloseRequest RequestClose(IEditorContext context)
+            => new(EditorContextCloseRequestStatus.NotOwned, Task.CompletedTask);
+    }
+
+    private sealed class BlockingReplacementExtension : EditorExtension
+    {
+        public TaskCompletionSource Entered { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource Release { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public BlockingEditorContext? CreatedContext { get; private set; }
+
+        public override FilePickerFileType GetFilePickerFileType() => new("Blocking");
+
+        public override IconSource? GetIcon() => null;
+
+        public override bool TryCreateEditor(
+            CoreObject obj,
+            [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Control? editor)
+        {
+            editor = null;
+            return false;
+        }
+
+        public override bool MatchFileExtension(string ext) => false;
+
+        public override bool TryCreateContext(
+            CoreObject obj,
+            IEditorContextServices services,
+            [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out IEditorContext? context)
+        {
+            Entered.TrySetResult();
+            Release.Task.GetAwaiter().GetResult();
+            CreatedContext = new BlockingEditorContext(blockDispose: false, obj, services.CloseService);
+            context = CreatedContext;
+            return true;
         }
     }
 

--- a/tests/Beutl.HeadlessUITests/EditorTabItemLifetimeTests.cs
+++ b/tests/Beutl.HeadlessUITests/EditorTabItemLifetimeTests.cs
@@ -492,6 +492,34 @@ public sealed class EditorTabItemLifetimeTests
     }
 
     [Test]
+    public async Task ActivationFactoryCannotSynchronouslyReconcileItsOwnAdmission()
+    {
+        var provider = new ExtensionProvider();
+        var service = new EditorService(provider);
+        var extension = new ReentrantReconcileReplacementExtension(
+            service,
+            useWorker: false,
+            matchFileExtension: true);
+        provider.AddExtensions(4, [extension]);
+        var scene = new Scene(16, 16, string.Empty)
+        {
+            Uri = new Uri(Path.Combine(Path.GetTempPath(), "activation-reentrant.operation"))
+        };
+
+        Task activation = Task.Run(() => service.ActivateTabItem(scene));
+        InvalidOperationException? failure = Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await activation.WaitAsync(TimeSpan.FromSeconds(5)));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(failure!.Message, Does.Contain("reconciliation"));
+            Assert.That(extension.CreationCount, Is.EqualTo(1));
+            Assert.That(service.TabItems, Is.Empty);
+        });
+        await service.ClearTabItemsAsync();
+    }
+
+    [Test]
     public async Task ActivationDoesNotDisposeAlreadyOwnedSameHostContext()
     {
         var provider = new ExtensionProvider();
@@ -676,6 +704,126 @@ public sealed class EditorTabItemLifetimeTests
             Assert.That(service.TabItems, Does.Contain(tab));
         });
         await service.CloseTabItem(tab).AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [TestCase(false)]
+    [TestCase(true)]
+    public async Task ReplacementFactoryCannotSynchronouslyReconcileItsOwnAdmission(bool useWorker)
+    {
+        var service = new EditorService(new ExtensionProvider());
+        var current = new BlockingEditorContext(blockDispose: false, closeService: service);
+        var tab = new EditorTabItem(current);
+        service.AddTabItem(tab);
+        var extension = new ReentrantReconcileReplacementExtension(service, useWorker);
+
+        InvalidOperationException? failure = Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await service.ReplaceContextAsync(tab, extension).AsTask()
+                .WaitAsync(TimeSpan.FromSeconds(5)));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(failure!.Message, Does.Contain("reconciliation"));
+            Assert.That(extension.CreationCount, Is.EqualTo(1));
+            Assert.That(tab.Context.Value, Is.SameAs(current));
+            Assert.That(current.DisposeCount, Is.Zero);
+        });
+        await service.CloseTabItem(tab).AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task ReplacementFactoryChildCanReconcileAfterAdmissionCompletes()
+    {
+        var service = new EditorService(new ExtensionProvider());
+        var current = new BlockingEditorContext(blockDispose: false, closeService: service);
+        var tab = new EditorTabItem(current);
+        service.AddTabItem(tab);
+        var extension = new DeferredReconcileReplacementExtension(service);
+
+        EditorContextReplacementStatus status = await service.ReplaceContextAsync(tab, extension);
+        Assert.That(status, Is.EqualTo(EditorContextReplacementStatus.CreationFailed));
+
+        extension.Release.TrySetResult();
+        await extension.Reconciliation.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Multiple(() =>
+        {
+            Assert.That(service.TabItems, Is.Empty);
+            Assert.That(current.DisposeCount, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public async Task CompletedAdmissionOperationDoesNotRetainEditorServiceInDelayedChild()
+    {
+        (WeakReference service, Task child, TaskCompletionSource release) =
+            await CreateDelayedAdmissionChildAsync();
+
+        for (int i = 0; service.IsAlive && i < 10; i++)
+        {
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+        }
+
+        Assert.That(service.IsAlive, Is.False);
+        release.TrySetResult();
+        await child.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [System.Runtime.CompilerServices.MethodImpl(
+        System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+    private static async Task<(WeakReference Service, Task Child, TaskCompletionSource Release)>
+        CreateDelayedAdmissionChildAsync()
+    {
+        var service = new EditorService(new ExtensionProvider());
+        var context = new BlockingEditorContext(blockDispose: false, closeService: service);
+        var tab = new EditorTabItem(context);
+        service.AddTabItem(tab);
+        var extension = new CapturingAdmissionChildExtension();
+
+        Assert.That(
+            await service.ReplaceContextAsync(tab, extension),
+            Is.EqualTo(EditorContextReplacementStatus.CreationFailed));
+        await service.CloseTabItem(tab).AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+
+        var serviceReference = new WeakReference(service);
+        Task child = extension.Child;
+        TaskCompletionSource release = extension.Release;
+        service = null!;
+        context = null!;
+        tab = null!;
+        extension = null!;
+        return (serviceReference, child, release);
+    }
+
+    [Test]
+    public async Task NestedHostReplacementCannotHideOuterAdmissionFromReconciliation()
+    {
+        var outerService = new EditorService(new ExtensionProvider());
+        var innerService = new EditorService(new ExtensionProvider());
+        var outerContext = new BlockingEditorContext(blockDispose: false, closeService: outerService);
+        var innerContext = new BlockingEditorContext(blockDispose: false, closeService: innerService);
+        var outerTab = new EditorTabItem(outerContext);
+        var innerTab = new EditorTabItem(innerContext);
+        outerService.AddTabItem(outerTab);
+        innerService.AddTabItem(innerTab);
+        var reconcileOuter = new ReentrantReconcileReplacementExtension(
+            outerService,
+            useWorker: false);
+        var nested = new NestedReplacementExtension(innerService, innerTab, reconcileOuter);
+
+        Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await outerService.ReplaceContextAsync(outerTab, nested).AsTask()
+                .WaitAsync(TimeSpan.FromSeconds(5)));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(outerTab.Context.Value, Is.SameAs(outerContext));
+            Assert.That(innerTab.Context.Value, Is.SameAs(innerContext));
+            Assert.That(outerContext.DisposeCount, Is.Zero);
+            Assert.That(innerContext.DisposeCount, Is.Zero);
+        });
+        await outerService.CloseTabItem(outerTab).AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+        await innerService.CloseTabItem(innerTab).AsTask().WaitAsync(TimeSpan.FromSeconds(5));
     }
 
     [Test]
@@ -2769,6 +2917,149 @@ public sealed class EditorTabItemLifetimeTests
             CreatedContext = new BlockingEditorContext(blockDispose: false, obj, services.CloseService);
             context = CreatedContext;
             return true;
+        }
+    }
+
+    private sealed class ReentrantReconcileReplacementExtension(
+        EditorService service,
+        bool useWorker,
+        bool matchFileExtension = false)
+        : EditorExtension
+    {
+        public int CreationCount { get; private set; }
+
+        public override FilePickerFileType GetFilePickerFileType() => new("ReentrantReconcile");
+
+        public override IconSource? GetIcon() => null;
+
+        public override bool TryCreateEditor(
+            CoreObject obj,
+            [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Control? editor)
+        {
+            editor = null;
+            return false;
+        }
+
+        public override bool MatchFileExtension(string ext) => matchFileExtension;
+
+        public override bool TryCreateContext(
+            CoreObject obj,
+            IEditorContextServices services,
+            [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out IEditorContext? context)
+        {
+            CreationCount++;
+            if (useWorker)
+            {
+                Task.Run(() => service.ClearTabItemsAsync().AsTask())
+                    .GetAwaiter()
+                    .GetResult();
+            }
+            else
+            {
+                service.ClearTabItemsAsync().AsTask().GetAwaiter().GetResult();
+            }
+            context = null;
+            return false;
+        }
+    }
+
+    private sealed class DeferredReconcileReplacementExtension(EditorService service)
+        : EditorExtension
+    {
+        public TaskCompletionSource Release { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task Reconciliation { get; private set; } = Task.CompletedTask;
+
+        public override FilePickerFileType GetFilePickerFileType() => new("DeferredReconcile");
+
+        public override IconSource? GetIcon() => null;
+
+        public override bool TryCreateEditor(
+            CoreObject obj,
+            [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Control? editor)
+        {
+            editor = null;
+            return false;
+        }
+
+        public override bool MatchFileExtension(string ext) => false;
+
+        public override bool TryCreateContext(
+            CoreObject obj,
+            IEditorContextServices services,
+            [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out IEditorContext? context)
+        {
+            Reconciliation = Task.Run(async () =>
+            {
+                await Release.Task;
+                await service.ClearTabItemsAsync();
+            });
+            context = null;
+            return false;
+        }
+    }
+
+    private sealed class CapturingAdmissionChildExtension : EditorExtension
+    {
+        public TaskCompletionSource Release { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task Child { get; private set; } = Task.CompletedTask;
+
+        public override FilePickerFileType GetFilePickerFileType() => new("CapturingChild");
+
+        public override IconSource? GetIcon() => null;
+
+        public override bool TryCreateEditor(
+            CoreObject obj,
+            [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Control? editor)
+        {
+            editor = null;
+            return false;
+        }
+
+        public override bool MatchFileExtension(string ext) => false;
+
+        public override bool TryCreateContext(
+            CoreObject obj,
+            IEditorContextServices services,
+            [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out IEditorContext? context)
+        {
+            TaskCompletionSource release = Release;
+            Child = Task.Run(async () => await release.Task);
+            context = null;
+            return false;
+        }
+    }
+
+    private sealed class NestedReplacementExtension(
+        EditorService service,
+        EditorTabItem tab,
+        EditorExtension nestedExtension) : EditorExtension
+    {
+        public override FilePickerFileType GetFilePickerFileType() => new("NestedReplacement");
+
+        public override IconSource? GetIcon() => null;
+
+        public override bool TryCreateEditor(
+            CoreObject obj,
+            [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Control? editor)
+        {
+            editor = null;
+            return false;
+        }
+
+        public override bool MatchFileExtension(string ext) => false;
+
+        public override bool TryCreateContext(
+            CoreObject obj,
+            IEditorContextServices services,
+            [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out IEditorContext? context)
+        {
+            service.ReplaceContextAsync(tab, nestedExtension).AsTask().GetAwaiter().GetResult();
+            context = null;
+            return false;
         }
     }
 

--- a/tests/Beutl.HeadlessUITests/EditorTabItemLifetimeTests.cs
+++ b/tests/Beutl.HeadlessUITests/EditorTabItemLifetimeTests.cs
@@ -17,7 +17,7 @@ public sealed class EditorTabItemLifetimeTests
     public async Task AddAndSelectIsLinearizedWithConcurrentDispose()
     {
         var service = new EditorService(new ExtensionProvider());
-        var context = new BlockingEditorContext(blockDispose: false);
+        var context = new BlockingEditorContext(blockDispose: false, closeService: service);
         var tab = new EditorTabItem(context);
         var inserted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -63,7 +63,7 @@ public sealed class EditorTabItemLifetimeTests
     public async Task RemovingAnAlreadyAbsentTabClearsStaleSelection()
     {
         var service = new EditorService(new ExtensionProvider());
-        var tab = new EditorTabItem(new BlockingEditorContext(blockDispose: false));
+        var tab = new EditorTabItem(new BlockingEditorContext(blockDispose: false, closeService: service));
         service.AddTabItem(tab);
         service.SelectedTabItem.Value = tab;
         await service.ClearTabItemsAsync();
@@ -78,7 +78,7 @@ public sealed class EditorTabItemLifetimeTests
     public async Task SameTabCannotBeAttachedTwice()
     {
         var service = new EditorService(new ExtensionProvider());
-        var tab = new EditorTabItem(new BlockingEditorContext(blockDispose: false));
+        var tab = new EditorTabItem(new BlockingEditorContext(blockDispose: false, closeService: service));
 
         Assert.Multiple(() =>
         {
@@ -94,13 +94,13 @@ public sealed class EditorTabItemLifetimeTests
     public async Task CloseRequestReportsOwnershipAndSharesTerminalCompletion()
     {
         var service = new EditorService(new ExtensionProvider());
-        var context = new BlockingEditorContext();
+        var context = new BlockingEditorContext(closeService: service);
         var tab = new EditorTabItem(context);
         service.AddTabItem(tab);
 
         EditorContextCloseRequest accepted = service.RequestClose(context);
         EditorContextCloseRequest repeated = service.RequestClose(context);
-        var unknown = new BlockingEditorContext(blockDispose: false);
+        var unknown = new BlockingEditorContext(blockDispose: false, closeService: service);
         EditorContextCloseRequest notOwned = service.RequestClose(unknown);
 
         Assert.Multiple(() =>
@@ -122,7 +122,7 @@ public sealed class EditorTabItemLifetimeTests
     public void CloseRequestCompletionPropagatesTerminalFailure()
     {
         var service = new EditorService(new ExtensionProvider());
-        var context = new ThrowingEditorContext();
+        var context = new ThrowingEditorContext(service);
         var tab = new EditorTabItem(context);
         service.AddTabItem(tab);
 
@@ -138,7 +138,7 @@ public sealed class EditorTabItemLifetimeTests
     public async Task DisposingHostOwnedTabUsesAuthoritativeHostClose()
     {
         var service = new EditorService(new ExtensionProvider());
-        var context = new BlockingEditorContext(blockDispose: false);
+        var context = new BlockingEditorContext(blockDispose: false, closeService: service);
         var tab = new EditorTabItem(context);
         service.AddTabItem(tab);
         service.SelectedTabItem.Value = tab;
@@ -158,7 +158,7 @@ public sealed class EditorTabItemLifetimeTests
     public async Task ContextIdentityCannotBeOwnedByTwoTabs()
     {
         var service = new EditorService(new ExtensionProvider());
-        var context = new BlockingEditorContext(blockDispose: false);
+        var context = new BlockingEditorContext(blockDispose: false, closeService: service);
         var first = new EditorTabItem(context);
         var second = new EditorTabItem(context);
 
@@ -178,7 +178,7 @@ public sealed class EditorTabItemLifetimeTests
     public async Task InitialClaimIsNotVisibleBeforeItemAcceptsOwnership()
     {
         var service = new EditorService(new ExtensionProvider());
-        var context = new BlockingEditorContext(blockDispose: false);
+        var context = new BlockingEditorContext(blockDispose: false, closeService: service);
         var tab = new EditorTabItem(context);
         var claimAttached = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var publishClaim = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -206,11 +206,8 @@ public sealed class EditorTabItemLifetimeTests
     {
         var firstService = new EditorService(new ExtensionProvider());
         var secondService = new EditorService(new ExtensionProvider());
-        var context = new BlockingEditorContext(blockDispose: false);
+        var context = new BlockingEditorContext(blockDispose: false, closeService: firstService);
         var tab = new EditorTabItem(context);
-        using var beforeAttach = new Barrier(2);
-        firstService.BeforeInitialOwnerAttach = WaitForBothServices;
-        secondService.BeforeInitialOwnerAttach = WaitForBothServices;
 
         Task<bool> first = Task.Run(() => firstService.TryAddTabItem(tab));
         Task<bool> second = Task.Run(() => secondService.TryAddTabItem(tab));
@@ -226,19 +223,200 @@ public sealed class EditorTabItemLifetimeTests
             Assert.That(loser.RequestClose(context).Status, Is.EqualTo(EditorContextCloseRequestStatus.NotOwned));
         });
         await owner.CloseTabItem(tab).AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+    }
 
-        void WaitForBothServices()
+    [Test]
+    public async Task ForeignHostContextIsRejectedByInitialAttachment()
+    {
+        var owner = new EditorService(new ExtensionProvider());
+        var foreign = new EditorService(new ExtensionProvider());
+        var context = new BlockingEditorContext(blockDispose: false, closeService: foreign);
+        var tab = new EditorTabItem(context);
+
+        Assert.That(owner.TryAddTabItem(tab), Is.False);
+        Assert.Multiple(() =>
         {
-            if (!beforeAttach.SignalAndWait(TimeSpan.FromSeconds(5)))
-                throw new TimeoutException("Both services did not reach owner attachment.");
-        }
+            Assert.That(owner.TabItems, Is.Empty);
+            Assert.That(tab.IsHostOwned, Is.False);
+            Assert.That(context.DisposeCount, Is.Zero);
+        });
+
+        await tab.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task ContextAlreadyOwnedByForeignHostIsRejectedWithoutDisturbingOwner()
+    {
+        var owner = new EditorService(new ExtensionProvider());
+        var foreign = new EditorService(new ExtensionProvider());
+        var context = new BlockingEditorContext(blockDispose: false, closeService: foreign);
+        var tab = new EditorTabItem(context);
+        foreign.AddTabItem(tab);
+
+        Assert.That(owner.TryAddTabItem(tab), Is.False);
+        Assert.Multiple(() =>
+        {
+            Assert.That(foreign.TabItems, Does.Contain(tab));
+            Assert.That(owner.TabItems, Is.Empty);
+            Assert.That(context.DisposeCount, Is.Zero);
+            Assert.That(owner.RequestClose(context).Status, Is.EqualTo(EditorContextCloseRequestStatus.NotOwned));
+        });
+
+        await foreign.CloseTabItem(tab).AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task AddTabItemRejectsForeignOwnedTabWithoutDisposingIt()
+    {
+        var owner = new EditorService(new ExtensionProvider());
+        var foreign = new EditorService(new ExtensionProvider());
+        var context = new BlockingEditorContext(blockDispose: false, closeService: foreign);
+        var tab = new EditorTabItem(context);
+        foreign.AddTabItem(tab);
+        int addNotifications = 0;
+        ((INotifyCollectionChanged)owner.TabItems).CollectionChanged += (_, args) =>
+        {
+            if (args.Action == NotifyCollectionChangedAction.Add)
+                addNotifications++;
+        };
+
+        owner.AddTabItem(tab);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(foreign.TabItems, Does.Contain(tab));
+            Assert.That(owner.TabItems, Is.Empty);
+            Assert.That(addNotifications, Is.Zero);
+            Assert.That(context.DisposeCount, Is.Zero);
+            Assert.That(owner.RequestClose(context).Status, Is.EqualTo(EditorContextCloseRequestStatus.NotOwned));
+        });
+
+        await foreign.CloseTabItem(tab).AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task ForeignHostContextIsRejectedByReplacementWithoutConsumption()
+    {
+        var owner = new EditorService(new ExtensionProvider());
+        var foreign = new EditorService(new ExtensionProvider());
+        var current = new BlockingEditorContext(blockDispose: false, closeService: owner);
+        var replacement = new BlockingEditorContext(blockDispose: false, closeService: foreign);
+        var tab = new EditorTabItem(current);
+        owner.AddTabItem(tab);
+
+        bool replaced = await tab.ReplaceContextAsync(replacement)
+            .AsTask()
+            .WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(replaced, Is.False);
+            Assert.That(tab.Context.Value, Is.SameAs(current));
+            Assert.That(current.DisposeCount, Is.Zero);
+            Assert.That(replacement.DisposeCount, Is.Zero);
+        });
+
+        await owner.CloseTabItem(tab).AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task ReplacementWithContextOwnedByForeignHostIsRejectedWithoutDisturbingEitherTab()
+    {
+        var firstHost = new EditorService(new ExtensionProvider());
+        var secondHost = new EditorService(new ExtensionProvider());
+        var foreignContext = new BlockingEditorContext(blockDispose: false, closeService: firstHost);
+        var foreignTab = new EditorTabItem(foreignContext);
+        firstHost.AddTabItem(foreignTab);
+
+        var currentContext = new BlockingEditorContext(blockDispose: false, closeService: secondHost);
+        var targetTab = new EditorTabItem(currentContext);
+        secondHost.AddTabItem(targetTab);
+
+        bool replaced = await targetTab.ReplaceContextAsync(foreignContext)
+            .AsTask()
+            .WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(replaced, Is.False);
+            Assert.That(foreignTab.Context.Value, Is.SameAs(foreignContext));
+            Assert.That(targetTab.Context.Value, Is.SameAs(currentContext));
+            Assert.That(foreignContext.DisposeCount, Is.Zero);
+            Assert.That(currentContext.DisposeCount, Is.Zero);
+            Assert.That(secondHost.RequestClose(foreignContext).Status, Is.EqualTo(EditorContextCloseRequestStatus.NotOwned));
+        });
+
+        EditorContextCloseRequest foreignClose = foreignContext.CloseService.RequestClose(foreignContext);
+        Assert.That(foreignClose.Status, Is.EqualTo(EditorContextCloseRequestStatus.Accepted));
+        await foreignClose.Completion.WaitAsync(TimeSpan.FromSeconds(5));
+        await secondHost.CloseTabItem(targetTab).AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task ForeignHostCannotDisposeTabWhileItsContextIsTemporarilyNull()
+    {
+        var owner = new EditorService(new ExtensionProvider());
+        var foreign = new EditorService(new ExtensionProvider());
+        var oldContext = new BlockingEditorContext(closeService: owner);
+        var replacement = new BlockingEditorContext(blockDispose: false, closeService: owner);
+        var tab = new EditorTabItem(oldContext);
+        owner.AddTabItem(tab);
+        int foreignAddNotifications = 0;
+        ((INotifyCollectionChanged)foreign.TabItems).CollectionChanged += (_, args) =>
+        {
+            if (args.Action == NotifyCollectionChangedAction.Add)
+                foreignAddNotifications++;
+        };
+
+        Task<bool> replacing = tab.ReplaceContextAsync(replacement).AsTask();
+        await oldContext.DisposeStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.That(tab.Context.Value, Is.Null);
+
+        foreign.AddTabItem(tab);
+        oldContext.ReleaseDispose();
+
+        Assert.That(await replacing.WaitAsync(TimeSpan.FromSeconds(5)), Is.True);
+        Assert.Multiple(() =>
+        {
+            Assert.That(owner.TabItems, Does.Contain(tab));
+            Assert.That(foreign.TabItems, Is.Empty);
+            Assert.That(foreignAddNotifications, Is.Zero);
+            Assert.That(tab.Context.Value, Is.SameAs(replacement));
+            Assert.That(replacement.DisposeCount, Is.Zero);
+        });
+
+        await owner.CloseTabItem(tab).AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task SameHostContextCanBeReplacedSuccessfully()
+    {
+        var owner = new EditorService(new ExtensionProvider());
+        var current = new BlockingEditorContext(blockDispose: false, closeService: owner);
+        var replacement = new BlockingEditorContext(blockDispose: false, closeService: owner);
+        var tab = new EditorTabItem(current);
+        owner.AddTabItem(tab);
+
+        bool replaced = await tab.ReplaceContextAsync(replacement)
+            .AsTask()
+            .WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(replaced, Is.True);
+            Assert.That(tab.Context.Value, Is.SameAs(replacement));
+            Assert.That(current.DisposeCount, Is.EqualTo(1));
+            Assert.That(replacement.DisposeCount, Is.Zero);
+        });
+
+        await owner.CloseTabItem(tab).AsTask().WaitAsync(TimeSpan.FromSeconds(5));
     }
 
     [Test]
     public async Task ConcurrentRemovalHasOnePhysicalExecutor()
     {
         var service = new EditorService(new ExtensionProvider());
-        var tab = new EditorTabItem(new BlockingEditorContext(blockDispose: false));
+        var tab = new EditorTabItem(new BlockingEditorContext(blockDispose: false, closeService: service));
         service.AddTabItem(tab);
         int removeNotifications = 0;
         ((INotifyCollectionChanged)service.TabItems).CollectionChanged += (_, args) =>
@@ -274,7 +452,7 @@ public sealed class EditorTabItemLifetimeTests
     public async Task AddObserverCanWaitForCloseWithoutDeadlock()
     {
         var service = new EditorService(new ExtensionProvider());
-        var tab = new EditorTabItem(new BlockingEditorContext(blockDispose: false));
+        var tab = new EditorTabItem(new BlockingEditorContext(blockDispose: false, closeService: service));
         EditorContextCloseRequest closeRequest = default;
         ((INotifyCollectionChanged)service.TabItems).CollectionChanged += (_, args) =>
         {
@@ -299,7 +477,7 @@ public sealed class EditorTabItemLifetimeTests
     public async Task RemovalObserverCanWaitForRejectedAddToReturn()
     {
         var service = new EditorService(new ExtensionProvider());
-        var tab = new EditorTabItem(new BlockingEditorContext(blockDispose: false));
+        var tab = new EditorTabItem(new BlockingEditorContext(blockDispose: false, closeService: service));
         var addReturned = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         bool removalObservedAddReturn = false;
         ((INotifyCollectionChanged)service.TabItems).CollectionChanged += (_, args) =>
@@ -335,7 +513,7 @@ public sealed class EditorTabItemLifetimeTests
     public async Task RemovalBeforePhysicalAddCannotLeaveAClosedTabPublished()
     {
         var service = new EditorService(new ExtensionProvider());
-        var context = new BlockingEditorContext(blockDispose: false);
+        var context = new BlockingEditorContext(blockDispose: false, closeService: service);
         var tab = new EditorTabItem(context);
         var beforeAdd = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var releaseAdd = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -371,7 +549,7 @@ public sealed class EditorTabItemLifetimeTests
     public async Task AttachmentCommitBeforePhysicalAddCannotPublishAfterRemovalReservation()
     {
         var service = new EditorService(new ExtensionProvider());
-        var context = new BlockingEditorContext(blockDispose: false);
+        var context = new BlockingEditorContext(blockDispose: false, closeService: service);
         var tab = new EditorTabItem(context);
         var attachmentCommitted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var releasePhysicalAdd = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -408,7 +586,7 @@ public sealed class EditorTabItemLifetimeTests
     public async Task RemoveObserverCanRequestCloseWithoutDeadlock()
     {
         var service = new EditorService(new ExtensionProvider());
-        var context = new BlockingEditorContext(blockDispose: false);
+        var context = new BlockingEditorContext(blockDispose: false, closeService: service);
         var tab = new EditorTabItem(context);
         service.AddTabItem(tab);
         EditorContextCloseRequest nestedClose = default;
@@ -435,7 +613,7 @@ public sealed class EditorTabItemLifetimeTests
     public async Task RemoveObserverCanWaitForCrossThreadCloseAdmission()
     {
         var service = new EditorService(new ExtensionProvider());
-        var context = new BlockingEditorContext(blockDispose: false);
+        var context = new BlockingEditorContext(blockDispose: false, closeService: service);
         var tab = new EditorTabItem(context);
         service.AddTabItem(tab);
         EditorContextCloseRequest nested = default;
@@ -462,7 +640,7 @@ public sealed class EditorTabItemLifetimeTests
     public async Task IsSelectedObserverClosingTabCannotLeaveStaleSelection()
     {
         var service = new EditorService(new ExtensionProvider());
-        var context = new BlockingEditorContext(blockDispose: false);
+        var context = new BlockingEditorContext(blockDispose: false, closeService: service);
         var tab = new EditorTabItem(context);
         EditorContextCloseRequest closeRequest = default;
         using IDisposable selectionObserver = tab.IsSelected.Subscribe(isSelected =>
@@ -485,7 +663,7 @@ public sealed class EditorTabItemLifetimeTests
     public async Task ThrowingSelectionObserverCannotLeakNewTabContext()
     {
         var service = new EditorService(new ExtensionProvider());
-        var context = new BlockingEditorContext(blockDispose: false);
+        var context = new BlockingEditorContext(blockDispose: false, closeService: service);
         var tab = new EditorTabItem(context);
         using IDisposable observer = tab.IsSelected.Subscribe(value =>
         {
@@ -512,7 +690,7 @@ public sealed class EditorTabItemLifetimeTests
         {
             Uri = new Uri(Path.Combine(Path.GetTempPath(), "existing-selection-close.scene"))
         };
-        var context = new BlockingEditorContext(blockDispose: false, scene);
+        var context = new BlockingEditorContext(blockDispose: false, scene, closeService: service);
         var tab = new EditorTabItem(context);
         service.AddTabItem(tab);
         EditorContextCloseRequest close = default;
@@ -541,7 +719,7 @@ public sealed class EditorTabItemLifetimeTests
         {
             Uri = new Uri(Path.Combine(Path.GetTempPath(), "existing-selection-fire-and-forget.scene"))
         };
-        var context = new BlockingEditorContext(blockDispose: false, scene);
+        var context = new BlockingEditorContext(blockDispose: false, scene, closeService: service);
         var tab = new EditorTabItem(context);
         service.AddTabItem(tab);
         EditorContextCloseRequest close = default;
@@ -569,7 +747,7 @@ public sealed class EditorTabItemLifetimeTests
         {
             Uri = new Uri(Path.Combine(Path.GetTempPath(), "delayed-selection-close.scene"))
         };
-        var context = new BlockingEditorContext(obj: scene);
+        var context = new BlockingEditorContext(obj: scene, closeService: service);
         var tab = new EditorTabItem(context);
         service.AddTabItem(tab);
         var releaseChild = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -605,8 +783,8 @@ public sealed class EditorTabItemLifetimeTests
         {
             Uri = new Uri(Path.Combine(Path.GetTempPath(), "selection-replacement.scene"))
         };
-        var original = new BlockingEditorContext(blockDispose: false, scene);
-        var replacement = new BlockingEditorContext(blockDispose: false);
+        var original = new BlockingEditorContext(blockDispose: false, scene, closeService: service);
+        var replacement = new BlockingEditorContext(blockDispose: false, closeService: service);
         var tab = new EditorTabItem(original);
         service.AddTabItem(tab);
         bool? replaced = null;
@@ -644,7 +822,7 @@ public sealed class EditorTabItemLifetimeTests
             {
                 Uri = new Uri(Path.Combine(Path.GetTempPath(), $"publication-gate-{iteration}.scene"))
             };
-            var context = new GatedEditorContext(scene);
+            var context = new GatedEditorContext(scene, service);
             var tab = new EditorTabItem(context);
             service.AddTabItem(tab);
             service.SelectedTabItem.Value = tab;
@@ -681,9 +859,9 @@ public sealed class EditorTabItemLifetimeTests
     public async Task ReplacementAndRemovalDoNotInvertContextPublicationGate()
     {
         var service = new EditorService(new ExtensionProvider());
-        var tab = new EditorTabItem(new BlockingEditorContext(blockDispose: false));
+        var tab = new EditorTabItem(new BlockingEditorContext(blockDispose: false, closeService: service));
         service.AddTabItem(tab);
-        var replacement = new GatedEditorContext(new Scene(16, 16, string.Empty));
+        var replacement = new GatedEditorContext(new Scene(16, 16, string.Empty), service);
         using IDisposable contextSubscription = tab.Context.Subscribe(value =>
         {
             if (ReferenceEquals(value, replacement))
@@ -762,7 +940,7 @@ public sealed class EditorTabItemLifetimeTests
     public async Task SameInstanceReplacementIsRejectedWithoutConsumption()
     {
         var service = new EditorService(new ExtensionProvider());
-        var context = new BlockingEditorContext(blockDispose: false);
+        var context = new BlockingEditorContext(blockDispose: false, closeService: service);
         var tab = new EditorTabItem(context);
         service.AddTabItem(tab);
 
@@ -803,8 +981,8 @@ public sealed class EditorTabItemLifetimeTests
     public async Task CrossTabReplacementIsRejectedWithoutConsumption()
     {
         var service = new EditorService(new ExtensionProvider());
-        var firstContext = new BlockingEditorContext(blockDispose: false);
-        var secondContext = new BlockingEditorContext(blockDispose: false);
+        var firstContext = new BlockingEditorContext(blockDispose: false, closeService: service);
+        var secondContext = new BlockingEditorContext(blockDispose: false, closeService: service);
         var first = new EditorTabItem(firstContext);
         var second = new EditorTabItem(secondContext);
         service.AddTabItem(first);
@@ -830,8 +1008,8 @@ public sealed class EditorTabItemLifetimeTests
     public async Task ClosingTabCannotConsumeAnotherTabsContext()
     {
         var service = new EditorService(new ExtensionProvider());
-        var closingContext = new BlockingEditorContext();
-        var otherContext = new BlockingEditorContext(blockDispose: false);
+        var closingContext = new BlockingEditorContext(closeService: service);
+        var otherContext = new BlockingEditorContext(blockDispose: false, closeService: service);
         var closing = new EditorTabItem(closingContext);
         var other = new EditorTabItem(otherContext);
         service.AddTabItem(closing);
@@ -854,8 +1032,8 @@ public sealed class EditorTabItemLifetimeTests
     public async Task RejectedReplacementReservationRemainsInvisibleUntilDisposalCompletes()
     {
         var service = new EditorService(new ExtensionProvider());
-        var closingContext = new BlockingEditorContext();
-        var rejectedContext = new BlockingEditorContext();
+        var closingContext = new BlockingEditorContext(closeService: service);
+        var rejectedContext = new BlockingEditorContext(closeService: service);
         var closing = new EditorTabItem(closingContext);
         service.AddTabItem(closing);
 
@@ -881,9 +1059,9 @@ public sealed class EditorTabItemLifetimeTests
     public async Task TransitioningTabCannotConsumeAnotherTabsContext()
     {
         var service = new EditorService(new ExtensionProvider());
-        var oldContext = new BlockingEditorContext();
-        var replacement = new BlockingEditorContext(blockDispose: false);
-        var otherContext = new BlockingEditorContext(blockDispose: false);
+        var oldContext = new BlockingEditorContext(closeService: service);
+        var replacement = new BlockingEditorContext(blockDispose: false, closeService: service);
+        var otherContext = new BlockingEditorContext(blockDispose: false, closeService: service);
         var transitioning = new EditorTabItem(oldContext);
         var other = new EditorTabItem(otherContext);
         service.AddTabItem(transitioning);
@@ -907,8 +1085,8 @@ public sealed class EditorTabItemLifetimeTests
     public async Task ReservedReplacementIdentityCanRequestOwningTabClose()
     {
         var service = new EditorService(new ExtensionProvider());
-        var oldContext = new BlockingEditorContext(blockDispose: false);
-        var replacement = new BlockingEditorContext(blockDispose: false);
+        var oldContext = new BlockingEditorContext(blockDispose: false, closeService: service);
+        var replacement = new BlockingEditorContext(blockDispose: false, closeService: service);
         var tab = new EditorTabItem(oldContext);
         service.AddTabItem(tab);
         EditorContextCloseRequest closeRequest = default;
@@ -936,8 +1114,8 @@ public sealed class EditorTabItemLifetimeTests
     public async Task StaleContextCloseGenerationCannotCloseReplacement()
     {
         var service = new EditorService(new ExtensionProvider());
-        var oldContext = new BlockingEditorContext(blockDispose: false);
-        var replacement = new BlockingEditorContext(blockDispose: false);
+        var oldContext = new BlockingEditorContext(blockDispose: false, closeService: service);
+        var replacement = new BlockingEditorContext(blockDispose: false, closeService: service);
         var tab = new EditorTabItem(oldContext);
         service.AddTabItem(tab);
         var lookupCompleted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -972,8 +1150,8 @@ public sealed class EditorTabItemLifetimeTests
     public async Task HostCloseReservationRejectsReplacementBeforeCloseStarts()
     {
         var service = new EditorService(new ExtensionProvider());
-        var oldContext = new BlockingEditorContext(blockDispose: false);
-        var replacement = new BlockingEditorContext(blockDispose: false);
+        var oldContext = new BlockingEditorContext(blockDispose: false, closeService: service);
+        var replacement = new BlockingEditorContext(blockDispose: false, closeService: service);
         var tab = new EditorTabItem(oldContext);
         service.AddTabItem(tab);
         var reservationCompleted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -1010,8 +1188,8 @@ public sealed class EditorTabItemLifetimeTests
     public async Task HostOwnedOutgoingDisposalDoesNotRequestTabClose()
     {
         var service = new EditorService(new ExtensionProvider());
-        var oldContext = new BlockingEditorContext(blockDispose: false);
-        var replacement = new BlockingEditorContext(blockDispose: false);
+        var oldContext = new BlockingEditorContext(blockDispose: false, closeService: service);
+        var replacement = new BlockingEditorContext(blockDispose: false, closeService: service);
         var tab = new EditorTabItem(oldContext);
         service.AddTabItem(tab);
         oldContext.OnDispose = () =>
@@ -1057,10 +1235,10 @@ public sealed class EditorTabItemLifetimeTests
     [Test]
     public async Task ReplacementContextDisposalCanReenterTabCloseWithoutDeadlock()
     {
-        var oldContext = new BlockingEditorContext(blockDispose: false);
-        var newContext = new BlockingEditorContext(blockDispose: false);
-        var tab = new EditorTabItem(oldContext);
         var service = new EditorService(new ExtensionProvider());
+        var oldContext = new BlockingEditorContext(blockDispose: false, closeService: service);
+        var newContext = new BlockingEditorContext(blockDispose: false, closeService: service);
+        var tab = new EditorTabItem(oldContext);
         service.AddTabItem(tab);
         EditorContextCloseRequest closeRequest = default;
         oldContext.OnDispose = () =>
@@ -1100,12 +1278,12 @@ public sealed class EditorTabItemLifetimeTests
     [Test]
     public async Task FailedReplacementTerminallyRemovesTabAndClearsSelection()
     {
-        var oldContext = new ThrowingEditorContext();
-        var tab = new EditorTabItem(oldContext);
         var service = new EditorService(new ExtensionProvider());
+        var oldContext = new ThrowingEditorContext(service);
+        var tab = new EditorTabItem(oldContext);
         service.AddTabItem(tab);
         service.SelectedTabItem.Value = tab;
-        var replacement = new BlockingEditorContext(blockDispose: false);
+        var replacement = new BlockingEditorContext(blockDispose: false, closeService: service);
         var values = new List<IEditorContext?>();
         using IDisposable subscription = tab.Context.Subscribe(values.Add);
 
@@ -1122,7 +1300,8 @@ public sealed class EditorTabItemLifetimeTests
     [Test]
     public async Task ConcurrentCloseJoinsThrowingReplacementWithoutDeadlock()
     {
-        var oldContext = new BlockingEditorContext();
+        var service = new EditorService(new ExtensionProvider());
+        var oldContext = new BlockingEditorContext(closeService: service);
         var fail = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         oldContext.OnDispose = async () =>
         {
@@ -1130,11 +1309,10 @@ public sealed class EditorTabItemLifetimeTests
             throw new InvalidOperationException("dispose failed");
         };
         var tab = new EditorTabItem(oldContext);
-        var service = new EditorService(new ExtensionProvider());
         service.AddTabItem(tab);
         service.SelectedTabItem.Value = tab;
 
-        Task replacement = tab.ReplaceContextAsync(new BlockingEditorContext(blockDispose: false)).AsTask();
+        Task replacement = tab.ReplaceContextAsync(new BlockingEditorContext(blockDispose: false, closeService: service)).AsTask();
         await oldContext.DisposeStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
         Task close = tab.DisposeAsync().AsTask();
         fail.TrySetResult();
@@ -1170,10 +1348,10 @@ public sealed class EditorTabItemLifetimeTests
     [Test]
     public async Task ContextSubscriberCanRequestHostCloseWhenReplacementPublishesNull()
     {
-        var oldContext = new BlockingEditorContext(blockDispose: false);
-        var replacement = new BlockingEditorContext(blockDispose: false);
-        var tab = new EditorTabItem(oldContext);
         var service = new EditorService(new ExtensionProvider());
+        var oldContext = new BlockingEditorContext(blockDispose: false, closeService: service);
+        var replacement = new BlockingEditorContext(blockDispose: false, closeService: service);
+        var tab = new EditorTabItem(oldContext);
         service.AddTabItem(tab);
         EditorContextCloseRequest closeRequest = default;
         using IDisposable subscription = tab.Context.Subscribe(value =>
@@ -1315,10 +1493,10 @@ public sealed class EditorTabItemLifetimeTests
     [Test]
     public async Task RejectedReplacementCanReenterCloseWithoutDeadlock()
     {
-        var oldContext = new BlockingEditorContext();
-        var replacement = new BlockingEditorContext(blockDispose: false);
-        var tab = new EditorTabItem(oldContext);
         var service = new EditorService(new ExtensionProvider());
+        var oldContext = new BlockingEditorContext(closeService: service);
+        var replacement = new BlockingEditorContext(blockDispose: false, closeService: service);
+        var tab = new EditorTabItem(oldContext);
         service.AddTabItem(tab);
         EditorContextCloseRequest nestedClose = default;
         replacement.OnDispose = () =>
@@ -1345,11 +1523,11 @@ public sealed class EditorTabItemLifetimeTests
     [Test]
     public async Task ImmediateRejectedReplacementUsesTheOwnedDisposalFence()
     {
-        var oldContext = new BlockingEditorContext(blockDispose: false);
-        var replacement = new BlockingEditorContext(blockDispose: false);
-        var nested = new BlockingEditorContext(blockDispose: false);
-        var tab = new EditorTabItem(oldContext);
         var service = new EditorService(new ExtensionProvider());
+        var oldContext = new BlockingEditorContext(blockDispose: false, closeService: service);
+        var replacement = new BlockingEditorContext(blockDispose: false, closeService: service);
+        var nested = new BlockingEditorContext(blockDispose: false, closeService: service);
+        var tab = new EditorTabItem(oldContext);
         service.AddTabItem(tab);
         Task<bool>? nestedReplacement = null;
         EditorContextCloseRequest closeRequest = default;
@@ -1445,9 +1623,9 @@ public sealed class EditorTabItemLifetimeTests
     [Test]
     public async Task ThrowingRemovalObserversCannotSkipTabCleanup()
     {
-        var context = new BlockingEditorContext(blockDispose: false);
-        var tab = new EditorTabItem(context);
         var service = new EditorService(new ExtensionProvider());
+        var context = new BlockingEditorContext(blockDispose: false, closeService: service);
+        var tab = new EditorTabItem(context);
         service.AddTabItem(tab);
         service.SelectedTabItem.Value = tab;
         ((INotifyCollectionChanged)service.TabItems).CollectionChanged += (_, _) =>
@@ -1472,8 +1650,8 @@ public sealed class EditorTabItemLifetimeTests
     public async Task ClosingOneTabWaitsForSiblingCloseStartedByItsContext()
     {
         var service = new EditorService(new ExtensionProvider());
-        var firstContext = new BlockingEditorContext(blockDispose: false);
-        var secondContext = new BlockingEditorContext(blockDispose: false);
+        var firstContext = new BlockingEditorContext(blockDispose: false, closeService: service);
+        var secondContext = new BlockingEditorContext(blockDispose: false, closeService: service);
         var first = new EditorTabItem(firstContext);
         var second = new EditorTabItem(secondContext);
         service.AddTabItem(first);
@@ -1500,8 +1678,8 @@ public sealed class EditorTabItemLifetimeTests
     public async Task MutualSiblingCloseUsesAncestorIdentityWithoutCycle()
     {
         var service = new EditorService(new ExtensionProvider());
-        var firstContext = new BlockingEditorContext(blockDispose: false);
-        var secondContext = new BlockingEditorContext(blockDispose: false);
+        var firstContext = new BlockingEditorContext(blockDispose: false, closeService: service);
+        var secondContext = new BlockingEditorContext(blockDispose: false, closeService: service);
         var first = new EditorTabItem(firstContext);
         var second = new EditorTabItem(secondContext);
         service.AddTabItem(first);
@@ -1536,10 +1714,14 @@ public sealed class EditorTabItemLifetimeTests
         private readonly bool _blockDispose;
         private readonly TaskCompletionSource _release = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        public BlockingEditorContext(bool blockDispose = true, CoreObject? obj = null)
+        public BlockingEditorContext(
+            bool blockDispose = true,
+            CoreObject? obj = null,
+            IEditorContextCloseService? closeService = null)
         {
             _blockDispose = blockDispose;
             Object = obj ?? new Scene(16, 16, string.Empty);
+            CloseService = closeService ?? new UnownedCloseService();
         }
 
         public TaskCompletionSource DisposeStarted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -1554,7 +1736,7 @@ public sealed class EditorTabItemLifetimeTests
 
         public EditorExtension Extension { get; } = TestEditorExtension.Instance;
 
-        public IEditorContextCloseService CloseService { get; } = new UnownedCloseService();
+        public IEditorContextCloseService CloseService { get; }
 
         public IReactiveProperty<bool> IsEnabled { get; } = new ReactivePropertySlim<bool>(true);
 
@@ -1590,11 +1772,16 @@ public sealed class EditorTabItemLifetimeTests
 
     private sealed class UnownedCloseService : IEditorContextCloseService
     {
+        public EditorContextHostToken HostToken { get; } = new();
+
         public EditorContextCloseRequest RequestClose(IEditorContext context)
             => new(EditorContextCloseRequestStatus.NotOwned, Task.CompletedTask);
     }
 
-    private sealed class GatedEditorContext(Scene scene) : BlockingEditorContext(false, scene), IEditorContextPublicationGate
+    private sealed class GatedEditorContext(
+        Scene scene,
+        IEditorContextCloseService? closeService = null)
+        : BlockingEditorContext(false, scene, closeService), IEditorContextPublicationGate
     {
         private readonly object _gate = new();
         private bool _pauseNext;
@@ -1627,7 +1814,8 @@ public sealed class EditorTabItemLifetimeTests
         public void ExitGate() => Monitor.Exit(_gate);
     }
 
-    private sealed class ThrowingEditorContext : BlockingEditorContext
+    private sealed class ThrowingEditorContext(IEditorContextCloseService? closeService = null)
+        : BlockingEditorContext(closeService: closeService)
     {
         private bool _throw = true;
 

--- a/tests/Beutl.HeadlessUITests/EditorTabItemLifetimeTests.cs
+++ b/tests/Beutl.HeadlessUITests/EditorTabItemLifetimeTests.cs
@@ -66,10 +66,10 @@ public sealed class EditorTabItemLifetimeTests
         var tab = new EditorTabItem(new BlockingEditorContext(blockDispose: false));
         service.AddTabItem(tab);
         service.SelectedTabItem.Value = tab;
-        service.ClearTabItems();
+        await service.ClearTabItemsAsync();
 
         Assert.That(service.SelectedTabItem.Value, Is.Null);
-        Assert.That(service.RemoveTabItem(tab), Is.False);
+        Assert.That(await service.RemoveTabItemAsync(tab), Is.False);
         Assert.That(service.SelectedTabItem.Value, Is.Null);
         await tab.DisposeAsync();
     }
@@ -248,22 +248,22 @@ public sealed class EditorTabItemLifetimeTests
         };
         using var start = new ManualResetEventSlim();
 
-        Task<bool> first = Task.Run(() =>
+        Task<bool> first = Task.Run(async () =>
         {
             start.Wait();
-            return service.RemoveTabItem(tab);
+            return await service.RemoveTabItemAsync(tab);
         });
-        Task<bool> second = Task.Run(() =>
+        Task<bool> second = Task.Run(async () =>
         {
             start.Wait();
-            return service.RemoveTabItem(tab);
+            return await service.RemoveTabItemAsync(tab);
         });
         start.Set();
 
         bool[] results = await Task.WhenAll(first, second).WaitAsync(TimeSpan.FromSeconds(5));
         Assert.Multiple(() =>
         {
-            Assert.That(results.Count(static value => value), Is.EqualTo(1));
+            Assert.That(results, Has.Some.True);
             Assert.That(removeNotifications, Is.EqualTo(1));
             Assert.That(service.TabItems, Is.Empty);
         });
@@ -352,10 +352,11 @@ public sealed class EditorTabItemLifetimeTests
             releaseAdd.Task.GetAwaiter().GetResult();
         }));
         await beforeAdd.Task.WaitAsync(TimeSpan.FromSeconds(5));
-        Assert.That(service.RemoveTabItem(tab), Is.True);
+        Assert.That(service.RequestTabRemoval(tab), Is.False);
         releaseAdd.TrySetResult();
 
         Assert.That(await add.WaitAsync(TimeSpan.FromSeconds(5)), Is.False);
+        await tab.GetRemovalCompletion().WaitAsync(TimeSpan.FromSeconds(5));
         await tab.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
         Assert.Multiple(() =>
         {
@@ -363,6 +364,43 @@ public sealed class EditorTabItemLifetimeTests
             Assert.That(service.SelectedTabItem.Value, Is.Null);
             Assert.That(context.DisposeCount, Is.EqualTo(1));
             Assert.That(addNotifications, Is.Zero);
+        });
+    }
+
+    [Test]
+    public async Task AttachmentCommitBeforePhysicalAddCannotPublishAfterRemovalReservation()
+    {
+        var service = new EditorService(new ExtensionProvider());
+        var context = new BlockingEditorContext(blockDispose: false);
+        var tab = new EditorTabItem(context);
+        var attachmentCommitted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releasePhysicalAdd = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        int addNotifications = 0;
+        ((INotifyCollectionChanged)service.TabItems).CollectionChanged += (_, args) =>
+        {
+            if (args.Action == NotifyCollectionChangedAction.Add)
+                Interlocked.Increment(ref addNotifications);
+        };
+        service.BeforePhysicalAdd = () =>
+        {
+            attachmentCommitted.TrySetResult();
+            releasePhysicalAdd.Task.GetAwaiter().GetResult();
+        };
+
+        Task<bool> add = Task.Run(() => service.TryAddTabItem(tab));
+        await attachmentCommitted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.That(service.RequestTabRemoval(tab), Is.False);
+        releasePhysicalAdd.TrySetResult();
+
+        Assert.That(await add.WaitAsync(TimeSpan.FromSeconds(5)), Is.False);
+        await tab.GetRemovalCompletion().WaitAsync(TimeSpan.FromSeconds(5));
+        await tab.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(service.TabItems, Is.Empty);
+            Assert.That(addNotifications, Is.Zero);
+            Assert.That(context.DisposeCount, Is.EqualTo(1));
         });
     }
 
@@ -380,7 +418,7 @@ public sealed class EditorTabItemLifetimeTests
                 nestedClose = service.RequestClose(context);
         };
 
-        bool removed = await Task.Run(() => service.RemoveTabItem(tab))
+        bool removed = await Task.Run(async () => await service.RemoveTabItemAsync(tab))
             .WaitAsync(TimeSpan.FromSeconds(5));
         Assert.That(nestedClose.Status, Is.EqualTo(EditorContextCloseRequestStatus.Accepted));
         await nestedClose.Completion.WaitAsync(TimeSpan.FromSeconds(5));
@@ -388,6 +426,33 @@ public sealed class EditorTabItemLifetimeTests
         Assert.Multiple(() =>
         {
             Assert.That(removed, Is.True);
+            Assert.That(service.TabItems, Is.Empty);
+            Assert.That(service.SelectedTabItem.Value, Is.Null);
+        });
+    }
+
+    [Test]
+    public async Task RemoveObserverCanWaitForCrossThreadCloseAdmission()
+    {
+        var service = new EditorService(new ExtensionProvider());
+        var context = new BlockingEditorContext(blockDispose: false);
+        var tab = new EditorTabItem(context);
+        service.AddTabItem(tab);
+        EditorContextCloseRequest nested = default;
+        ((INotifyCollectionChanged)service.TabItems).CollectionChanged += (_, args) =>
+        {
+            if (args.Action == NotifyCollectionChangedAction.Remove)
+            {
+                Task<EditorContextCloseRequest> request = Task.Run(() => service.RequestClose(context));
+                nested = request.GetAwaiter().GetResult();
+            }
+        };
+
+        await service.CloseTabItem(tab).AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(nested.Status, Is.EqualTo(EditorContextCloseRequestStatus.AlreadyClosing));
             Assert.That(service.TabItems, Is.Empty);
             Assert.That(service.SelectedTabItem.Value, Is.Null);
         });
@@ -572,41 +637,44 @@ public sealed class EditorTabItemLifetimeTests
     [Test]
     public async Task SelectionAndRemovalDoNotInvertContextPublicationGate()
     {
-        var service = new EditorService(new ExtensionProvider());
-        var scene = new Scene(16, 16, string.Empty)
+        for (int iteration = 0; iteration < 20; iteration++)
         {
-            Uri = new Uri(Path.Combine(Path.GetTempPath(), "publication-gate.scene"))
-        };
-        var context = new GatedEditorContext(scene);
-        var tab = new EditorTabItem(context);
-        service.AddTabItem(tab);
-        service.SelectedTabItem.Value = tab;
-        context.PauseNextPublication();
-
-        ((System.Collections.Specialized.INotifyCollectionChanged)service.TabItems).CollectionChanged += (_, args) =>
-        {
-            if (args.Action == System.Collections.Specialized.NotifyCollectionChangedAction.Remove)
+            var service = new EditorService(new ExtensionProvider());
+            var scene = new Scene(16, 16, string.Empty)
             {
-                context.EnterGate();
-                context.ExitGate();
-            }
-        };
+                Uri = new Uri(Path.Combine(Path.GetTempPath(), $"publication-gate-{iteration}.scene"))
+            };
+            var context = new GatedEditorContext(scene);
+            var tab = new EditorTabItem(context);
+            service.AddTabItem(tab);
+            service.SelectedTabItem.Value = tab;
+            context.PauseNextPublication();
 
-        Task activate = Task.Run(() => service.ActivateTabItem(scene));
-        await context.PublicationPaused.Task.WaitAsync(TimeSpan.FromSeconds(5));
-        Task<bool> remove = Task.Run(() => service.RemoveTabItem(tab));
-        context.ReleasePublication();
+            ((System.Collections.Specialized.INotifyCollectionChanged)service.TabItems).CollectionChanged += (_, args) =>
+            {
+                if (args.Action == System.Collections.Specialized.NotifyCollectionChangedAction.Remove)
+                {
+                    context.EnterGate();
+                    context.ExitGate();
+                }
+            };
 
-        await Task.WhenAll(
-            activate.WaitAsync(TimeSpan.FromSeconds(5)),
-            remove.WaitAsync(TimeSpan.FromSeconds(5)));
+            Task activate = Task.Run(() => service.ActivateTabItem(scene));
+            await context.PublicationPaused.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            Task<bool> remove = Task.Run(async () => await service.RemoveTabItemAsync(tab));
+            context.ReleasePublication();
 
-        Assert.Multiple(() =>
-        {
-            Assert.That(service.TabItems, Is.Empty);
-            Assert.That(service.SelectedTabItem.Value, Is.Null);
-        });
-        await tab.DisposeAsync();
+            await Task.WhenAll(
+                activate.WaitAsync(TimeSpan.FromSeconds(5)),
+                remove.WaitAsync(TimeSpan.FromSeconds(5)));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(service.TabItems, Is.Empty, $"iteration {iteration}");
+                Assert.That(service.SelectedTabItem.Value, Is.Null, $"iteration {iteration}");
+            });
+            await tab.DisposeAsync();
+        }
     }
 
     [Test]
@@ -634,8 +702,7 @@ public sealed class EditorTabItemLifetimeTests
 
         Task<bool> replace = Task.Run(async () => await tab.ReplaceContextAsync(replacement));
         await replacement.PublicationPaused.Task.WaitAsync(TimeSpan.FromSeconds(5));
-        Task<bool> remove = Task.Run(() => service.RemoveTabItem(tab));
-        Assert.That(await remove.WaitAsync(TimeSpan.FromSeconds(5)), Is.True);
+        Assert.That(service.RequestTabRemoval(tab), Is.False);
         Assert.That(service.ContainsTabItem(tab), Is.True,
             "Physical removal waits for the admitted replacement publication to drain.");
         replacement.ReleasePublication();
@@ -862,6 +929,80 @@ public sealed class EditorTabItemLifetimeTests
             Assert.That(closeRequest.Status, Is.EqualTo(EditorContextCloseRequestStatus.Accepted));
             Assert.That(oldContext.DisposeCount, Is.EqualTo(1));
             Assert.That(replacement.DisposeCount, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public async Task StaleContextCloseGenerationCannotCloseReplacement()
+    {
+        var service = new EditorService(new ExtensionProvider());
+        var oldContext = new BlockingEditorContext(blockDispose: false);
+        var replacement = new BlockingEditorContext(blockDispose: false);
+        var tab = new EditorTabItem(oldContext);
+        service.AddTabItem(tab);
+        var lookupCompleted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseAdmission = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        service.BeforeContextCloseAdmission = () =>
+        {
+            lookupCompleted.TrySetResult();
+            releaseAdmission.Task.GetAwaiter().GetResult();
+        };
+
+        Task<EditorContextCloseRequest> staleClose = Task.Run(() => service.RequestClose(oldContext));
+        await lookupCompleted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.That(
+            await tab.ReplaceContextAsync(replacement).AsTask().WaitAsync(TimeSpan.FromSeconds(5)),
+            Is.True);
+        releaseAdmission.TrySetResult();
+
+        EditorContextCloseRequest request = await staleClose.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Multiple(() =>
+        {
+            Assert.That(request.Status, Is.EqualTo(EditorContextCloseRequestStatus.NotOwned));
+            Assert.That(tab.Context.Value, Is.SameAs(replacement));
+            Assert.That(service.TabItems, Does.Contain(tab));
+            Assert.That(replacement.DisposeCount, Is.Zero);
+        });
+
+        service.BeforeContextCloseAdmission = null;
+        await service.CloseTabItem(tab).AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task HostCloseReservationRejectsReplacementBeforeCloseStarts()
+    {
+        var service = new EditorService(new ExtensionProvider());
+        var oldContext = new BlockingEditorContext(blockDispose: false);
+        var replacement = new BlockingEditorContext(blockDispose: false);
+        var tab = new EditorTabItem(oldContext);
+        service.AddTabItem(tab);
+        var reservationCompleted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseCloseStart = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        service.BeforeHostCloseStart = () =>
+        {
+            reservationCompleted.TrySetResult();
+            releaseCloseStart.Task.GetAwaiter().GetResult();
+        };
+
+        Task<EditorContextCloseRequest> close = Task.Run(() => service.RequestClose(oldContext));
+        await reservationCompleted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        bool replaced = await tab.ReplaceContextAsync(replacement)
+            .AsTask()
+            .WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.That(replaced, Is.False);
+        Assert.That(oldContext.DisposeCount, Is.Zero);
+        Assert.That(replacement.DisposeCount, Is.EqualTo(1));
+
+        releaseCloseStart.TrySetResult();
+        EditorContextCloseRequest request = await close.WaitAsync(TimeSpan.FromSeconds(5));
+        await request.Completion.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(request.Status, Is.EqualTo(EditorContextCloseRequestStatus.Accepted));
+            Assert.That(oldContext.DisposeCount, Is.EqualTo(1));
+            Assert.That(service.TabItems, Is.Empty);
         });
     }
 
@@ -1413,6 +1554,8 @@ public sealed class EditorTabItemLifetimeTests
 
         public EditorExtension Extension { get; } = TestEditorExtension.Instance;
 
+        public IEditorContextCloseService CloseService { get; } = new UnownedCloseService();
+
         public IReactiveProperty<bool> IsEnabled { get; } = new ReactivePropertySlim<bool>(true);
 
         public IKnownEditorCommands? Commands => null;
@@ -1443,6 +1586,12 @@ public sealed class EditorTabItemLifetimeTests
         }
 
         public object? GetService(Type serviceType) => null;
+    }
+
+    private sealed class UnownedCloseService : IEditorContextCloseService
+    {
+        public EditorContextCloseRequest RequestClose(IEditorContext context)
+            => new(EditorContextCloseRequestStatus.NotOwned, Task.CompletedTask);
     }
 
     private sealed class GatedEditorContext(Scene scene) : BlockingEditorContext(false, scene), IEditorContextPublicationGate

--- a/tests/Beutl.HeadlessUITests/EditorTabItemLifetimeTests.cs
+++ b/tests/Beutl.HeadlessUITests/EditorTabItemLifetimeTests.cs
@@ -295,6 +295,32 @@ public sealed class EditorTabItemLifetimeTests
     }
 
     [Test]
+    public async Task ForeignHostCannotCloseOwnerTabViaPublicOverload()
+    {
+        var owner = new EditorService(new ExtensionProvider());
+        var foreign = new EditorService(new ExtensionProvider());
+        var context = new BlockingEditorContext(blockDispose: false, closeService: owner);
+        var tab = new EditorTabItem(context);
+        owner.AddTabItem(tab);
+
+        await foreign.CloseTabItem(tab).AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(owner.TabItems, Does.Contain(tab));
+            Assert.That(tab.Context.Value, Is.SameAs(context));
+            Assert.That(context.DisposeCount, Is.Zero);
+            Assert.That(foreign.RequestClose(context).Status, Is.EqualTo(EditorContextCloseRequestStatus.NotOwned));
+        });
+
+        EditorContextCloseRequest ownerClose = owner.RequestClose(context);
+        Assert.That(ownerClose.Status, Is.EqualTo(EditorContextCloseRequestStatus.Accepted));
+        await ownerClose.Completion.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.That(context.DisposeCount, Is.EqualTo(1));
+        Assert.That(owner.TabItems, Is.Empty);
+    }
+
+    [Test]
     public async Task ForeignHostContextIsRejectedByReplacementWithoutConsumption()
     {
         var owner = new EditorService(new ExtensionProvider());
@@ -317,6 +343,59 @@ public sealed class EditorTabItemLifetimeTests
         });
 
         await owner.CloseTabItem(tab).AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task ActivationDisposesContextWhenExtensionReturnsForeignHostToken()
+    {
+        var foreign = new EditorService(new ExtensionProvider());
+        var provider = new ExtensionProvider();
+        var extension = new ForeignContextEditorExtension(foreign);
+        provider.AddExtensions(1, [extension]);
+        var service = new EditorService(provider);
+        var scene = new Scene(16, 16, string.Empty)
+        {
+            Uri = new Uri(Path.Combine(Path.GetTempPath(), "activation-foreign-token.activation"))
+        };
+
+        service.ActivateTabItem(scene);
+
+        BlockingEditorContext context = await extension.CreatedContext.Task
+            .WaitAsync(TimeSpan.FromSeconds(5));
+        await context.Disposed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(service.TabItems, Is.Empty);
+            Assert.That(foreign.TabItems, Is.Empty);
+            Assert.That(context.DisposeCount, Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public async Task ActivationDisposesTransferredContextWhenTabConstructionFails()
+    {
+        var provider = new ExtensionProvider();
+        var service = new EditorService(provider);
+        var extension = new TransferredContextEditorExtension(service);
+        provider.AddExtensions(2, [extension]);
+        service.BeforeActivationTabConstruction =
+            _ => throw new InvalidOperationException("Tab creation failed.");
+        var scene = new Scene(16, 16, string.Empty)
+        {
+            Uri = new Uri(Path.Combine(Path.GetTempPath(), "activation-throw.activation-fault"))
+        };
+
+        Assert.Throws<InvalidOperationException>(() => service.ActivateTabItem(scene));
+
+        BlockingEditorContext context = await extension.CreatedContext.Task
+            .WaitAsync(TimeSpan.FromSeconds(5));
+        await context.Disposed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Multiple(() =>
+        {
+            Assert.That(service.TabItems, Is.Empty);
+            Assert.That(context.DisposeCount, Is.EqualTo(1));
+        });
     }
 
     [Test]
@@ -1857,6 +1936,68 @@ public sealed class EditorTabItemLifetimeTests
         {
             context = null;
             return false;
+        }
+    }
+
+    private sealed class ForeignContextEditorExtension(EditorService foreignHost) : EditorExtension
+    {
+        public TaskCompletionSource<BlockingEditorContext> CreatedContext { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public override FilePickerFileType GetFilePickerFileType() => new("Foreign");
+
+        public override IconSource? GetIcon() => null;
+
+        public override bool TryCreateEditor(
+            CoreObject obj,
+            [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Control? editor)
+        {
+            editor = null;
+            return false;
+        }
+
+        public override bool MatchFileExtension(string ext) => ext == ".activation";
+
+        public override bool TryCreateContext(
+            CoreObject obj,
+            IEditorContextServices services,
+            [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out IEditorContext? context)
+        {
+            var created = new BlockingEditorContext(blockDispose: false, obj, foreignHost);
+            CreatedContext.TrySetResult(created);
+            context = created;
+            return true;
+        }
+    }
+
+    private sealed class TransferredContextEditorExtension(EditorService host) : EditorExtension
+    {
+        public TaskCompletionSource<BlockingEditorContext> CreatedContext { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public override FilePickerFileType GetFilePickerFileType() => new("Throwing");
+
+        public override IconSource? GetIcon() => null;
+
+        public override bool TryCreateEditor(
+            CoreObject obj,
+            [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Control? editor)
+        {
+            editor = null;
+            return false;
+        }
+
+        public override bool MatchFileExtension(string ext) => ext == ".activation-fault";
+
+        public override bool TryCreateContext(
+            CoreObject obj,
+            IEditorContextServices services,
+            [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out IEditorContext? context)
+        {
+            var created = new BlockingEditorContext(blockDispose: false, obj, host);
+            CreatedContext.TrySetResult(created);
+            context = created;
+            return true;
         }
     }
 }

--- a/tests/Beutl.HeadlessUITests/EditorTabItemLifetimeTests.cs
+++ b/tests/Beutl.HeadlessUITests/EditorTabItemLifetimeTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Specialized;
 using Avalonia.Controls;
+using Avalonia.Headless.NUnit;
 using Avalonia.Platform.Storage;
 using Beutl.Api.Services;
 using Beutl.Collections;
@@ -3307,6 +3308,53 @@ public sealed class EditorTabItemLifetimeTests
             Assert.That(service.TabItems, Is.Empty);
             Assert.That(firstReentrantClose.Status, Is.EqualTo(EditorContextCloseRequestStatus.AlreadyClosing));
         });
+    }
+
+    [AvaloniaTest]
+    public async Task Concurrent_activation_publishes_one_tab_and_disposes_losing_context()
+    {
+        await TestReset.ResetShellAsync();
+        var provider = new ExtensionProvider();
+        var service = new EditorService(provider);
+        var extension = new ConcurrentActivationExtension();
+        provider.AddExtensions(-2324, [extension]);
+        var scene = new Scene(16, 16, string.Empty) { Uri = new Uri("file:///activation.concurrent") };
+        Task first = service.ActivateTabItemAsync(scene);
+        Task second = service.ActivateTabItemAsync(scene);
+        await extension.BothEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        extension.Release.TrySetResult();
+        await Task.WhenAll(first, second).WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.That(service.TabItems, Has.Count.EqualTo(1));
+        BlockingEditorContext loser = extension.Contexts.Single(context =>
+            !ReferenceEquals(context, service.TabItems.Single().Context.Value));
+        await loser.Disposed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.That(extension.Contexts.Sum(context => context.DisposeCount), Is.EqualTo(1));
+        await service.CloseTabItem(service.TabItems.Single());
+    }
+
+    private sealed class ConcurrentActivationExtension : EditorExtension
+    {
+        public readonly TaskCompletionSource BothEntered = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public readonly TaskCompletionSource Release = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public readonly List<BlockingEditorContext> Contexts = [];
+        public override FilePickerFileType GetFilePickerFileType() => new("Concurrent");
+        public override IconSource? GetIcon() => null;
+        public override bool MatchFileExtension(string ext) => ext == ".concurrent";
+        public override bool TryCreateEditor(CoreObject obj,
+            [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Control? editor)
+        {
+            editor = null;
+            return false;
+        }
+        public override async ValueTask<IEditorContext?> CreateContextAsync(CoreObject obj, IEditorContextServices services)
+        {
+            var context = new BlockingEditorContext(false, obj, services.CloseService);
+            Contexts.Add(context);
+            if (Contexts.Count == 2)
+                BothEntered.TrySetResult();
+            await Release.Task;
+            return context;
+        }
     }
 
     private class BlockingEditorContext : IEditorContext

--- a/tests/Beutl.HeadlessUITests/EditorTabItemLifetimeTests.cs
+++ b/tests/Beutl.HeadlessUITests/EditorTabItemLifetimeTests.cs
@@ -2,6 +2,7 @@
 using Avalonia.Controls;
 using Avalonia.Platform.Storage;
 using Beutl.Api.Services;
+using Beutl.Collections;
 using Beutl.Extensibility;
 using Beutl.ProjectSystem;
 using Beutl.Services;
@@ -13,6 +14,54 @@ namespace Beutl.HeadlessUITests;
 [TestFixture, NonParallelizable]
 public sealed class EditorTabItemLifetimeTests
 {
+    [Test]
+    public async Task PublicSelectionSurfaceOnlyActivatesPublishedHostTabs()
+    {
+        var service = new EditorService(new ExtensionProvider());
+        var owned = new EditorTabItem(
+            new BlockingEditorContext(blockDispose: false, closeService: service));
+        var foreign = new EditorTabItem(
+            new BlockingEditorContext(blockDispose: false, closeService: service));
+        IReadOnlyReactiveProperty<EditorTabItem?> selectedTab = service.SelectedTabItem;
+        IReadOnlyReactiveProperty<bool> selectedState = owned.IsSelected;
+        NotifyCollectionChangedEventArgs? collectionChange = null;
+        object? collectionSender = null;
+        service.TabItems.CollectionChanged += (sender, args) =>
+        {
+            collectionSender = sender;
+            collectionChange = args;
+        };
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                typeof(EditorTabItem).GetConstructors(),
+                Is.Empty,
+                "Only EditorService may construct and claim editor tabs for publication.");
+            Assert.That(service.TabItems, Is.Not.InstanceOf<ICoreList<EditorTabItem>>());
+            Assert.That(selectedTab, Is.Not.InstanceOf<IReactiveProperty<EditorTabItem?>>());
+            Assert.That(owned.Context, Is.Not.InstanceOf<IReactiveProperty<IEditorContext?>>());
+            Assert.That(selectedState, Is.Not.InstanceOf<IReactiveProperty<bool>>());
+        });
+        Assert.That(service.TryAddTabItem(owned), Is.True);
+        Assert.That(collectionChange?.Action, Is.EqualTo(NotifyCollectionChangedAction.Add));
+        Assert.That(collectionSender, Is.SameAs(service.TabItems));
+        Assert.That(collectionSender, Is.Not.InstanceOf<ICoreList<EditorTabItem>>());
+        Assert.That(service.ActivateTabItem(foreign), Is.False);
+        Assert.That(selectedTab.Value, Is.Null);
+        Assert.That(selectedState.Value, Is.False);
+
+        Assert.That(service.ActivateTabItem(owned), Is.True);
+        Assert.That(selectedTab.Value, Is.SameAs(owned));
+        Assert.That(selectedState.Value, Is.True);
+
+        await service.CloseTabItem(owned).AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.That(service.ActivateTabItem(owned), Is.False);
+        Assert.That(selectedTab.Value, Is.Null);
+        Assert.That(selectedState.Value, Is.False);
+        await foreign.DisposeAsync();
+    }
+
     [Test]
     public async Task EditorContextOwnershipLeaseIsExclusiveAndGenerationSafe()
     {
@@ -106,7 +155,7 @@ public sealed class EditorTabItemLifetimeTests
         var service = new EditorService(new ExtensionProvider());
         var tab = new EditorTabItem(new BlockingEditorContext(blockDispose: false, closeService: service));
         service.AddTabItem(tab);
-        service.SelectedTabItem.Value = tab;
+        Assert.That(service.ActivateTabItem(tab), Is.True);
         await service.ClearTabItemsAsync();
 
         Assert.That(service.SelectedTabItem.Value, Is.Null);
@@ -182,7 +231,7 @@ public sealed class EditorTabItemLifetimeTests
         var context = new BlockingEditorContext(blockDispose: false, closeService: service);
         var tab = new EditorTabItem(context);
         service.AddTabItem(tab);
-        service.SelectedTabItem.Value = tab;
+        Assert.That(service.ActivateTabItem(tab), Is.True);
 
         await tab.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
 
@@ -399,7 +448,7 @@ public sealed class EditorTabItemLifetimeTests
             Uri = new Uri(Path.Combine(Path.GetTempPath(), "activation-foreign-token.activation"))
         };
 
-        service.ActivateTabItem(scene);
+        await service.ActivateTabItemAsync(scene);
 
         BlockingEditorContext context = await extension.CreatedContext.Task
             .WaitAsync(TimeSpan.FromSeconds(5));
@@ -442,7 +491,7 @@ public sealed class EditorTabItemLifetimeTests
             Uri = new Uri(Path.Combine(Path.GetTempPath(), "activation-immediate-fault.activation"))
         };
 
-        service.ActivateTabItem(scene);
+        await service.ActivateTabItemAsync(scene);
         Assert.That(context.DisposeStarted.Task.IsCompleted, Is.True);
 
         Assert.ThrowsAsync<InvalidOperationException>(async () =>
@@ -465,7 +514,7 @@ public sealed class EditorTabItemLifetimeTests
             Uri = new Uri(Path.Combine(Path.GetTempPath(), "activation-delayed-fault.activation"))
         };
 
-        service.ActivateTabItem(scene);
+        await service.ActivateTabItemAsync(scene);
         await context.DisposeStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
         Task drain = service.ClearTabItemsAsync().AsTask();
         Assert.That(drain.IsCompleted, Is.False);
@@ -493,7 +542,7 @@ public sealed class EditorTabItemLifetimeTests
             Uri = new Uri(Path.Combine(Path.GetTempPath(), "activation-success.activation"))
         };
 
-        service.ActivateTabItem(scene);
+        await service.ActivateTabItemAsync(scene);
         await service.ClearTabItemsAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
         await service.ClearTabItemsAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
 
@@ -521,7 +570,7 @@ public sealed class EditorTabItemLifetimeTests
             Uri = new Uri(Path.Combine(Path.GetTempPath(), "activation-post-await.activation"))
         };
 
-        service.ActivateTabItem(scene);
+        await service.ActivateTabItemAsync(scene);
         await context.DisposeStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
         await service.ClearTabItemsAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
         Assert.That(context.DisposeCount, Is.EqualTo(1));
@@ -1109,7 +1158,7 @@ public sealed class EditorTabItemLifetimeTests
             Uri = new Uri(Path.Combine(Path.GetTempPath(), "activation-host-fault.activation"))
         };
 
-        Assert.Throws<InvalidOperationException>(() => service.ActivateTabItem(scene));
+        Assert.ThrowsAsync<InvalidOperationException>(async () => await service.ActivateTabItemAsync(scene));
         await context.DisposeStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
         Exception? failure = null;
@@ -1147,7 +1196,7 @@ public sealed class EditorTabItemLifetimeTests
             Uri = new Uri(Path.Combine(Path.GetTempPath(), "activation-throw.activation-fault"))
         };
 
-        Assert.Throws<InvalidOperationException>(() => service.ActivateTabItem(scene));
+        Assert.ThrowsAsync<InvalidOperationException>(async () => await service.ActivateTabItemAsync(scene));
 
         BlockingEditorContext context = await extension.CreatedContext.Task
             .WaitAsync(TimeSpan.FromSeconds(5));
@@ -1185,7 +1234,7 @@ public sealed class EditorTabItemLifetimeTests
             Uri = new Uri(Path.Combine(Path.GetTempPath(), "activation-host-token.activation-fault"))
         };
 
-        Assert.Throws<InvalidOperationException>(() => service.ActivateTabItem(scene));
+        Assert.ThrowsAsync<InvalidOperationException>(async () => await service.ActivateTabItemAsync(scene));
 
         BlockingEditorContext context = await extension.CreatedContext.Task
             .WaitAsync(TimeSpan.FromSeconds(5));
@@ -1212,7 +1261,7 @@ public sealed class EditorTabItemLifetimeTests
             Uri = new Uri(Path.Combine(Path.GetTempPath(), "activation-reentrant.operation"))
         };
 
-        Task activation = Task.Run(() => service.ActivateTabItem(scene));
+        Task activation = Task.Run(() => service.ActivateTabItemAsync(scene));
         InvalidOperationException? failure = Assert.ThrowsAsync<InvalidOperationException>(async () =>
             await activation.WaitAsync(TimeSpan.FromSeconds(5)));
 
@@ -1244,7 +1293,7 @@ public sealed class EditorTabItemLifetimeTests
             Uri = new Uri(Path.Combine(Path.GetTempPath(), "activation-same-owned.activation"))
         };
 
-        service.ActivateTabItem(activationScene);
+        await service.ActivateTabItemAsync(activationScene);
 
         Assert.Multiple(() =>
         {
@@ -1278,7 +1327,7 @@ public sealed class EditorTabItemLifetimeTests
             Uri = new Uri(Path.Combine(Path.GetTempPath(), "activation-foreign-owned.activation"))
         };
 
-        service.ActivateTabItem(activationScene);
+        await service.ActivateTabItemAsync(activationScene);
 
         Assert.Multiple(() =>
         {
@@ -2195,7 +2244,7 @@ public sealed class EditorTabItemLifetimeTests
                 close = service.RequestClose(context);
         });
 
-        await Task.Run(() => service.ActivateTabItem(scene))
+        await Task.Run(() => service.ActivateTabItemAsync(scene))
             .WaitAsync(TimeSpan.FromSeconds(5));
         Assert.That(close.Status, Is.EqualTo(EditorContextCloseRequestStatus.Accepted));
         await close.Completion.WaitAsync(TimeSpan.FromSeconds(5));
@@ -2224,7 +2273,7 @@ public sealed class EditorTabItemLifetimeTests
                 close = service.RequestClose(context);
         });
 
-        service.ActivateTabItem(scene);
+        await service.ActivateTabItemAsync(scene);
         Assert.That(close.Status, Is.EqualTo(EditorContextCloseRequestStatus.Accepted));
         await close.Completion.WaitAsync(TimeSpan.FromSeconds(5));
         Assert.Multiple(() =>
@@ -2259,7 +2308,7 @@ public sealed class EditorTabItemLifetimeTests
             }
         });
 
-        service.ActivateTabItem(scene);
+        await service.ActivateTabItemAsync(scene);
         Assert.That(delayedClose, Is.Not.Null);
         releaseChild.TrySetResult();
         await context.DisposeStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
@@ -2294,7 +2343,7 @@ public sealed class EditorTabItemLifetimeTests
             }
         });
 
-        await Task.Run(() => service.ActivateTabItem(scene))
+        await Task.Run(() => service.ActivateTabItemAsync(scene))
             .WaitAsync(TimeSpan.FromSeconds(5));
 
         Assert.Multiple(() =>
@@ -2320,7 +2369,7 @@ public sealed class EditorTabItemLifetimeTests
             var context = new GatedEditorContext(scene, service);
             var tab = new EditorTabItem(context);
             service.AddTabItem(tab);
-            service.SelectedTabItem.Value = tab;
+            Assert.That(service.ActivateTabItem(tab), Is.True);
             context.PauseNextPublication();
 
             ((System.Collections.Specialized.INotifyCollectionChanged)service.TabItems).CollectionChanged += (_, args) =>
@@ -2332,7 +2381,7 @@ public sealed class EditorTabItemLifetimeTests
                 }
             };
 
-            Task activate = Task.Run(() => service.ActivateTabItem(scene));
+            Task activate = Task.Run(() => service.ActivateTabItemAsync(scene));
             await context.PublicationPaused.Task.WaitAsync(TimeSpan.FromSeconds(5));
             Task<bool> remove = Task.Run(async () => await service.RemoveTabItemAsync(tab));
             context.ReleasePublication();
@@ -2818,7 +2867,7 @@ public sealed class EditorTabItemLifetimeTests
         var oldContext = new ThrowingEditorContext(service);
         var tab = new EditorTabItem(oldContext);
         service.AddTabItem(tab);
-        service.SelectedTabItem.Value = tab;
+        Assert.That(service.ActivateTabItem(tab), Is.True);
         var replacement = new BlockingEditorContext(blockDispose: false, closeService: service);
         var values = new List<IEditorContext?>();
         using IDisposable subscription = tab.Context.Subscribe(values.Add);
@@ -2846,7 +2895,7 @@ public sealed class EditorTabItemLifetimeTests
         };
         var tab = new EditorTabItem(oldContext);
         service.AddTabItem(tab);
-        service.SelectedTabItem.Value = tab;
+        Assert.That(service.ActivateTabItem(tab), Is.True);
 
         Task replacement = tab.ReplaceContextAsync(new BlockingEditorContext(blockDispose: false, closeService: service)).AsTask();
         await oldContext.DisposeStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
@@ -3178,7 +3227,7 @@ public sealed class EditorTabItemLifetimeTests
         var context = new BlockingEditorContext(blockDispose: false, closeService: service);
         var tab = new EditorTabItem(context);
         service.AddTabItem(tab);
-        service.SelectedTabItem.Value = tab;
+        Assert.That(service.ActivateTabItem(tab), Is.True);
         ((INotifyCollectionChanged)service.TabItems).CollectionChanged += (_, _) =>
             throw new InvalidOperationException("collection observer failed");
         using IDisposable selected = service.SelectedTabItem.Subscribe(value =>
@@ -3403,14 +3452,10 @@ public sealed class EditorTabItemLifetimeTests
 
         public override bool MatchFileExtension(string ext) => false;
 
-        public override bool TryCreateContext(
+        public override ValueTask<IEditorContext?> CreateContextAsync(
             CoreObject obj,
-            IEditorContextServices services,
-            [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out IEditorContext? context)
-        {
-            context = null;
-            return false;
-        }
+            IEditorContextServices services)
+            => ValueTask.FromResult<IEditorContext?>(null);
     }
 
     private sealed class HostMediatedReplacementExtension(bool throwOnHostToken = false) : EditorExtension
@@ -3433,18 +3478,16 @@ public sealed class EditorTabItemLifetimeTests
 
         public override bool MatchFileExtension(string ext) => false;
 
-        public override bool TryCreateContext(
+        public override ValueTask<IEditorContext?> CreateContextAsync(
             CoreObject obj,
-            IEditorContextServices services,
-            [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out IEditorContext? context)
+            IEditorContextServices services)
         {
             CreationCount++;
             IEditorContextCloseService closeService = throwOnHostToken
                 ? new ThrowingHostTokenCloseService()
                 : services.CloseService;
             CreatedContext = new BlockingEditorContext(blockDispose: false, obj, closeService);
-            context = CreatedContext;
-            return true;
+            return ValueTask.FromResult<IEditorContext?>(CreatedContext);
         }
     }
 
@@ -3464,13 +3507,11 @@ public sealed class EditorTabItemLifetimeTests
 
         public override bool MatchFileExtension(string ext) => false;
 
-        public override bool TryCreateContext(
+        public override ValueTask<IEditorContext?> CreateContextAsync(
             CoreObject obj,
-            IEditorContextServices services,
-            [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out IEditorContext? context)
+            IEditorContextServices services)
         {
-            context = existingContext;
-            return true;
+            return ValueTask.FromResult<IEditorContext?>(existingContext);
         }
     }
 
@@ -3493,14 +3534,12 @@ public sealed class EditorTabItemLifetimeTests
 
         public override bool MatchFileExtension(string ext) => true;
 
-        public override bool TryCreateContext(
+        public override ValueTask<IEditorContext?> CreateContextAsync(
             CoreObject obj,
-            IEditorContextServices services,
-            [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out IEditorContext? context)
+            IEditorContextServices services)
         {
             CreationCount++;
-            context = existingContext;
-            return true;
+            return ValueTask.FromResult<IEditorContext?>(existingContext);
         }
     }
 
@@ -3521,13 +3560,11 @@ public sealed class EditorTabItemLifetimeTests
 
         public override bool MatchFileExtension(string ext) => true;
 
-        public override bool TryCreateContext(
+        public override ValueTask<IEditorContext?> CreateContextAsync(
             CoreObject obj,
-            IEditorContextServices services,
-            [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out IEditorContext? context)
+            IEditorContextServices services)
         {
-            context = suppliedContext;
-            return true;
+            return ValueTask.FromResult<IEditorContext?>(suppliedContext);
         }
     }
 
@@ -3627,13 +3664,11 @@ public sealed class EditorTabItemLifetimeTests
 
         public override bool MatchFileExtension(string ext) => ext == fileExtension;
 
-        public override bool TryCreateContext(
+        public override ValueTask<IEditorContext?> CreateContextAsync(
             CoreObject obj,
-            IEditorContextServices services,
-            [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out IEditorContext? result)
+            IEditorContextServices services)
         {
-            result = context;
-            return true;
+            return ValueTask.FromResult<IEditorContext?>(context);
         }
     }
 
@@ -3780,18 +3815,16 @@ public sealed class EditorTabItemLifetimeTests
 
         public override bool MatchFileExtension(string ext) => ext == ".activation-fault";
 
-        public override bool TryCreateContext(
+        public override ValueTask<IEditorContext?> CreateContextAsync(
             CoreObject obj,
-            IEditorContextServices services,
-            [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out IEditorContext? context)
+            IEditorContextServices services)
         {
             var created = new BlockingEditorContext(
                 blockDispose: false,
                 obj,
                 new ThrowingHostTokenCloseService());
             CreatedContext.TrySetResult(created);
-            context = created;
-            return true;
+            return ValueTask.FromResult<IEditorContext?>(created);
         }
     }
 
@@ -3824,10 +3857,9 @@ public sealed class EditorTabItemLifetimeTests
 
         public override bool MatchFileExtension(string ext) => false;
 
-        public override bool TryCreateContext(
+        public override ValueTask<IEditorContext?> CreateContextAsync(
             CoreObject obj,
-            IEditorContextServices services,
-            [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out IEditorContext? context)
+            IEditorContextServices services)
         {
             CreatedContext = new BlockingEditorContext(
                 blockDispose: false,
@@ -3835,8 +3867,7 @@ public sealed class EditorTabItemLifetimeTests
                 new ForwardingCloseService(service));
             CreatedTab = new EditorTabItem(CreatedContext);
             service.AddTabItem(CreatedTab);
-            context = CreatedContext;
-            return true;
+            return ValueTask.FromResult<IEditorContext?>(CreatedContext);
         }
     }
 
@@ -3872,16 +3903,14 @@ public sealed class EditorTabItemLifetimeTests
 
         public override bool MatchFileExtension(string ext) => false;
 
-        public override bool TryCreateContext(
+        public override async ValueTask<IEditorContext?> CreateContextAsync(
             CoreObject obj,
-            IEditorContextServices services,
-            [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out IEditorContext? context)
+            IEditorContextServices services)
         {
             Entered.TrySetResult();
-            Release.Task.GetAwaiter().GetResult();
+            await Release.Task;
             CreatedContext = new BlockingEditorContext(blockDispose: false, obj, services.CloseService);
-            context = CreatedContext;
-            return true;
+            return CreatedContext;
         }
     }
 
@@ -3907,24 +3936,20 @@ public sealed class EditorTabItemLifetimeTests
 
         public override bool MatchFileExtension(string ext) => matchFileExtension;
 
-        public override bool TryCreateContext(
+        public override async ValueTask<IEditorContext?> CreateContextAsync(
             CoreObject obj,
-            IEditorContextServices services,
-            [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out IEditorContext? context)
+            IEditorContextServices services)
         {
             CreationCount++;
             if (useWorker)
             {
-                Task.Run(() => service.ClearTabItemsAsync().AsTask())
-                    .GetAwaiter()
-                    .GetResult();
+                await Task.Run(() => service.ClearTabItemsAsync().AsTask());
             }
             else
             {
-                service.ClearTabItemsAsync().AsTask().GetAwaiter().GetResult();
+                await service.ClearTabItemsAsync();
             }
-            context = null;
-            return false;
+            return null;
         }
     }
 
@@ -3950,18 +3975,16 @@ public sealed class EditorTabItemLifetimeTests
 
         public override bool MatchFileExtension(string ext) => false;
 
-        public override bool TryCreateContext(
+        public override ValueTask<IEditorContext?> CreateContextAsync(
             CoreObject obj,
-            IEditorContextServices services,
-            [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out IEditorContext? context)
+            IEditorContextServices services)
         {
             Reconciliation = Task.Run(async () =>
             {
                 await Release.Task;
                 await service.ClearTabItemsAsync();
             });
-            context = null;
-            return false;
+            return ValueTask.FromResult<IEditorContext?>(null);
         }
     }
 
@@ -3986,15 +4009,13 @@ public sealed class EditorTabItemLifetimeTests
 
         public override bool MatchFileExtension(string ext) => false;
 
-        public override bool TryCreateContext(
+        public override ValueTask<IEditorContext?> CreateContextAsync(
             CoreObject obj,
-            IEditorContextServices services,
-            [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out IEditorContext? context)
+            IEditorContextServices services)
         {
             TaskCompletionSource release = Release;
             Child = Task.Run(async () => await release.Task);
-            context = null;
-            return false;
+            return ValueTask.FromResult<IEditorContext?>(null);
         }
     }
 
@@ -4017,14 +4038,12 @@ public sealed class EditorTabItemLifetimeTests
 
         public override bool MatchFileExtension(string ext) => false;
 
-        public override bool TryCreateContext(
+        public override async ValueTask<IEditorContext?> CreateContextAsync(
             CoreObject obj,
-            IEditorContextServices services,
-            [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out IEditorContext? context)
+            IEditorContextServices services)
         {
-            service.ReplaceContextAsync(tab, nestedExtension).AsTask().GetAwaiter().GetResult();
-            context = null;
-            return false;
+            await service.ReplaceContextAsync(tab, nestedExtension);
+            return null;
         }
     }
 
@@ -4049,15 +4068,13 @@ public sealed class EditorTabItemLifetimeTests
 
         public override bool MatchFileExtension(string ext) => ext == ".activation";
 
-        public override bool TryCreateContext(
+        public override ValueTask<IEditorContext?> CreateContextAsync(
             CoreObject obj,
-            IEditorContextServices services,
-            [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out IEditorContext? context)
+            IEditorContextServices services)
         {
             var created = new BlockingEditorContext(blockDispose, obj, foreignHost);
             CreatedContext.TrySetResult(created);
-            context = created;
-            return true;
+            return ValueTask.FromResult<IEditorContext?>(created);
         }
     }
 
@@ -4082,15 +4099,13 @@ public sealed class EditorTabItemLifetimeTests
 
         public override bool MatchFileExtension(string ext) => ext == ".activation-fault";
 
-        public override bool TryCreateContext(
+        public override ValueTask<IEditorContext?> CreateContextAsync(
             CoreObject obj,
-            IEditorContextServices services,
-            [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out IEditorContext? context)
+            IEditorContextServices services)
         {
             var created = new BlockingEditorContext(blockDispose, obj, host);
             CreatedContext.TrySetResult(created);
-            context = created;
-            return true;
+            return ValueTask.FromResult<IEditorContext?>(created);
         }
     }
 }

--- a/tests/Beutl.HeadlessUITests/EditorViewModelDisposeRaceTests.cs
+++ b/tests/Beutl.HeadlessUITests/EditorViewModelDisposeRaceTests.cs
@@ -31,7 +31,7 @@ public class EditorViewModelDisposeRaceTests
         HeadlessTestHelpers.Settle();
         Scene scene = project.Items.OfType<Scene>().First();
 
-        TestShell.Editor.ActivateTabItem(scene);
+        await TestShell.Editor.ActivateTabItemAsync(scene);
         HeadlessTestHelpers.Settle();
         return (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
     }

--- a/tests/Beutl.HeadlessUITests/EditorWorkflowTests.cs
+++ b/tests/Beutl.HeadlessUITests/EditorWorkflowTests.cs
@@ -34,7 +34,7 @@ public class EditorWorkflowTests
 
         EditorTabItem tab = TestShell.Editor.SelectedTabItem.Value!;
         // The scene editor's IEditorContext is the EditViewModel itself.
-        return (EditViewModel)tab.Context.Value;
+        return (EditViewModel)tab.Context.Value!;
     }
 
     private static async Task<Element> AddRectangle(EditViewModel editor, TimeSpan start, int layer)
@@ -57,7 +57,7 @@ public class EditorWorkflowTests
         EditViewModel editor = await OpenEditorForNewScene("editvm");
 
         Assert.That(editor, Is.Not.Null);
-        Assert.That(editor.Scene, Is.SameAs(TestShell.Editor.SelectedTabItem.Value!.Context.Value.Object));
+        Assert.That(editor.Scene, Is.SameAs(TestShell.Editor.SelectedTabItem.Value!.Context.Value!.Object));
         Assert.That(editor.HistoryManager, Is.Not.Null);
         Assert.That(editor.HistoryManager.Root, Is.SameAs(editor.Scene));
     }

--- a/tests/Beutl.HeadlessUITests/EditorWorkflowTests.cs
+++ b/tests/Beutl.HeadlessUITests/EditorWorkflowTests.cs
@@ -29,7 +29,7 @@ public class EditorWorkflowTests
         HeadlessTestHelpers.Settle();
         Scene scene = project.Items.OfType<Scene>().First();
 
-        TestShell.Editor.ActivateTabItem(scene);
+        await TestShell.Editor.ActivateTabItemAsync(scene);
         HeadlessTestHelpers.Settle();
 
         EditorTabItem tab = TestShell.Editor.SelectedTabItem.Value!;

--- a/tests/Beutl.HeadlessUITests/ElementAddEntryPointTests.cs
+++ b/tests/Beutl.HeadlessUITests/ElementAddEntryPointTests.cs
@@ -43,7 +43,7 @@ public class ElementAddEntryPointTests
         HeadlessTestHelpers.Settle();
         Scene scene = project.Items.OfType<Scene>().First();
 
-        TestShell.Editor.ActivateTabItem(scene);
+        await TestShell.Editor.ActivateTabItemAsync(scene);
         HeadlessTestHelpers.Settle();
 
         EditorTabItem tab = TestShell.Editor.SelectedTabItem.Value!;
@@ -271,7 +271,7 @@ public class ElementAddEntryPointTests
         await TestReset.ResetShellAsync();
         (EditViewModel editor, TimelineTabViewModel timeline) =
             await OpenEditorForNewScene("player-drop-without-timeline");
-        editor.CloseToolTab(timeline);
+        await editor.CloseToolTabAsync(timeline);
         Assert.That(editor.FindToolTab<TimelineTabViewModel>(), Is.Null);
         using (editor.HistoryManager.SuppressRecording())
         {

--- a/tests/Beutl.HeadlessUITests/ElementAdderTests.cs
+++ b/tests/Beutl.HeadlessUITests/ElementAdderTests.cs
@@ -28,7 +28,7 @@ public class ElementAdderTests
         HeadlessTestHelpers.Settle();
         Scene scene = project.Items.OfType<Scene>().First();
 
-        TestShell.Editor.ActivateTabItem(scene);
+        await TestShell.Editor.ActivateTabItemAsync(scene);
         HeadlessTestHelpers.Settle();
 
         EditorTabItem tab = TestShell.Editor.SelectedTabItem.Value!;

--- a/tests/Beutl.HeadlessUITests/ElementViewLayoutTests.cs
+++ b/tests/Beutl.HeadlessUITests/ElementViewLayoutTests.cs
@@ -41,7 +41,7 @@ public class ElementViewLayoutTests
 
         TestShell.Editor.ActivateTabItem(scene);
         HeadlessTestHelpers.Settle();
-        return (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
+        return (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value!;
     }
 
     private static async Task AddRectangle(EditViewModel editor)

--- a/tests/Beutl.HeadlessUITests/ElementViewLayoutTests.cs
+++ b/tests/Beutl.HeadlessUITests/ElementViewLayoutTests.cs
@@ -39,7 +39,7 @@ public class ElementViewLayoutTests
         HeadlessTestHelpers.Settle();
         Scene scene = project.Items.OfType<Scene>().First();
 
-        TestShell.Editor.ActivateTabItem(scene);
+        await TestShell.Editor.ActivateTabItemAsync(scene);
         HeadlessTestHelpers.Settle();
         return (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value!;
     }

--- a/tests/Beutl.HeadlessUITests/ExportTests.cs
+++ b/tests/Beutl.HeadlessUITests/ExportTests.cs
@@ -160,7 +160,7 @@ public class ExportTests
 
         TestShell.Editor.ActivateTabItem(scene);
         HeadlessTestHelpers.Settle();
-        var editor = (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
+        var editor = (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value!;
 
         var adder = (IElementAdder)editor.GetService(typeof(IElementAdder))!;
         await adder.AddAsync([new ElementDescription(

--- a/tests/Beutl.HeadlessUITests/ExportTests.cs
+++ b/tests/Beutl.HeadlessUITests/ExportTests.cs
@@ -950,7 +950,7 @@ public class ExportTests
             NotificationService.Handler = previousHandler;
             context.Finish();
             await execution.WaitAsync(TimeSpan.FromSeconds(5));
-            viewModel.Dispose();
+            await viewModel.DisposeAsync();
         }
     }
 
@@ -992,7 +992,7 @@ public class ExportTests
         {
             NotificationService.Handler = previousHandler;
             nextItem.Dispose();
-            viewModel.Dispose();
+            await viewModel.DisposeAsync();
         }
     }
 
@@ -1037,7 +1037,7 @@ public class ExportTests
         {
             viewModel.Items.CollectionChanged -= observer;
             nextItem.Dispose();
-            viewModel.Dispose();
+            await viewModel.DisposeAsync();
         }
     }
 

--- a/tests/Beutl.HeadlessUITests/ExportTests.cs
+++ b/tests/Beutl.HeadlessUITests/ExportTests.cs
@@ -158,7 +158,7 @@ public class ExportTests
         Scene scene = project.Items.OfType<Scene>().First();
         scene.Duration = TimeSpan.FromMilliseconds(200);
 
-        TestShell.Editor.ActivateTabItem(scene);
+        await TestShell.Editor.ActivateTabItemAsync(scene);
         HeadlessTestHelpers.Settle();
         var editor = (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value!;
 

--- a/tests/Beutl.HeadlessUITests/FileBrowserMultipleTabsTests.cs
+++ b/tests/Beutl.HeadlessUITests/FileBrowserMultipleTabsTests.cs
@@ -34,7 +34,7 @@ public class FileBrowserMultipleTabsTests
 
         TestShell.Editor.ActivateTabItem(scene);
         HeadlessTestHelpers.Settle();
-        return (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
+        return (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value!;
     }
 
     private static BeutlToolDockable[] FileBrowsers(EditViewModel editor)

--- a/tests/Beutl.HeadlessUITests/FileBrowserMultipleTabsTests.cs
+++ b/tests/Beutl.HeadlessUITests/FileBrowserMultipleTabsTests.cs
@@ -32,7 +32,7 @@ public class FileBrowserMultipleTabsTests
         HeadlessTestHelpers.Settle();
         Scene scene = project.Items.OfType<Scene>().First();
 
-        TestShell.Editor.ActivateTabItem(scene);
+        await TestShell.Editor.ActivateTabItemAsync(scene);
         HeadlessTestHelpers.Settle();
         return (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value!;
     }

--- a/tests/Beutl.HeadlessUITests/FileBrowserMultipleTabsTests.cs
+++ b/tests/Beutl.HeadlessUITests/FileBrowserMultipleTabsTests.cs
@@ -59,7 +59,7 @@ public class FileBrowserMultipleTabsTests
         EditViewModel editor = await OpenEditorForNewScene("filebrowser-second-tab");
         IToolDock left = editor.DockHost.Factory.GetAnchoredDock(DockAnchor.Left)!;
 
-        Assert.That(editor.DockHost.OpenToolTabFromExtension(FileBrowserTabExtension.Instance, left), Is.True);
+        Assert.That(await editor.DockHost.OpenToolTabFromExtensionAsync(FileBrowserTabExtension.Instance, left), Is.True);
         HeadlessTestHelpers.Settle();
 
         BeutlToolDockable[] browsers = FileBrowsers(editor);
@@ -76,7 +76,7 @@ public class FileBrowserMultipleTabsTests
         await TestReset.ResetShellAsync();
         EditViewModel editor = await OpenEditorForNewScene("filebrowser-titles");
         IToolDock left = editor.DockHost.Factory.GetAnchoredDock(DockAnchor.Left)!;
-        editor.DockHost.OpenToolTabFromExtension(FileBrowserTabExtension.Instance, left);
+        await editor.DockHost.OpenToolTabFromExtensionAsync(FileBrowserTabExtension.Instance, left);
         HeadlessTestHelpers.Settle();
 
         BeutlToolDockable[] browsers = FileBrowsers(editor);
@@ -107,7 +107,7 @@ public class FileBrowserMultipleTabsTests
         await TestReset.ResetShellAsync();
         EditViewModel editor = await OpenEditorForNewScene("filebrowser-roundtrip");
         IToolDock left = editor.DockHost.Factory.GetAnchoredDock(DockAnchor.Left)!;
-        editor.DockHost.OpenToolTabFromExtension(FileBrowserTabExtension.Instance, left);
+        await editor.DockHost.OpenToolTabFromExtensionAsync(FileBrowserTabExtension.Instance, left);
         HeadlessTestHelpers.Settle();
 
         BeutlToolDockable[] browsers = FileBrowsers(editor);
@@ -123,7 +123,7 @@ public class FileBrowserMultipleTabsTests
         var restored = new DockHostViewModel("filebrowser-roundtrip", editor);
         try
         {
-            restored.ReadFromJson(json);
+            await restored.ReadFromJsonAsync(json);
             HeadlessTestHelpers.Settle();
 
             string[] paths = restored.Factory.EnumerateTools()
@@ -136,7 +136,7 @@ public class FileBrowserMultipleTabsTests
         }
         finally
         {
-            restored.Dispose();
+            await restored.DisposeAsync();
         }
     }
 
@@ -160,7 +160,7 @@ public class FileBrowserMultipleTabsTests
         var restored = new DockHostViewModel("filebrowser-effectItem-id", editor);
         try
         {
-            restored.ReadFromJson(json);
+            await restored.ReadFromJsonAsync(json);
             HeadlessTestHelpers.Settle();
 
             BeutlToolDockable[] browsers = restored.Factory.EnumerateTools()
@@ -179,7 +179,7 @@ public class FileBrowserMultipleTabsTests
         }
         finally
         {
-            restored.Dispose();
+            await restored.DisposeAsync();
         }
     }
 
@@ -205,13 +205,13 @@ public class FileBrowserMultipleTabsTests
         await TestReset.ResetShellAsync();
         EditViewModel editor = await OpenEditorForNewScene("filebrowser-close-one");
         IToolDock left = editor.DockHost.Factory.GetAnchoredDock(DockAnchor.Left)!;
-        editor.DockHost.OpenToolTabFromExtension(FileBrowserTabExtension.Instance, left);
+        await editor.DockHost.OpenToolTabFromExtensionAsync(FileBrowserTabExtension.Instance, left);
         HeadlessTestHelpers.Settle();
 
         BeutlToolDockable[] browsers = FileBrowsers(editor);
         var survivor = (FileBrowserTabViewModel)browsers[1].ToolContext;
 
-        editor.DockHost.CloseToolTab(browsers[0].ToolContext);
+        await editor.DockHost.CloseToolTabAsync(browsers[0].ToolContext);
         HeadlessTestHelpers.Settle();
 
         survivor.NavigateToHome();

--- a/tests/Beutl.HeadlessUITests/MainViewModelShutdownTests.cs
+++ b/tests/Beutl.HeadlessUITests/MainViewModelShutdownTests.cs
@@ -137,4 +137,49 @@ public sealed class MainViewModelShutdownTests
         }
     }
 
+    [AvaloniaTest]
+    public async Task SynchronousAndAsynchronousDisposalJoinThePublishedTerminalTask()
+    {
+        await TestReset.ResetShellAsync();
+        var viewModel = new MainViewModel();
+
+        viewModel.Dispose();
+        Task first = viewModel.WaitForDisposalAsync();
+        Task second = viewModel.DisposeAsync().AsTask();
+
+        Assert.That(second, Is.SameAs(first));
+        await first.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public void DisposalAttemptsEveryOwnedComponentAndAggregatesFailures()
+    {
+        var attempted = new List<string>();
+
+        AggregateException? failure = Assert.ThrowsAsync<AggregateException>(async () =>
+            await MainViewModel.DisposeComponentsAsync(
+                () =>
+                {
+                    attempted.Add("palette");
+                    throw new InvalidOperationException("palette");
+                },
+                () => attempted.Add("agent"),
+                () =>
+                {
+                    attempted.Add("project");
+                    return Task.FromException(new InvalidOperationException("project"));
+                },
+                () =>
+                {
+                    attempted.Add("editor");
+                    return ValueTask.FromException(new InvalidOperationException("editor"));
+                },
+                () => attempted.Add("items")));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(attempted, Is.EqualTo(new[] { "palette", "agent", "project", "editor", "items" }));
+            Assert.That(failure!.InnerExceptions, Has.Count.EqualTo(3));
+        });
+    }
 }

--- a/tests/Beutl.HeadlessUITests/MainViewModelShutdownTests.cs
+++ b/tests/Beutl.HeadlessUITests/MainViewModelShutdownTests.cs
@@ -102,7 +102,7 @@ public sealed class MainViewModelShutdownTests
         Project project = (await viewModel.ProjectService.CreateProject(
             640, 480, 30, 44_100, "shutdown-editor", workspace))!;
         Scene scene = project.Items.OfType<Scene>().Single();
-        viewModel.EditorService.ActivateTabItem(scene);
+        await viewModel.EditorService.ActivateTabItemAsync(scene);
         HeadlessTestHelpers.Settle();
 
         try

--- a/tests/Beutl.HeadlessUITests/PlayerViewModelDisposalTests.cs
+++ b/tests/Beutl.HeadlessUITests/PlayerViewModelDisposalTests.cs
@@ -34,7 +34,7 @@ public class PlayerViewModelDisposalTests
         HeadlessTestHelpers.Settle();
         Scene scene = project.Items.OfType<Scene>().First();
 
-        TestShell.Editor.ActivateTabItem(scene);
+        await TestShell.Editor.ActivateTabItemAsync(scene);
         HeadlessTestHelpers.Settle();
         return (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
     }

--- a/tests/Beutl.HeadlessUITests/PreviewRenderErrorTests.cs
+++ b/tests/Beutl.HeadlessUITests/PreviewRenderErrorTests.cs
@@ -45,7 +45,7 @@ public class PreviewRenderErrorTests
 
         TestShell.Editor.ActivateTabItem(scene);
         HeadlessTestHelpers.Settle();
-        EditViewModel editor = (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
+        EditViewModel editor = (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value!;
 
         // Opening a scene queues a preview render that is dispatched asynchronously to the
         // render thread; when it succeeds it posts a clear of PreviewRenderError. Drain it

--- a/tests/Beutl.HeadlessUITests/PreviewRenderErrorTests.cs
+++ b/tests/Beutl.HeadlessUITests/PreviewRenderErrorTests.cs
@@ -43,7 +43,7 @@ public class PreviewRenderErrorTests
         HeadlessTestHelpers.Settle();
         Scene scene = project.Items.OfType<Scene>().First();
 
-        TestShell.Editor.ActivateTabItem(scene);
+        await TestShell.Editor.ActivateTabItemAsync(scene);
         HeadlessTestHelpers.Settle();
         EditViewModel editor = (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value!;
 

--- a/tests/Beutl.HeadlessUITests/PreviewRenderTests.cs
+++ b/tests/Beutl.HeadlessUITests/PreviewRenderTests.cs
@@ -37,7 +37,7 @@ public class PreviewRenderTests
 
         TestShell.Editor.ActivateTabItem(scene);
         HeadlessTestHelpers.Settle();
-        var editor = (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
+        var editor = (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value!;
 
         var adder = (IElementAdder)editor.GetService(typeof(IElementAdder))!;
         await adder.AddAsync([new ElementDescription(
@@ -86,7 +86,7 @@ public class PreviewRenderTests
         await ResetProjectAsync();
 
         Scene scene = await NewSceneWithRectangle("playerpreview");
-        var editor = (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
+        var editor = (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value!;
 
         Bitmap snapshot = RenderThread.Dispatcher.Invoke(() =>
         {

--- a/tests/Beutl.HeadlessUITests/PreviewRenderTests.cs
+++ b/tests/Beutl.HeadlessUITests/PreviewRenderTests.cs
@@ -35,7 +35,7 @@ public class PreviewRenderTests
         HeadlessTestHelpers.Settle();
         Scene scene = project.Items.OfType<Scene>().First();
 
-        TestShell.Editor.ActivateTabItem(scene);
+        await TestShell.Editor.ActivateTabItemAsync(scene);
         HeadlessTestHelpers.Settle();
         var editor = (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value!;
 

--- a/tests/Beutl.HeadlessUITests/SaveRoundTripTests.cs
+++ b/tests/Beutl.HeadlessUITests/SaveRoundTripTests.cs
@@ -34,7 +34,7 @@ public class SaveRoundTripTests
 
         TestShell.Editor.ActivateTabItem(scene);
         HeadlessTestHelpers.Settle();
-        var editor = (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
+        var editor = (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value!;
 
         var adder = (IElementAdder)editor.GetService(typeof(IElementAdder))!;
         await adder.AddAsync([new ElementDescription(
@@ -84,7 +84,7 @@ public class SaveRoundTripTests
 
         TestShell.Editor.ActivateTabItem(scene);
         HeadlessTestHelpers.Settle();
-        var editor = (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
+        var editor = (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value!;
 
         var adder = (IElementAdder)editor.GetService(typeof(IElementAdder))!;
         await adder.AddAsync([new ElementDescription(

--- a/tests/Beutl.HeadlessUITests/SaveRoundTripTests.cs
+++ b/tests/Beutl.HeadlessUITests/SaveRoundTripTests.cs
@@ -32,7 +32,7 @@ public class SaveRoundTripTests
         string projectFile = project.Uri!.LocalPath;
         Scene scene = project.Items.OfType<Scene>().First();
 
-        TestShell.Editor.ActivateTabItem(scene);
+        await TestShell.Editor.ActivateTabItemAsync(scene);
         HeadlessTestHelpers.Settle();
         var editor = (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value!;
 
@@ -82,7 +82,7 @@ public class SaveRoundTripTests
         HeadlessTestHelpers.Settle();
         Scene scene = project.Items.OfType<Scene>().First();
 
-        TestShell.Editor.ActivateTabItem(scene);
+        await TestShell.Editor.ActivateTabItemAsync(scene);
         HeadlessTestHelpers.Settle();
         var editor = (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value!;
 

--- a/tests/Beutl.HeadlessUITests/SceneEditorContextServicesTests.cs
+++ b/tests/Beutl.HeadlessUITests/SceneEditorContextServicesTests.cs
@@ -115,4 +115,36 @@ public class SceneEditorContextServicesTests
         await tab.DisposeAsync();
         HeadlessTestHelpers.Settle();
     }
+
+    [AvaloniaTest]
+    public async Task EditViewModelPublicationObserverCanWaitForDisposeWithoutDeadlock()
+    {
+        string workspace = Path.Combine(BeutlHomeIsolation.CurrentHome!, "context-publication-close");
+        Directory.CreateDirectory(workspace);
+        var scene = new Scene(640, 480, "context-publication-close")
+        {
+            Uri = new Uri(Path.Combine(workspace, "context-publication-close.scene"))
+        };
+        var extensionProvider = new ExtensionProvider();
+        var editorService = new EditorService(extensionProvider);
+        IEditorContextServices services = new EditorContextServices(editorService, extensionProvider);
+
+        Assert.That(
+            SceneEditorExtension.Instance.TryCreateContext(scene, services, out IEditorContext? context),
+            Is.True);
+        var gate = (IEditorContextPublicationGate)context!;
+        Task? close = null;
+
+        bool published = await Task.Run(() => gate.TryPublish(() =>
+        {
+            close = Task.Run(() => context!.DisposeAsync().AsTask());
+            close.GetAwaiter().GetResult();
+        })).WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.That(close, Is.Not.Null);
+        await close!.WaitAsync(TimeSpan.FromSeconds(5));
+        await context!.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.That(published, Is.False);
+        HeadlessTestHelpers.Settle();
+    }
 }

--- a/tests/Beutl.HeadlessUITests/SceneEditorContextServicesTests.cs
+++ b/tests/Beutl.HeadlessUITests/SceneEditorContextServicesTests.cs
@@ -89,4 +89,30 @@ public class SceneEditorContextServicesTests
             HeadlessTestHelpers.Settle();
         }
     }
+
+    [AvaloniaTest]
+    public async Task Context_disposal_before_tab_publication_is_not_published()
+    {
+        string workspace = Path.Combine(BeutlHomeIsolation.CurrentHome!, "publication-race");
+        Directory.CreateDirectory(workspace);
+        var scene = new Scene(640, 480, "publication-race")
+        {
+            Uri = new Uri(Path.Combine(workspace, "publication-race.scene"))
+        };
+        var extensionProvider = new ExtensionProvider();
+        var editorService = new EditorService(extensionProvider);
+        IEditorContextServices services = new EditorContextServices(editorService, extensionProvider);
+
+        Assert.That(
+            SceneEditorExtension.Instance.TryCreateContext(scene, services, out IEditorContext? context),
+            Is.True);
+        var tab = new EditorTabItem(context!);
+        await context!.DisposeAsync();
+
+        editorService.AddTabItem(tab);
+
+        Assert.That(editorService.TabItems, Does.Not.Contain(tab));
+        await tab.DisposeAsync();
+        HeadlessTestHelpers.Settle();
+    }
 }

--- a/tests/Beutl.HeadlessUITests/SceneEditorContextServicesTests.cs
+++ b/tests/Beutl.HeadlessUITests/SceneEditorContextServicesTests.cs
@@ -20,18 +20,34 @@ public class SceneEditorContextServicesTests
 {
     // An IEditorContextServices that is deliberately NOT the host's concrete EditorContextServices,
     // so the test exercises the by-type TryGetService path instead of a concrete downcast.
-    private sealed class FakeEditorContextServices(EditorService editorService, ExtensionProvider extensionProvider)
+    private sealed class FakeEditorContextServices(
+        EditorService editorService,
+        ExtensionProvider extensionProvider,
+        IEditorContextCloseService? closeService = null)
         : IEditorContextServices
     {
         public IExtensionProvider ExtensionProvider => extensionProvider;
 
-        public IEditorContextCloseService CloseService => editorService;
+        public IEditorContextCloseService CloseService => closeService ?? editorService;
 
         public bool TryGetService<T>([NotNullWhen(true)] out T? service)
             where T : class
         {
             service = editorService as T ?? extensionProvider as T;
             return service is not null;
+        }
+    }
+
+    private sealed class CountingCloseService(IEditorContextCloseService inner) : IEditorContextCloseService
+    {
+        public EditorContextHostToken HostToken => inner.HostToken;
+
+        public int RequestCount { get; private set; }
+
+        public EditorContextCloseRequest RequestClose(IEditorContext context)
+        {
+            RequestCount++;
+            return inner.RequestClose(context);
         }
     }
 
@@ -206,7 +222,7 @@ public class SceneEditorContextServicesTests
         var extensionProvider = new ExtensionProvider();
         var editorService = new EditorService(extensionProvider);
 
-        var viewModel = new EditViewModel(scene, editorService);
+        var viewModel = new EditViewModel(scene, editorService, editorService);
         try
         {
             Assert.Multiple(() =>
@@ -219,6 +235,48 @@ public class SceneEditorContextServicesTests
         finally
         {
             await viewModel.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+            HeadlessTestHelpers.Settle();
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task TryCreateContext_forwards_close_requests_to_supplied_close_service()
+    {
+        string workspace = Path.Combine(BeutlHomeIsolation.CurrentHome!, "supplied-close-service");
+        Directory.CreateDirectory(workspace);
+        var scene = new Scene(640, 480, "supplied-close-service")
+        {
+            Uri = new Uri(Path.Combine(workspace, "supplied-close-service.scene"))
+        };
+        var extensionProvider = new ExtensionProvider();
+        var editorService = new EditorService(extensionProvider);
+        var suppliedCloseService = new CountingCloseService(editorService);
+        IEditorContextServices services = new FakeEditorContextServices(
+            editorService,
+            extensionProvider,
+            suppliedCloseService);
+
+        Assert.That(
+            SceneEditorExtension.Instance.TryCreateContext(scene, services, out IEditorContext? context),
+            Is.True);
+        var tab = new EditorTabItem(context!);
+        editorService.AddTabItem(tab);
+
+        try
+        {
+            Assert.That(context!.CloseService.HostToken, Is.SameAs(suppliedCloseService.HostToken));
+
+            EditorContextCloseRequest request = context.CloseService.RequestClose(context);
+
+            Assert.That(suppliedCloseService.RequestCount, Is.EqualTo(1));
+            Assert.That(request.Status, Is.EqualTo(EditorContextCloseRequestStatus.Accepted));
+            await request.Completion.WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.That(editorService.TabItems, Is.Empty);
+        }
+        finally
+        {
+            await context!.DisposeAsync();
+            await tab.DisposeAsync();
             HeadlessTestHelpers.Settle();
         }
     }

--- a/tests/Beutl.HeadlessUITests/SceneEditorContextServicesTests.cs
+++ b/tests/Beutl.HeadlessUITests/SceneEditorContextServicesTests.cs
@@ -189,6 +189,41 @@ public class SceneEditorContextServicesTests
     }
 
     [AvaloniaTest]
+    public void EditViewModel_constructor_is_not_public()
+    {
+        Assert.That(typeof(EditViewModel).GetConstructors(), Is.Empty);
+    }
+
+    [AvaloniaTest]
+    public async Task EditViewModel_constructor_accepts_services_from_same_host()
+    {
+        string workspace = Path.Combine(BeutlHomeIsolation.CurrentHome!, "edit-view-model-host-match");
+        Directory.CreateDirectory(workspace);
+        var scene = new Scene(640, 480, "edit-view-model-host-match")
+        {
+            Uri = new Uri(Path.Combine(workspace, "edit-view-model-host-match.scene"))
+        };
+        var extensionProvider = new ExtensionProvider();
+        var editorService = new EditorService(extensionProvider);
+
+        var viewModel = new EditViewModel(scene, editorService);
+        try
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(viewModel.EditorService, Is.SameAs(editorService));
+                Assert.That(viewModel.CloseService.HostToken, Is.SameAs(editorService.HostToken));
+                Assert.That(viewModel.ExtensionProvider, Is.SameAs(extensionProvider));
+            });
+        }
+        finally
+        {
+            await viewModel.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+            HeadlessTestHelpers.Settle();
+        }
+    }
+
+    [AvaloniaTest]
     public async Task Context_disposal_before_tab_publication_is_not_published()
     {
         string workspace = Path.Combine(BeutlHomeIsolation.CurrentHome!, "publication-race");

--- a/tests/Beutl.HeadlessUITests/SceneEditorContextServicesTests.cs
+++ b/tests/Beutl.HeadlessUITests/SceneEditorContextServicesTests.cs
@@ -12,8 +12,9 @@ using Beutl.ViewModels;
 namespace Beutl.HeadlessUITests;
 
 // Guards that SceneEditorExtension.TryCreateContext resolves host services by type through
-// IEditorContextServices, so any implementation (including a test fake) is accepted, not only the
-// host's concrete EditorContextServices.
+// IEditorContextServices, so matching implementations (including a test fake) are accepted, not
+// only the host's concrete EditorContextServices. Host-token mismatches are rejected before context
+// construction.
 [TestFixture]
 public class SceneEditorContextServicesTests
 {
@@ -25,6 +26,24 @@ public class SceneEditorContextServicesTests
         public IExtensionProvider ExtensionProvider => extensionProvider;
 
         public IEditorContextCloseService CloseService => editorService;
+
+        public bool TryGetService<T>([NotNullWhen(true)] out T? service)
+            where T : class
+        {
+            service = editorService as T ?? extensionProvider as T;
+            return service is not null;
+        }
+    }
+
+    private sealed class MismatchedEditorContextServices(
+        EditorService editorService,
+        ExtensionProvider extensionProvider,
+        IEditorContextCloseService closeService)
+        : IEditorContextServices
+    {
+        public IExtensionProvider ExtensionProvider => extensionProvider;
+
+        public IEditorContextCloseService CloseService => closeService;
 
         public bool TryGetService<T>([NotNullWhen(true)] out T? service)
             where T : class
@@ -142,6 +161,34 @@ public class SceneEditorContextServicesTests
     }
 
     [AvaloniaTest]
+    public void TryCreateContext_rejects_mismatched_close_service_without_creating_context()
+    {
+        string workspace = Path.Combine(BeutlHomeIsolation.CurrentHome!, "mismatched-close-service");
+        Directory.CreateDirectory(workspace);
+        var scene = new Scene(640, 480, "mismatched-close-service")
+        {
+            Uri = new Uri(Path.Combine(workspace, "mismatched-close-service.scene"))
+        };
+
+        var extensionProvider = new ExtensionProvider();
+        var owner = new EditorService(extensionProvider);
+        var foreign = new EditorService(extensionProvider);
+        IEditorContextServices services = new MismatchedEditorContextServices(owner, extensionProvider, foreign);
+
+        bool created = SceneEditorExtension.Instance.TryCreateContext(scene, services, out IEditorContext? context);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(created, Is.False);
+            Assert.That(context, Is.Null);
+            Assert.That(owner.TabItems, Is.Empty);
+            Assert.That(foreign.TabItems, Is.Empty);
+        });
+
+        HeadlessTestHelpers.Settle();
+    }
+
+    [AvaloniaTest]
     public async Task Context_disposal_before_tab_publication_is_not_published()
     {
         string workspace = Path.Combine(BeutlHomeIsolation.CurrentHome!, "publication-race");
@@ -221,9 +268,10 @@ public class SceneEditorContextServicesTests
             beforeDispose.TrySetResult();
             releaseDispose.Task.GetAwaiter().GetResult();
         };
-        var closeService = (IEditorContextCloseService)editor.GetService(
-            typeof(IEditorContextCloseService))!;
+        IEditorContextCloseService closeService = editor.CloseService;
         Assert.That(editor.GetService(typeof(EditorService)), Is.Null);
+        Assert.That(editor.GetService(typeof(IEditorContextCloseService)), Is.Null);
+        Assert.That(editor.CloseService, Is.SameAs(closeService));
 
         Task<EditorContextCloseRequest> close = Task.Run(() => closeService.RequestClose(editor));
         await beforeDispose.Task.WaitAsync(TimeSpan.FromSeconds(5));
@@ -258,9 +306,6 @@ public class SceneEditorContextServicesTests
         var tab = new EditorTabItem(context!);
         editorService.AddTabItem(tab);
         var gate = (IEditorContextPublicationGate)context!;
-        Assert.That(
-            services.TryGetService<IEditorContextCloseService>(out IEditorContextCloseService? closeService),
-            Is.True);
         EditorContextCloseRequest closeRequest = default;
         bool requestReturned = false;
         bool completionWasPending = false;
@@ -271,7 +316,7 @@ public class SceneEditorContextServicesTests
             {
                 Dispatcher.UIThread.Invoke(() =>
                 {
-                    closeRequest = closeService!.RequestClose(context!);
+                    closeRequest = context!.CloseService.RequestClose(context);
                     requestReturned = true;
                     completionWasPending = !closeRequest.Completion.IsCompleted;
                 });
@@ -309,9 +354,6 @@ public class SceneEditorContextServicesTests
             Is.True);
         var tab = new EditorTabItem(context!);
         editorService.AddTabItem(tab);
-        Assert.That(
-            services.TryGetService<IEditorContextCloseService>(out IEditorContextCloseService? closeService),
-            Is.True);
         EditorContextCloseRequest closeRequest = default;
         using IDisposable observer = tab.IsSelected.Subscribe(selected =>
         {
@@ -319,7 +361,7 @@ public class SceneEditorContextServicesTests
             {
                 Dispatcher.UIThread.Invoke(() =>
                 {
-                    closeRequest = closeService!.RequestClose(context!);
+                    closeRequest = context!.CloseService.RequestClose(context);
                 });
             }
         });

--- a/tests/Beutl.HeadlessUITests/SceneEditorContextServicesTests.cs
+++ b/tests/Beutl.HeadlessUITests/SceneEditorContextServicesTests.cs
@@ -11,7 +11,7 @@ using Beutl.ViewModels;
 
 namespace Beutl.HeadlessUITests;
 
-// Guards that SceneEditorExtension.TryCreateContext resolves host services by type through
+// Guards that SceneEditorExtension.CreateContextAsync resolves host services by type through
 // IEditorContextServices, so matching implementations (including a test fake) are accepted, not
 // only the host's concrete EditorContextServices. Host-token mismatches are rejected before context
 // construction.
@@ -116,12 +116,10 @@ public class SceneEditorContextServicesTests
         var editorService = new EditorService(extensionProvider);
         IEditorContextServices services = new EditorContextServices(editorService, extensionProvider);
 
-        Assert.That(
-            SceneEditorExtension.Instance.TryCreateContext(firstScene, services, out IEditorContext? first),
-            Is.True);
-        Assert.That(
-            SceneEditorExtension.Instance.TryCreateContext(secondScene, services, out IEditorContext? second),
-            Is.True);
+        IEditorContext? first = await SceneEditorExtension.Instance.CreateContextAsync(firstScene, services);
+        IEditorContext? second = await SceneEditorExtension.Instance.CreateContextAsync(secondScene, services);
+        Assert.That(first, Is.Not.Null);
+        Assert.That(second, Is.Not.Null);
 
         try
         {
@@ -141,7 +139,7 @@ public class SceneEditorContextServicesTests
     }
 
     [AvaloniaTest]
-    public async Task TryCreateContext_accepts_a_non_concrete_IEditorContextServices()
+    public async Task CreateContextAsync_accepts_a_non_concrete_IEditorContextServices()
     {
         string workspace = Path.Combine(BeutlHomeIsolation.CurrentHome!, "trycreatecontext");
         Directory.CreateDirectory(workspace);
@@ -154,14 +152,14 @@ public class SceneEditorContextServicesTests
         var editorService = new EditorService(extensionProvider);
         IEditorContextServices services = new FakeEditorContextServices(editorService, extensionProvider);
 
-        bool created = SceneEditorExtension.Instance.TryCreateContext(scene, services, out IEditorContext? context);
+        IEditorContext? context = await SceneEditorExtension.Instance.CreateContextAsync(scene, services);
 
         try
         {
             Assert.That(
-                created,
-                Is.True,
-                "TryCreateContext must accept any IEditorContextServices, not only the host's concrete type.");
+                context,
+                Is.Not.Null,
+                "CreateContextAsync must accept any IEditorContextServices, not only the host's concrete type.");
             Assert.That(context, Is.Not.Null);
             Assert.That(context, Is.InstanceOf<EditViewModel>());
         }
@@ -177,7 +175,7 @@ public class SceneEditorContextServicesTests
     }
 
     [AvaloniaTest]
-    public void TryCreateContext_rejects_mismatched_close_service_without_creating_context()
+    public async Task CreateContextAsync_rejects_mismatched_close_service_without_creating_context()
     {
         string workspace = Path.Combine(BeutlHomeIsolation.CurrentHome!, "mismatched-close-service");
         Directory.CreateDirectory(workspace);
@@ -191,11 +189,10 @@ public class SceneEditorContextServicesTests
         var foreign = new EditorService(extensionProvider);
         IEditorContextServices services = new MismatchedEditorContextServices(owner, extensionProvider, foreign);
 
-        bool created = SceneEditorExtension.Instance.TryCreateContext(scene, services, out IEditorContext? context);
+        IEditorContext? context = await SceneEditorExtension.Instance.CreateContextAsync(scene, services);
 
         Assert.Multiple(() =>
         {
-            Assert.That(created, Is.False);
             Assert.That(context, Is.Null);
             Assert.That(owner.TabItems, Is.Empty);
             Assert.That(foreign.TabItems, Is.Empty);
@@ -240,7 +237,7 @@ public class SceneEditorContextServicesTests
     }
 
     [AvaloniaTest]
-    public async Task TryCreateContext_forwards_close_requests_to_supplied_close_service()
+    public async Task CreateContextAsync_forwards_close_requests_to_supplied_close_service()
     {
         string workspace = Path.Combine(BeutlHomeIsolation.CurrentHome!, "supplied-close-service");
         Directory.CreateDirectory(workspace);
@@ -256,9 +253,8 @@ public class SceneEditorContextServicesTests
             extensionProvider,
             suppliedCloseService);
 
-        Assert.That(
-            SceneEditorExtension.Instance.TryCreateContext(scene, services, out IEditorContext? context),
-            Is.True);
+        IEditorContext? context = await SceneEditorExtension.Instance.CreateContextAsync(scene, services);
+        Assert.That(context, Is.Not.Null);
         var tab = new EditorTabItem(context!);
         editorService.AddTabItem(tab);
 
@@ -294,9 +290,8 @@ public class SceneEditorContextServicesTests
         var editorService = new EditorService(extensionProvider);
         IEditorContextServices services = new EditorContextServices(editorService, extensionProvider);
 
-        Assert.That(
-            SceneEditorExtension.Instance.TryCreateContext(scene, services, out IEditorContext? context),
-            Is.True);
+        IEditorContext? context = await SceneEditorExtension.Instance.CreateContextAsync(scene, services);
+        Assert.That(context, Is.Not.Null);
         var tab = new EditorTabItem(context!);
         await context!.DisposeAsync();
 
@@ -320,9 +315,8 @@ public class SceneEditorContextServicesTests
         var editorService = new EditorService(extensionProvider);
         IEditorContextServices services = new EditorContextServices(editorService, extensionProvider);
 
-        Assert.That(
-            SceneEditorExtension.Instance.TryCreateContext(scene, services, out IEditorContext? context),
-            Is.True);
+        IEditorContext? context = await SceneEditorExtension.Instance.CreateContextAsync(scene, services);
+        Assert.That(context, Is.Not.Null);
         var tab = new EditorTabItem(context!);
         editorService.AddTabItem(tab);
 
@@ -348,9 +342,8 @@ public class SceneEditorContextServicesTests
         var extensionProvider = new ExtensionProvider();
         var editorService = new EditorService(extensionProvider);
         IEditorContextServices services = new EditorContextServices(editorService, extensionProvider);
-        Assert.That(
-            SceneEditorExtension.Instance.TryCreateContext(scene, services, out IEditorContext? context),
-            Is.True);
+        IEditorContext? context = await SceneEditorExtension.Instance.CreateContextAsync(scene, services);
+        Assert.That(context, Is.Not.Null);
         var editor = (EditViewModel)context!;
         Assert.That(editor.CloseService.HostToken, Is.SameAs(services.CloseService.HostToken));
         var tab = new EditorTabItem(editor);
@@ -393,9 +386,8 @@ public class SceneEditorContextServicesTests
         var editorService = new EditorService(extensionProvider);
         IEditorContextServices services = new EditorContextServices(editorService, extensionProvider);
 
-        Assert.That(
-            SceneEditorExtension.Instance.TryCreateContext(scene, services, out IEditorContext? context),
-            Is.True);
+        IEditorContext? context = await SceneEditorExtension.Instance.CreateContextAsync(scene, services);
+        Assert.That(context, Is.Not.Null);
         var tab = new EditorTabItem(context!);
         editorService.AddTabItem(tab);
         var gate = (IEditorContextPublicationGate)context!;
@@ -442,9 +434,8 @@ public class SceneEditorContextServicesTests
         var editorService = new EditorService(extensionProvider);
         IEditorContextServices services = new EditorContextServices(editorService, extensionProvider);
 
-        Assert.That(
-            SceneEditorExtension.Instance.TryCreateContext(scene, services, out IEditorContext? context),
-            Is.True);
+        IEditorContext? context = await SceneEditorExtension.Instance.CreateContextAsync(scene, services);
+        Assert.That(context, Is.Not.Null);
         var tab = new EditorTabItem(context!);
         editorService.AddTabItem(tab);
         EditorContextCloseRequest closeRequest = default;
@@ -461,7 +452,7 @@ public class SceneEditorContextServicesTests
 
         Task activation;
         using (ExecutionContext.SuppressFlow())
-            activation = Task.Run(() => editorService.ActivateTabItem(scene));
+            activation = Task.Run(() => editorService.ActivateTabItemAsync(scene));
 
         await activation.WaitAsync(TimeSpan.FromSeconds(5));
         await closeRequest.Completion.WaitAsync(TimeSpan.FromSeconds(5));

--- a/tests/Beutl.HeadlessUITests/SceneEditorContextServicesTests.cs
+++ b/tests/Beutl.HeadlessUITests/SceneEditorContextServicesTests.cs
@@ -24,6 +24,8 @@ public class SceneEditorContextServicesTests
     {
         public IExtensionProvider ExtensionProvider => extensionProvider;
 
+        public IEditorContextCloseService CloseService => editorService;
+
         public bool TryGetService<T>([NotNullWhen(true)] out T? service)
             where T : class
         {
@@ -50,6 +52,7 @@ public class SceneEditorContextServicesTests
                 services.TryGetService<IEditorContextCloseService>(out IEditorContextCloseService? closeService),
                 Is.True);
             Assert.That(closeService, Is.SameAs(editorService));
+            Assert.That(services.CloseService, Is.SameAs(editorService));
 
 
             Assert.That(services.TryGetService<IExtensionProvider>(out IExtensionProvider? resolvedInterface), Is.True);
@@ -58,6 +61,47 @@ public class SceneEditorContextServicesTests
             Assert.That(services.TryGetService<string>(out string? missing), Is.False);
             Assert.That(missing, Is.Null);
         });
+    }
+
+    [AvaloniaTest]
+    public async Task ContextCloseService_rejects_a_foreign_context()
+    {
+        string workspace = Path.Combine(BeutlHomeIsolation.CurrentHome!, "foreign-context-close");
+        Directory.CreateDirectory(workspace);
+        var firstScene = new Scene(640, 480, "first")
+        {
+            Uri = new Uri(Path.Combine(workspace, "first.scene"))
+        };
+        var secondScene = new Scene(640, 480, "second")
+        {
+            Uri = new Uri(Path.Combine(workspace, "second.scene"))
+        };
+        var extensionProvider = new ExtensionProvider();
+        var editorService = new EditorService(extensionProvider);
+        IEditorContextServices services = new EditorContextServices(editorService, extensionProvider);
+
+        Assert.That(
+            SceneEditorExtension.Instance.TryCreateContext(firstScene, services, out IEditorContext? first),
+            Is.True);
+        Assert.That(
+            SceneEditorExtension.Instance.TryCreateContext(secondScene, services, out IEditorContext? second),
+            Is.True);
+
+        try
+        {
+            EditorContextCloseRequest request = first!.CloseService.RequestClose(second!);
+            Assert.Multiple(() =>
+            {
+                Assert.That(request.Status, Is.EqualTo(EditorContextCloseRequestStatus.NotOwned));
+                Assert.That(request.Completion.IsCompletedSuccessfully, Is.True);
+                Assert.That(((EditViewModel)second!).IsDisposeRequested, Is.False);
+            });
+        }
+        finally
+        {
+            await first!.DisposeAsync();
+            await second!.DisposeAsync();
+        }
     }
 
     [AvaloniaTest]
@@ -177,6 +221,7 @@ public class SceneEditorContextServicesTests
         };
         var closeService = (IEditorContextCloseService)editor.GetService(
             typeof(IEditorContextCloseService))!;
+        Assert.That(editor.GetService(typeof(EditorService)), Is.Null);
 
         Task<EditorContextCloseRequest> close = Task.Run(() => closeService.RequestClose(editor));
         await beforeDispose.Task.WaitAsync(TimeSpan.FromSeconds(5));

--- a/tests/Beutl.HeadlessUITests/SceneEditorContextServicesTests.cs
+++ b/tests/Beutl.HeadlessUITests/SceneEditorContextServicesTests.cs
@@ -53,6 +53,7 @@ public class SceneEditorContextServicesTests
                 Is.True);
             Assert.That(closeService, Is.SameAs(editorService));
             Assert.That(services.CloseService, Is.SameAs(editorService));
+            Assert.That(services.CloseService.HostToken, Is.SameAs(editorService.HostToken));
 
 
             Assert.That(services.TryGetService<IExtensionProvider>(out IExtensionProvider? resolvedInterface), Is.True);
@@ -211,6 +212,7 @@ public class SceneEditorContextServicesTests
             SceneEditorExtension.Instance.TryCreateContext(scene, services, out IEditorContext? context),
             Is.True);
         var editor = (EditViewModel)context!;
+        Assert.That(editor.CloseService.HostToken, Is.SameAs(services.CloseService.HostToken));
         var tab = new EditorTabItem(editor);
         var beforeDispose = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var releaseDispose = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/tests/Beutl.HeadlessUITests/SceneEditorContextServicesTests.cs
+++ b/tests/Beutl.HeadlessUITests/SceneEditorContextServicesTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using Avalonia.Headless.NUnit;
+using Avalonia.Threading;
 using Beutl.Api.Services;
 using Beutl.Extensibility;
 using Beutl.ProjectSystem;
@@ -45,6 +46,11 @@ public class SceneEditorContextServicesTests
 
             Assert.That(services.TryGetService<ExtensionProvider>(out ExtensionProvider? resolvedProvider), Is.False);
             Assert.That(resolvedProvider, Is.Null);
+            Assert.That(
+                services.TryGetService<IEditorContextCloseService>(out IEditorContextCloseService? closeService),
+                Is.True);
+            Assert.That(closeService, Is.SameAs(editorService));
+
 
             Assert.That(services.TryGetService<IExtensionProvider>(out IExtensionProvider? resolvedInterface), Is.True);
             Assert.That(resolvedInterface, Is.SameAs(extensionProvider));
@@ -117,7 +123,77 @@ public class SceneEditorContextServicesTests
     }
 
     [AvaloniaTest]
-    public async Task EditViewModelPublicationObserverCanWaitForDisposeWithoutDeadlock()
+    public async Task AttachedContextDisposalRemovesRegisteredTab()
+    {
+        string workspace = Path.Combine(BeutlHomeIsolation.CurrentHome!, "registered-context-close");
+        Directory.CreateDirectory(workspace);
+        var scene = new Scene(640, 480, "registered-context-close")
+        {
+            Uri = new Uri(Path.Combine(workspace, "registered-context-close.scene"))
+        };
+        var extensionProvider = new ExtensionProvider();
+        var editorService = new EditorService(extensionProvider);
+        IEditorContextServices services = new EditorContextServices(editorService, extensionProvider);
+
+        Assert.That(
+            SceneEditorExtension.Instance.TryCreateContext(scene, services, out IEditorContext? context),
+            Is.True);
+        var tab = new EditorTabItem(context!);
+        editorService.AddTabItem(tab);
+
+        await context!.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+        await tab.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Multiple(() =>
+        {
+            Assert.That(editorService.TabItems, Is.Empty);
+            Assert.That(editorService.SelectedTabItem.Value, Is.Null);
+        });
+        HeadlessTestHelpers.Settle();
+    }
+
+    [AvaloniaTest]
+    public async Task PreOwnershipCloseRechecksAConcurrentInitialClaim()
+    {
+        string workspace = Path.Combine(BeutlHomeIsolation.CurrentHome!, "preownership-close-claim");
+        Directory.CreateDirectory(workspace);
+        var scene = new Scene(640, 480, "preownership-close-claim")
+        {
+            Uri = new Uri(Path.Combine(workspace, "preownership-close-claim.scene"))
+        };
+        var extensionProvider = new ExtensionProvider();
+        var editorService = new EditorService(extensionProvider);
+        IEditorContextServices services = new EditorContextServices(editorService, extensionProvider);
+        Assert.That(
+            SceneEditorExtension.Instance.TryCreateContext(scene, services, out IEditorContext? context),
+            Is.True);
+        var editor = (EditViewModel)context!;
+        var tab = new EditorTabItem(editor);
+        var beforeDispose = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseDispose = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        editor.BeforePreOwnershipCloseStart = () =>
+        {
+            beforeDispose.TrySetResult();
+            releaseDispose.Task.GetAwaiter().GetResult();
+        };
+        var closeService = (IEditorContextCloseService)editor.GetService(
+            typeof(IEditorContextCloseService))!;
+
+        Task<EditorContextCloseRequest> close = Task.Run(() => closeService.RequestClose(editor));
+        await beforeDispose.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        editorService.AddTabItem(tab);
+        releaseDispose.TrySetResult();
+
+        EditorContextCloseRequest request = await close.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.That(
+            request.Status,
+            Is.AnyOf(EditorContextCloseRequestStatus.Accepted, EditorContextCloseRequestStatus.AlreadyClosing));
+        await request.Completion.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.That(editorService.TabItems, Is.Empty);
+        HeadlessTestHelpers.Settle();
+    }
+
+    [AvaloniaTest]
+    public async Task EditViewModelPublicationObserverCanRequestCloseAcrossDispatcher()
     {
         string workspace = Path.Combine(BeutlHomeIsolation.CurrentHome!, "context-publication-close");
         Directory.CreateDirectory(workspace);
@@ -132,19 +208,87 @@ public class SceneEditorContextServicesTests
         Assert.That(
             SceneEditorExtension.Instance.TryCreateContext(scene, services, out IEditorContext? context),
             Is.True);
+        var tab = new EditorTabItem(context!);
+        editorService.AddTabItem(tab);
         var gate = (IEditorContextPublicationGate)context!;
-        Task? close = null;
-
-        bool published = await Task.Run(() => gate.TryPublish(() =>
+        Assert.That(
+            services.TryGetService<IEditorContextCloseService>(out IEditorContextCloseService? closeService),
+            Is.True);
+        EditorContextCloseRequest closeRequest = default;
+        bool requestReturned = false;
+        bool completionWasPending = false;
+        Task<bool> publication;
+        using (ExecutionContext.SuppressFlow())
         {
-            close = Task.Run(() => context!.DisposeAsync().AsTask());
-            close.GetAwaiter().GetResult();
-        })).WaitAsync(TimeSpan.FromSeconds(5));
+            publication = Task.Run(() => gate.TryPublish(() =>
+            {
+                Dispatcher.UIThread.Invoke(() =>
+                {
+                    closeRequest = closeService!.RequestClose(context!);
+                    requestReturned = true;
+                    completionWasPending = !closeRequest.Completion.IsCompleted;
+                });
+            }));
+        }
 
-        Assert.That(close, Is.Not.Null);
-        await close!.WaitAsync(TimeSpan.FromSeconds(5));
-        await context!.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
-        Assert.That(published, Is.False);
+        bool published = await publication.WaitAsync(TimeSpan.FromSeconds(5));
+        await closeRequest.Completion.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Multiple(() =>
+        {
+            Assert.That(requestReturned, Is.True);
+            Assert.That(completionWasPending, Is.True);
+            Assert.That(closeRequest.Status, Is.EqualTo(EditorContextCloseRequestStatus.Accepted));
+            Assert.That(published, Is.False);
+            Assert.That(editorService.TabItems, Is.Empty);
+        });
+        HeadlessTestHelpers.Settle();
+    }
+
+    [AvaloniaTest]
+    public async Task TabSelectionObserverCanDispatchCloseWithoutExecutionContext()
+    {
+        string workspace = Path.Combine(BeutlHomeIsolation.CurrentHome!, "tab-publication-dispatch-close");
+        Directory.CreateDirectory(workspace);
+        var scene = new Scene(640, 480, "tab-publication-dispatch-close")
+        {
+            Uri = new Uri(Path.Combine(workspace, "tab-publication-dispatch-close.scene"))
+        };
+        var extensionProvider = new ExtensionProvider();
+        var editorService = new EditorService(extensionProvider);
+        IEditorContextServices services = new EditorContextServices(editorService, extensionProvider);
+
+        Assert.That(
+            SceneEditorExtension.Instance.TryCreateContext(scene, services, out IEditorContext? context),
+            Is.True);
+        var tab = new EditorTabItem(context!);
+        editorService.AddTabItem(tab);
+        Assert.That(
+            services.TryGetService<IEditorContextCloseService>(out IEditorContextCloseService? closeService),
+            Is.True);
+        EditorContextCloseRequest closeRequest = default;
+        using IDisposable observer = tab.IsSelected.Subscribe(selected =>
+        {
+            if (selected)
+            {
+                Dispatcher.UIThread.Invoke(() =>
+                {
+                    closeRequest = closeService!.RequestClose(context!);
+                });
+            }
+        });
+
+        Task activation;
+        using (ExecutionContext.SuppressFlow())
+            activation = Task.Run(() => editorService.ActivateTabItem(scene));
+
+        await activation.WaitAsync(TimeSpan.FromSeconds(5));
+        await closeRequest.Completion.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Multiple(() =>
+        {
+            Assert.That(closeRequest.Status, Is.EqualTo(EditorContextCloseRequestStatus.Accepted));
+            Assert.That(editorService.TabItems, Is.Empty);
+            Assert.That(editorService.SelectedTabItem.Value, Is.Null);
+        });
         HeadlessTestHelpers.Settle();
     }
 }

--- a/tests/Beutl.HeadlessUITests/SelectedDrawableRenderTests.cs
+++ b/tests/Beutl.HeadlessUITests/SelectedDrawableRenderTests.cs
@@ -31,7 +31,7 @@ public class SelectedDrawableRenderTests
         HeadlessTestHelpers.Settle();
         Scene scene = project.Items.OfType<Scene>().First();
 
-        TestShell.Editor.ActivateTabItem(scene);
+        await TestShell.Editor.ActivateTabItemAsync(scene);
         HeadlessTestHelpers.Settle();
         return (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
     }

--- a/tests/Beutl.HeadlessUITests/ShellSmokeTests.cs
+++ b/tests/Beutl.HeadlessUITests/ShellSmokeTests.cs
@@ -47,7 +47,7 @@ public class ShellSmokeTests
         HeadlessTestHelpers.Settle();
         Scene scene = project!.Items.OfType<Scene>().First();
 
-        TestShell.Editor.ActivateTabItem(scene);
+        await TestShell.Editor.ActivateTabItemAsync(scene);
         HeadlessTestHelpers.Settle();
 
         Assert.That(TestShell.Editor.TabItems, Is.Not.Empty);

--- a/tests/Beutl.HeadlessUITests/ShellViewTests.cs
+++ b/tests/Beutl.HeadlessUITests/ShellViewTests.cs
@@ -35,7 +35,7 @@ public class ShellViewTests
 
         TestShell.Editor.ActivateTabItem(scene);
         HeadlessTestHelpers.Settle();
-        return (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
+        return (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value!;
     }
 
     [AvaloniaTest]

--- a/tests/Beutl.HeadlessUITests/ShellViewTests.cs
+++ b/tests/Beutl.HeadlessUITests/ShellViewTests.cs
@@ -33,7 +33,7 @@ public class ShellViewTests
         HeadlessTestHelpers.Settle();
         Scene scene = project.Items.OfType<Scene>().First();
 
-        TestShell.Editor.ActivateTabItem(scene);
+        await TestShell.Editor.ActivateTabItemAsync(scene);
         HeadlessTestHelpers.Settle();
         return (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value!;
     }

--- a/tests/Beutl.HeadlessUITests/TerminalTabLifecycleTests.cs
+++ b/tests/Beutl.HeadlessUITests/TerminalTabLifecycleTests.cs
@@ -48,7 +48,7 @@ public class TerminalTabLifecycleTests
 
         TestShell.Editor.ActivateTabItem(scene);
         HeadlessTestHelpers.Settle();
-        return (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
+        return (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value!;
     }
 
     [AvaloniaTest]

--- a/tests/Beutl.HeadlessUITests/TerminalTabLifecycleTests.cs
+++ b/tests/Beutl.HeadlessUITests/TerminalTabLifecycleTests.cs
@@ -64,7 +64,7 @@ public class TerminalTabLifecycleTests
         EditViewModel editor = await OpenEditorForNewScene("terminal-tab-lifecycle");
         IToolDock bottomDock = editor.DockHost.Factory.GetAnchoredDock(DockAnchor.Bottom)!;
         var terminalContext = new TerminalTabViewModel(editor);
-        Assert.That(editor.DockHost.OpenToolTab(terminalContext, bottomDock), Is.True);
+        Assert.That(await editor.DockHost.OpenToolTabAsync(terminalContext, bottomDock), Is.True);
 
         var terminalDockable = editor.DockHost.Factory.EnumerateTools()
             .Single(item => ReferenceEquals(item.ToolContext, terminalContext));
@@ -108,7 +108,7 @@ public class TerminalTabLifecycleTests
         }
         finally
         {
-            editor.CloseToolTab(terminalContext);
+            await editor.CloseToolTabAsync(terminalContext);
             window.Close();
             HeadlessTestHelpers.Settle();
         }
@@ -121,7 +121,7 @@ public class TerminalTabLifecycleTests
         EditViewModel editor = await OpenEditorForNewScene("tool-tab-content-lifecycle");
         IToolDock bottomDock = editor.DockHost.Factory.GetAnchoredDock(DockAnchor.Bottom)!;
         var transientContext = new TransientToolContext();
-        Assert.That(editor.DockHost.OpenToolTab(transientContext, bottomDock), Is.True);
+        Assert.That(await editor.DockHost.OpenToolTabAsync(transientContext, bottomDock), Is.True);
         BeutlToolDockable timelineDockable = editor.DockHost.Factory.EnumerateTools()
             .Single(item => ReferenceEquals(item.ToolContext.Extension, TimelineTabExtension.Instance));
         BeutlToolDockable transientDockable = editor.DockHost.Factory.EnumerateTools()
@@ -150,7 +150,7 @@ public class TerminalTabLifecycleTests
         }
         finally
         {
-            editor.CloseToolTab(transientContext);
+            await editor.CloseToolTabAsync(transientContext);
             window.Close();
             HeadlessTestHelpers.Settle();
         }
@@ -168,7 +168,7 @@ public class TerminalTabLifecycleTests
         EditViewModel editor = await OpenEditorForNewScene("terminal-tab-theme-resources");
         IToolDock bottomDock = editor.DockHost.Factory.GetAnchoredDock(DockAnchor.Bottom)!;
         var terminalContext = new TerminalTabViewModel(editor);
-        Assert.That(editor.DockHost.OpenToolTab(terminalContext, bottomDock), Is.True);
+        Assert.That(await editor.DockHost.OpenToolTabAsync(terminalContext, bottomDock), Is.True);
         var terminalDockable = editor.DockHost.Factory.EnumerateTools()
             .Single(item => ReferenceEquals(item.ToolContext, terminalContext));
         var view = new EditView { DataContext = editor };
@@ -208,7 +208,7 @@ public class TerminalTabLifecycleTests
         finally
         {
             currentApp.RequestedThemeVariant = originalVariant;
-            editor.CloseToolTab(terminalContext);
+            await editor.CloseToolTabAsync(terminalContext);
             window.Close();
             HeadlessTestHelpers.Settle();
         }
@@ -246,9 +246,10 @@ public class TerminalTabLifecycleTests
 
         public IReadOnlyReactiveProperty<string> Header { get; } = new ReactivePropertySlim<string>("Transient");
 
-        public void Dispose()
+        public ValueTask DisposeAsync()
         {
             IsSelected.Dispose();
+            return ValueTask.CompletedTask;
         }
 
         public object? GetService(Type serviceType) => null;

--- a/tests/Beutl.HeadlessUITests/TerminalTabLifecycleTests.cs
+++ b/tests/Beutl.HeadlessUITests/TerminalTabLifecycleTests.cs
@@ -46,7 +46,7 @@ public class TerminalTabLifecycleTests
         HeadlessTestHelpers.Settle();
         Scene scene = project.Items.OfType<Scene>().First();
 
-        TestShell.Editor.ActivateTabItem(scene);
+        await TestShell.Editor.ActivateTabItemAsync(scene);
         HeadlessTestHelpers.Settle();
         return (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value!;
     }

--- a/tests/Beutl.HeadlessUITests/TestReset.cs
+++ b/tests/Beutl.HeadlessUITests/TestReset.cs
@@ -34,7 +34,6 @@ internal static class TestReset
     // blocking the UI thread on it would deadlock against playback callbacks posted to the dispatcher.
     private static async Task DisposeOpenEditorTabsAsync()
     {
-        TestShell.Editor.SelectedTabItem.Value = null;
         foreach (EditorTabItem tab in TestShell.Editor.TabItems.ToArray())
         {
             await TestShell.Editor.CloseTabItem(tab);

--- a/tests/Beutl.HeadlessUITests/ThemeCaptureTests.cs
+++ b/tests/Beutl.HeadlessUITests/ThemeCaptureTests.cs
@@ -82,7 +82,7 @@ public class ThemeCaptureTests
 
         TestShell.Editor.ActivateTabItem(scene);
         HeadlessTestHelpers.Settle();
-        return (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
+        return (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value!;
     }
 
     private static async Task AddRectangle(EditViewModel editor, TimeSpan start, int layer)

--- a/tests/Beutl.HeadlessUITests/ThemeCaptureTests.cs
+++ b/tests/Beutl.HeadlessUITests/ThemeCaptureTests.cs
@@ -438,7 +438,7 @@ public class ThemeCaptureTests
 
         FileBrowserTabViewModel? browser = editor.FindToolTab<FileBrowserTabViewModel>();
         Assert.That(browser, Is.Not.Null, "File Browser tab missing from the default layout.");
-        editor.OpenToolTab(browser!);
+        await editor.OpenToolTabAsync(browser!);
         HeadlessTestHelpers.Settle();
 
         Project project = editor.Scene.FindRequiredHierarchicalParent<Project>();

--- a/tests/Beutl.HeadlessUITests/ThemeCaptureTests.cs
+++ b/tests/Beutl.HeadlessUITests/ThemeCaptureTests.cs
@@ -80,7 +80,7 @@ public class ThemeCaptureTests
         HeadlessTestHelpers.Settle();
         Scene scene = project.Items.OfType<Scene>().First();
 
-        TestShell.Editor.ActivateTabItem(scene);
+        await TestShell.Editor.ActivateTabItemAsync(scene);
         HeadlessTestHelpers.Settle();
         return (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value!;
     }

--- a/tests/Beutl.HeadlessUITests/ToolTabCallbackTests.cs
+++ b/tests/Beutl.HeadlessUITests/ToolTabCallbackTests.cs
@@ -1,0 +1,141 @@
+﻿using System.Reflection;
+using Avalonia.Headless.NUnit;
+using Beutl.Editor.Components.GraphEditorTab.ViewModels;
+using Beutl.Editor.Components.Helpers;
+using Beutl.Editor.Components.LibraryTab.ViewModels;
+using Beutl.Extensibility;
+using Beutl.ProjectSystem;
+using Beutl.Testing.Headless;
+using Reactive.Bindings;
+
+namespace Beutl.HeadlessUITests;
+
+[TestFixture]
+public class ToolTabCallbackTests
+{
+    [AvaloniaTest]
+    [TestCase(false)]
+    [TestCase(true)]
+    public async Task Rejected_factory_result_is_cleaned_without_disposing_a_foreign_tool(bool throws)
+    {
+        await TestReset.ResetShellAsync();
+        var editor = new FailingEditorContext();
+        var tool = new RejectedTool();
+        var extension = new RejectingExtension(tool, throws);
+        var owner = new ToolContextHostToken();
+        Assert.That(owner.TryAcquireContext(tool, out var lease), Is.True);
+        using (lease)
+        {
+            await ToolTabCallback.OpenFromExtensionAsync(editor, extension);
+            Assert.That(tool.DisposeCalls, Is.Zero);
+        }
+        await ToolTabCallback.OpenFromExtensionAsync(editor, extension);
+        Assert.That(tool.DisposeCalls, Is.EqualTo(1));
+    }
+    [AvaloniaTest]
+    public async Task Both_synchronous_and_asynchronous_callback_failures_are_contained()
+    {
+        await TestReset.ResetShellAsync();
+        await ToolTabCallback.RunAsync(() => throw new InvalidOperationException("synchronous callback"));
+        await ToolTabCallback.RunAsync(async () =>
+        {
+            await Task.Yield();
+            throw new InvalidOperationException("asynchronous callback");
+        });
+    }
+
+    [AvaloniaTest]
+    [TestCase("OnElementDetached")]
+    [TestCase("OnAnimationDetached")]
+    public async Task Graph_detach_callback_contains_asynchronous_close_failure(string methodName)
+    {
+        await TestReset.ResetShellAsync();
+        var editor = new FailingEditorContext();
+        var graph = new GraphEditorTabViewModel(editor);
+        try
+        {
+            typeof(GraphEditorTabViewModel).GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Instance)!
+                .Invoke(graph, [null, null]);
+            await editor.CloseStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            await Task.Yield();
+            HeadlessTestHelpers.Settle();
+            Assert.That(editor.CloseCalls, Is.EqualTo(1));
+        }
+        finally
+        {
+            await graph.DisposeAsync();
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task Library_disposal_drains_search_admission_and_rejects_late_searches()
+    {
+        await TestReset.ResetShellAsync();
+        var library = new LibraryTabViewModel(new FailingEditorContext());
+        var gate = (SemaphoreSlim)typeof(LibraryTabViewModel)
+            .GetField("_asyncLock", BindingFlags.NonPublic | BindingFlags.Instance)!.GetValue(library)!;
+        await gate.WaitAsync();
+        Task search = library.Search("rectangle", CancellationToken.None);
+        Task disposal = library.DisposeAsync().AsTask();
+        Assert.That(disposal.IsCompleted, Is.False);
+        gate.Release();
+        await Task.WhenAll(search, disposal).WaitAsync(TimeSpan.FromSeconds(5));
+        await library.Search("rectangle", CancellationToken.None);
+        Assert.That(library.AllItems, Is.Empty);
+        Assert.That(library.SearchResult, Is.Empty);
+    }
+
+    private sealed class FailingEditorContext : IEditorContext
+    {
+        public TaskCompletionSource CloseStarted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public int CloseCalls { get; private set; }
+        public CoreObject Object { get; } = new Scene();
+        public EditorExtension Extension => throw new NotSupportedException();
+        public IEditorContextCloseService CloseService => TestShell.Editor;
+        public IReactiveProperty<bool> IsEnabled { get; } = new ReactivePropertySlim<bool>(true);
+        public IKnownEditorCommands? Commands => null;
+        public object? GetService(Type serviceType) => null;
+        public T? FindToolTab<T>() where T : IToolContext => default;
+        public T? FindToolTab<T>(Func<T, bool> condition) where T : IToolContext => default;
+        public ValueTask<bool> OpenToolTabAsync(IToolContext item) => ValueTask.FromResult(false);
+        public async ValueTask CloseToolTabAsync(IToolContext item)
+        {
+            CloseCalls++;
+            CloseStarted.TrySetResult();
+            await Task.Yield();
+            throw new InvalidOperationException("close callback");
+        }
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    private sealed class RejectedTool : IToolContext
+    {
+        public int DisposeCalls { get; private set; }
+        public ToolTabExtension Extension => throw new NotSupportedException();
+        public IReactiveProperty<bool> IsSelected { get; } = new ReactivePropertySlim<bool>();
+        public IReadOnlyReactiveProperty<string> Header { get; } = new ReactivePropertySlim<string>("Rejected");
+        public ValueTask DisposeAsync() { DisposeCalls++; return ValueTask.CompletedTask; }
+        public object? GetService(Type serviceType) => null;
+        public void ReadFromJson(System.Text.Json.Nodes.JsonObject json) { }
+        public void WriteToJson(System.Text.Json.Nodes.JsonObject json) { }
+    }
+
+    private sealed class RejectingExtension(IToolContext tool, bool throws) : ToolTabExtension
+    {
+        public override bool CanMultiple => true;
+        public override bool TryCreateContext(IEditorContext editor,
+            [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out IToolContext? context)
+        {
+            context = tool;
+            if (throws)
+                throw new InvalidOperationException("factory failed after allocation");
+            return false;
+        }
+        public override bool TryCreateContent(IEditorContext editor,
+            [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Avalonia.Controls.Control? control)
+        {
+            control = null;
+            return false;
+        }
+    }
+}

--- a/tests/Beutl.HeadlessUITests/ToolTabHeaderTests.cs
+++ b/tests/Beutl.HeadlessUITests/ToolTabHeaderTests.cs
@@ -48,7 +48,7 @@ public class ToolTabHeaderTests
         Assert.That(dockable.Title, Is.EqualTo("second"));
 
         // Keep the source alive so this verifies the dockable's unsubscribe.
-        dockable.Dispose();
+        await dockable.DisposeAsync();
         context.HeaderSource.Value = "after-dispose";
         Assert.Multiple(() =>
         {
@@ -66,7 +66,7 @@ public class ToolTabHeaderTests
         EditViewModel editor = await OpenEditorForNewScene("tooltab-header-blank");
 
         var context = new FakeToolContext(string.Empty);
-        using var dockable = new BeutlToolDockable(context, editor);
+        await using var dockable = new BeutlToolDockable(context, editor);
 
         Assert.That(dockable.Title, Is.EqualTo(FakeToolExtension.Instance.Header));
 
@@ -84,13 +84,83 @@ public class ToolTabHeaderTests
         EditViewModel editor = await OpenEditorForNewScene("tooltab-header-blank-extension");
 
         var context = new FakeToolContext(string.Empty, BlankHeaderToolExtension.Instance);
-        using var dockable = new BeutlToolDockable(context, editor);
+        await using var dockable = new BeutlToolDockable(context, editor);
 
         Assert.Multiple(() =>
         {
             Assert.That(dockable.Title, Is.EqualTo(BlankHeaderToolExtension.Instance.DisplayName));
             Assert.That(dockable.Title, Is.Not.EqualTo(BlankHeaderToolExtension.Instance.Name));
         });
+    }
+
+    [AvaloniaTest]
+    public async Task ToolDisposalCanReenterCloseWithoutWaitingOnItself()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditorForNewScene("tooltab-reentrant-close");
+        var context = new FakeToolContext("reentrant");
+        Assert.That(await editor.OpenToolTabAsync(context), Is.True);
+        context.OnDispose = () => editor.CloseToolTabAsync(context);
+
+        await editor.CloseToolTabAsync(context).AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.That(context.DisposeCount, Is.EqualTo(1));
+    }
+
+    [AvaloniaTest]
+    public async Task LayoutTeardownAllowsOneToolToCloseAnotherWithoutParentCycle()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditorForNewScene("tooltab-reentrant-sibling-close");
+        var first = new FakeToolContext("first");
+        var second = new FakeToolContext("second");
+        Assert.That(await editor.OpenToolTabAsync(first), Is.True);
+        Assert.That(await editor.OpenToolTabAsync(second), Is.True);
+        first.OnDispose = () => editor.CloseToolTabAsync(second);
+
+        await editor.DockHost.ResetLayoutAsync().WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(first.DisposeCount, Is.EqualTo(1));
+            Assert.That(second.DisposeCount, Is.EqualTo(1));
+        });
+    }
+
+    [AvaloniaTest]
+    public async Task LayoutTeardownAllowsMutualToolCloseWithoutCycle()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditorForNewScene("tooltab-mutual-close");
+        var first = new FakeToolContext("first");
+        var second = new FakeToolContext("second");
+        Assert.That(await editor.OpenToolTabAsync(first), Is.True);
+        Assert.That(await editor.OpenToolTabAsync(second), Is.True);
+        first.OnDispose = () => editor.CloseToolTabAsync(second);
+        second.OnDispose = () => editor.CloseToolTabAsync(first);
+
+        await editor.DockHost.ResetLayoutAsync().WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(first.DisposeCount, Is.EqualTo(1));
+            Assert.That(second.DisposeCount, Is.EqualTo(1));
+        });
+    }
+
+    [AvaloniaTest]
+    public async Task ToolDisposalCanRequestEditorDisposalWithoutParentSelfWait()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditorForNewScene("tooltab-reentrant-editor-dispose");
+        var context = new FakeToolContext("editor dispose");
+        Assert.That(await editor.OpenToolTabAsync(context), Is.True);
+        context.OnDispose = () => editor.DisposeAsync();
+
+        await editor.CloseToolTabAsync(context).AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+        await editor.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.That(context.DisposeCount, Is.EqualTo(1));
     }
 
     private sealed class FakeToolContext(string header, ToolTabExtension? extension = null) : IToolContext
@@ -103,9 +173,16 @@ public class ToolTabHeaderTests
 
         public IReadOnlyReactiveProperty<string> Header => HeaderSource;
 
+        public Func<ValueTask>? OnDispose { get; set; }
+
+        public int DisposeCount { get; private set; }
+
         // Keep HeaderSource alive to test the dockable's unsubscribe.
-        public void Dispose()
+        public async ValueTask DisposeAsync()
         {
+            DisposeCount++;
+            if (OnDispose is { } onDispose)
+                await onDispose();
             IsSelected.Dispose();
         }
 

--- a/tests/Beutl.HeadlessUITests/ToolTabHeaderTests.cs
+++ b/tests/Beutl.HeadlessUITests/ToolTabHeaderTests.cs
@@ -897,12 +897,12 @@ public class ToolTabHeaderTests
         var oldBlocking = new BlockingEditorContext(entered, release, TestShell.Editor);
         var blockingTab = new EditorTabItem(oldBlocking);
         TestShell.Editor.AddTabItem(blockingTab);
-        Task<bool> replace = blockingTab.ReplaceContextAsync(replacement).AsTask();
+        Task<EditorContextReplacementResult> replace = blockingTab.ReplaceContextAsync(replacement).AsTask();
         await entered.Task.WaitAsync(TimeSpan.FromSeconds(5));
         _ = replacement.DisposeAsync();
         release.TrySetResult();
 
-        Assert.That(await replace.WaitAsync(TimeSpan.FromSeconds(5)), Is.False);
+        Assert.That((await replace!.WaitAsync(TimeSpan.FromSeconds(5))).Succeeded, Is.False);
         Assert.That(blockingTab.Context.Value, Is.Null);
         await blockingTab.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
         await owner.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));

--- a/tests/Beutl.HeadlessUITests/ToolTabHeaderTests.cs
+++ b/tests/Beutl.HeadlessUITests/ToolTabHeaderTests.cs
@@ -4,14 +4,18 @@ using Avalonia.Controls;
 using Avalonia.Headless.NUnit;
 using Beutl.Extensibility;
 using Beutl.ProjectSystem;
+using Beutl.Services;
 using Beutl.Testing.Headless;
 using Beutl.ViewModels;
 using Beutl.ViewModels.Dock;
+using Dock.Model.Controls;
+using Dock.Model.Core;
+using Dock.Model.Core.Events;
 using Reactive.Bindings;
 
 namespace Beutl.HeadlessUITests;
 
-[TestFixture]
+[TestFixture, NonParallelizable]
 public class ToolTabHeaderTests
 {
     private static string NewWorkspace(string name)
@@ -30,7 +34,7 @@ public class ToolTabHeaderTests
 
         TestShell.Editor.ActivateTabItem(scene);
         HeadlessTestHelpers.Settle();
-        return (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
+        return (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value!;
     }
 
     [AvaloniaTest]
@@ -163,6 +167,510 @@ public class ToolTabHeaderTests
         Assert.That(context.DisposeCount, Is.EqualTo(1));
     }
 
+    [AvaloniaTest]
+    public async Task PostAttachFailureRollsBackDockableAndDisposesContextOnce()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditorForNewScene("tooltab-post-attach-failure");
+        var context = new FakeToolContext("post-attach");
+        editor.DockHost.Factory.AfterToolAttach = _ => throw new InvalidOperationException("activation failed");
+
+        Assert.That(await editor.OpenToolTabAsync(context), Is.False);
+        Assert.Multiple(() =>
+        {
+            Assert.That(editor.DockHost.Factory.EnumerateTools(), Does.Not.Contain(
+                Has.Property(nameof(BeutlToolDockable.ToolContext)).SameAs(context)));
+            Assert.That(context.DisposeCount, Is.EqualTo(1));
+        });
+    }
+
+    [AvaloniaTest]
+    public async Task UserCloseVetoKeepsTheDockableAndContextAlive()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditorForNewScene("tooltab-close-veto");
+        var context = new FakeToolContext("close-veto");
+        Assert.That(await editor.OpenToolTabAsync(context), Is.True);
+        BeutlToolDockable dockable = editor.DockHost.Factory.EnumerateTools()
+            .Single(item => item.ToolContext == context);
+        EventHandler<DockableClosingEventArgs> veto = (_, args) => args.Cancel = true;
+        editor.DockHost.Factory.DockableClosing += veto;
+
+        editor.DockHost.Factory.CloseDockable(dockable);
+
+        editor.DockHost.Factory.DockableClosing -= veto;
+        Assert.Multiple(() =>
+        {
+            Assert.That(editor.DockHost.Factory.EnumerateTools(), Does.Contain(dockable));
+            Assert.That(dockable.Owner, Is.Not.Null);
+            Assert.That(context.DisposeCount, Is.Zero);
+        });
+        await editor.CloseToolTabAsync(context);
+    }
+
+    [AvaloniaTest]
+    public async Task ThrowingUserCloseCallbackDoesNotCorruptTheDockable()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditorForNewScene("tooltab-close-throw");
+        var context = new FakeToolContext("close-throw");
+        Assert.That(await editor.OpenToolTabAsync(context), Is.True);
+        BeutlToolDockable dockable = editor.DockHost.Factory.EnumerateTools()
+            .Single(item => item.ToolContext == context);
+        EventHandler<DockableClosingEventArgs> throwing = (_, _) =>
+            throw new InvalidOperationException("close observer failed");
+        editor.DockHost.Factory.DockableClosing += throwing;
+
+        editor.DockHost.Factory.CloseDockable(dockable);
+
+        editor.DockHost.Factory.DockableClosing -= throwing;
+        Assert.Multiple(() =>
+        {
+            Assert.That(editor.DockHost.Factory.EnumerateTools(), Does.Contain(dockable));
+            Assert.That(dockable.Owner, Is.Not.Null);
+            Assert.That(context.DisposeCount, Is.Zero);
+        });
+        await editor.CloseToolTabAsync(context);
+    }
+
+    [AvaloniaTest]
+    public async Task UserCloseObservesAContextDisposalFailure()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditorForNewScene("tooltab-user-close-dispose-failure");
+        var context = new FakeToolContext("user-close-dispose-failure")
+        {
+            OnDispose = () => ValueTask.FromException(
+                new InvalidOperationException("dispose failed")),
+        };
+        Assert.That(await editor.OpenToolTabAsync(context), Is.True);
+        BeutlToolDockable dockable = editor.DockHost.Factory.EnumerateTools()
+            .Single(item => item.ToolContext == context);
+        Func<BeutlToolDockable, Task> tracker = editor.DockHost.Factory.DisposalTracker!;
+        Task? tracked = null;
+        editor.DockHost.Factory.DisposalTracker = item => tracked = tracker(item);
+
+        editor.DockHost.Factory.CloseDockable(dockable);
+
+        Assert.That(tracked, Is.Not.Null);
+        Assert.CatchAsync<Exception>(async () =>
+            await tracked!.WaitAsync(TimeSpan.FromSeconds(5)));
+        Assert.That(context.DisposeCount, Is.EqualTo(1));
+    }
+
+    [AvaloniaTest]
+    public async Task LayoutResetBypassesThrowingCloseCallbacksAndCanRunAgain()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditorForNewScene("tooltab-reset-close-throw");
+        var context = new FakeToolContext("reset-close-throw");
+        Assert.That(await editor.OpenToolTabAsync(context), Is.True);
+        EventHandler<DockableClosingEventArgs> throwing = (_, _) =>
+            throw new InvalidOperationException("close observer failed");
+        editor.DockHost.Factory.DockableClosing += throwing;
+
+        await editor.DockHost.ResetLayoutAsync().WaitAsync(TimeSpan.FromSeconds(5));
+        await editor.DockHost.ResetLayoutAsync().WaitAsync(TimeSpan.FromSeconds(5));
+
+        editor.DockHost.Factory.DockableClosing -= throwing;
+        Assert.That(context.DisposeCount, Is.EqualTo(1));
+    }
+
+    [AvaloniaTest]
+    public async Task LayoutResetRemovesHiddenToolsBeforeDisposal()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditorForNewScene("tooltab-hidden-reset");
+        var context = new FakeToolContext("hidden-reset");
+        Assert.That(await editor.OpenToolTabAsync(context), Is.True);
+        BeutlToolDockable dockable = editor.DockHost.Factory.EnumerateTools()
+            .Single(item => item.ToolContext == context);
+        IRootDock oldRoot = editor.DockHost.Layout.Value;
+        editor.DockHost.Factory.HideDockable(dockable);
+        Assert.That(oldRoot.HiddenDockables, Does.Contain(dockable));
+
+        await editor.DockHost.ResetLayoutAsync().WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(context.DisposeCount, Is.EqualTo(1));
+            Assert.That(oldRoot.HiddenDockables, Does.Not.Contain(dockable));
+            Assert.That(dockable.Owner, Is.Null);
+        });
+    }
+
+    [AvaloniaTest]
+    public async Task ProgrammaticCloseRemovesAnEmptyFloatingWindow()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditorForNewScene("tooltab-floating-close");
+        var context = new FakeToolContext("floating-close");
+        Assert.That(await editor.OpenToolTabAsync(context), Is.True);
+        BeutlToolDockable dockable = editor.DockHost.Factory.EnumerateTools()
+            .Single(item => item.ToolContext == context);
+        IRootDock mainRoot = editor.DockHost.Layout.Value;
+        editor.DockHost.Factory.FloatDockable(dockable);
+        Assert.That(mainRoot.Windows, Is.Not.Null.And.Not.Empty);
+
+        await editor.CloseToolTabAsync(context).AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(mainRoot.Windows, Is.Empty);
+            Assert.That(context.DisposeCount, Is.EqualTo(1));
+            Assert.That(dockable.Owner, Is.Null);
+        });
+    }
+
+    [AvaloniaTest]
+    public async Task PartialDisposalPreparationCannotStrandLayoutTransition()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditorForNewScene("tooltab-partial-prepare");
+        var first = new FakeToolContext("partial-first");
+        var second = new FakeToolContext("partial-second");
+        Assert.That(await editor.OpenToolTabAsync(first), Is.True);
+        Assert.That(await editor.OpenToolTabAsync(second), Is.True);
+        int preparations = 0;
+        editor.DockHost.BeforePrepareDockableDisposal = _ =>
+        {
+            if (++preparations == 2)
+                throw new InvalidOperationException("prepare failed");
+        };
+
+        Exception? resetError = null;
+        try
+        {
+            await editor.DockHost.ResetLayoutAsync().WaitAsync(TimeSpan.FromSeconds(5));
+        }
+        catch (Exception ex)
+        {
+            resetError = ex;
+        }
+        Assert.That(resetError, Is.TypeOf<InvalidOperationException>());
+        editor.DockHost.BeforePrepareDockableDisposal = null;
+        await editor.DockHost.ResetLayoutAsync().WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(first.DisposeCount, Is.EqualTo(1));
+            Assert.That(second.DisposeCount, Is.EqualTo(1));
+        });
+    }
+
+    [AvaloniaTest]
+    public async Task OpenStartedBeforeResetNeverAttachesToDetachedRoot()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditorForNewScene("tooltab-open-reset-race");
+        var extension = new BlockingToolExtension();
+        IToolDock oldTarget = editor.DockHost.Factory.GetAnchoredDock(DockAnchor.Left)!;
+        Task<bool> open = Task.Run(() => editor.DockHost.OpenToolTabFromExtensionAsync(extension, oldTarget));
+
+        await extension.Entered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await editor.DockHost.ResetLayoutAsync().WaitAsync(TimeSpan.FromSeconds(5));
+        extension.Release();
+
+        bool opened = await open.WaitAsync(TimeSpan.FromSeconds(5));
+        var context = extension.CreatedContext!;
+        Assert.That(context.DisposeCount, Is.EqualTo(opened ? 0 : 1));
+        if (opened)
+        {
+            BeutlToolDockable dockable = editor.DockHost.Factory.EnumerateTools()
+                .Single(t => t.ToolContext == context);
+            Assert.That(BeutlDockFactory.Traverse(editor.DockHost.Layout.Value), Does.Contain(dockable));
+            Assert.That(BeutlDockFactory.Traverse(editor.DockHost.Layout.Value), Does.Not.Contain(oldTarget));
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task ConcurrentCloseSharesOneInFlightDisposal()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditorForNewScene("tooltab-concurrent-close");
+        var context = new FakeToolContext("concurrent-close");
+        Assert.That(await editor.OpenToolTabAsync(context), Is.True);
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        context.OnDispose = async () =>
+        {
+            entered.TrySetResult();
+            await release.Task;
+        };
+
+        Task first = editor.CloseToolTabAsync(context).AsTask();
+        await entered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Task second = editor.CloseToolTabAsync(context).AsTask();
+        Task<bool> reopen = editor.OpenToolTabAsync(context).AsTask();
+        Assert.That(reopen.IsCompleted, Is.False,
+            "A reopen of an in-flight disposal must join that disposal before it is rejected.");
+        release.TrySetResult();
+        await Task.WhenAll(first, second, reopen).WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(reopen.Result, Is.False);
+            Assert.That(context.DisposeCount, Is.EqualTo(1));
+            Assert.That(editor.DockHost.Factory.EnumerateTools(), Does.Not.Contain(
+                Has.Property(nameof(BeutlToolDockable.ToolContext)).SameAs(context)));
+        });
+    }
+
+    [AvaloniaTest]
+    public async Task ReentrantOpenOfSameContextDoesNotSelfWait()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditorForNewScene("tooltab-reentrant-open");
+        var context = new FakeToolContext("reentrant-open");
+        context.OnDispose = async () => { await editor.OpenToolTabAsync(context).AsTask(); };
+        Assert.That(await editor.OpenToolTabAsync(context), Is.True);
+        await editor.CloseToolTabAsync(context).AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.That(context.DisposeCount, Is.EqualTo(1));
+    }
+
+    [AvaloniaTest]
+    public async Task MutualReentrantOpenDuringDisposalDoesNotCycle()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditorForNewScene("tooltab-mutual-reentrant-open");
+        var first = new FakeToolContext("mutual-open-first");
+        var second = new FakeToolContext("mutual-open-second");
+        Assert.That(await editor.OpenToolTabAsync(first), Is.True);
+        Assert.That(await editor.OpenToolTabAsync(second), Is.True);
+        first.OnDispose = async () =>
+        {
+            Assert.That(await editor.OpenToolTabAsync(second), Is.False);
+        };
+        second.OnDispose = async () =>
+        {
+            Assert.That(await editor.OpenToolTabAsync(first), Is.False);
+        };
+
+        await editor.CloseToolTabAsync(first).AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+        await editor.CloseToolTabAsync(second).AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(first.DisposeCount, Is.EqualTo(1));
+            Assert.That(second.DisposeCount, Is.EqualTo(1));
+        });
+    }
+
+    [AvaloniaTest]
+    public async Task ReentrantOpenOfFreshContextDuringResetStillConsumesIt()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditorForNewScene("tooltab-reset-fresh-reentrant");
+        var outgoing = new FakeToolContext("reset-outgoing");
+        var fresh = new FakeToolContext("reset-fresh");
+        Assert.That(await editor.OpenToolTabAsync(outgoing), Is.True);
+        outgoing.OnDispose = async () =>
+        {
+            Assert.That(await editor.OpenToolTabAsync(fresh), Is.False);
+        };
+
+        await editor.DockHost.ResetLayoutAsync().WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.That(fresh.DisposeCount, Is.EqualTo(1));
+        Assert.That(editor.DockHost.Factory.EnumerateTools(), Does.Not.Contain(
+            Has.Property(nameof(BeutlToolDockable.ToolContext)).SameAs(fresh)));
+    }
+
+    [AvaloniaTest]
+    public async Task DockableCleanupFailureStillDisposesAndReleasesItsContext()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditorForNewScene("tooltab-cleanup-failure");
+        var context = new FakeToolContext("cleanup-failure");
+        Assert.That(await editor.OpenToolTabAsync(context), Is.True);
+        BeutlToolDockable dockable = editor.DockHost.Factory.EnumerateTools()
+            .Single(item => item.ToolContext == context);
+        void ThrowOnContextClear(object? _, System.ComponentModel.PropertyChangedEventArgs args)
+        {
+            if (args.PropertyName == nameof(IDockable.Context))
+                throw new InvalidOperationException("observer failed");
+        }
+        dockable.PropertyChanged += ThrowOnContextClear;
+
+        Assert.ThrowsAsync<AggregateException>(async () =>
+            await dockable.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5)));
+        dockable.PropertyChanged -= ThrowOnContextClear;
+        editor.DockHost.Factory.DetachDockable(dockable);
+
+        Assert.That(context.DisposeCount, Is.EqualTo(1));
+        Assert.Throws<ObjectDisposedException>(() => _ = dockable.ToolContext);
+    }
+
+    [AvaloniaTest]
+    public async Task CompletedDisposalDoesNotRetainContextOrRedisposeLateClose()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditorForNewScene("tooltab-disposal-weak-retention");
+        (WeakReference contextWeak, WeakReference dockableWeak) = await Task.Run(() => OpenAndClose(editor));
+
+        ForceGc();
+        Assert.Multiple(() =>
+        {
+            Assert.That(contextWeak.IsAlive, Is.False,
+                "the dock host must not strongly retain a disposed context");
+            Assert.That(dockableWeak.IsAlive, Is.False,
+                "the dock host must not strongly retain a detached dockable");
+        });
+
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        static (WeakReference Context, WeakReference Dockable) OpenAndClose(EditViewModel editor)
+        {
+            var context = new FakeToolContext("weak-retention");
+            Assert.That(editor.OpenToolTabAsync(context).AsTask().GetAwaiter().GetResult(), Is.True);
+            BeutlToolDockable dockable = editor.DockHost.Factory.EnumerateTools()
+                .Single(item => item.ToolContext == context);
+            editor.DockHost.Factory.InitLayout(editor.DockHost.Layout.Value);
+            WeakReference contextWeak = new(context);
+            WeakReference dockableWeak = new(dockable);
+            editor.CloseToolTabAsync(context).AsTask().GetAwaiter().GetResult();
+            editor.CloseToolTabAsync(context).AsTask().GetAwaiter().GetResult();
+            Assert.That(context.DisposeCount, Is.EqualTo(1));
+            Assert.That(editor.DockHost.Factory.EnumerateTools(), Does.Not.Contain(
+                Has.Property(nameof(BeutlToolDockable.ToolContext)).SameAs(context)));
+            Assert.That(editor.DockHost.Factory.CurrentDockable, Is.Not.SameAs(dockable));
+            Assert.That(dockable.Owner, Is.Null);
+            Assert.That(dockable.OriginalOwner, Is.Null);
+            Assert.That(dockable.Context, Is.Null);
+            Assert.That(editor.DockHost.Factory.ToolControls.ContainsKey(dockable), Is.False);
+            Assert.That(editor.DockHost.Factory.VisibleDockableControls.ContainsKey(dockable), Is.False);
+            Assert.That(editor.DockHost.Factory.PinnedDockableControls.ContainsKey(dockable), Is.False);
+            Assert.That(editor.DockHost.Factory.TabDockableControls.ContainsKey(dockable), Is.False);
+            context.HeaderSource.Dispose();
+            context = null!;
+            dockable = null!;
+            return (contextWeak, dockableWeak);
+        }
+
+        static void ForceGc()
+        {
+            for (int i = 0; i < 3; i++)
+            {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                GC.Collect();
+                Thread.Sleep(10);
+            }
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task ExternalOperationsCannotInterleaveDefaultTabMaterialization()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditorForNewScene("tooltab-default-materialization");
+        var extension = new DefaultToolExtension();
+        editor.DockHost.DefaultExtensionsOverride = [extension];
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        editor.DockHost.BeforeDefaultTabMaterializationAsync = async () =>
+        {
+            entered.TrySetResult();
+            await release.Task;
+        };
+
+        Task reset = editor.DockHost.ResetLayoutAsync();
+        await entered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        IRootDock transitionRoot = editor.DockHost.Layout.Value;
+
+        await editor.DockHost.ResetLayoutAsync();
+        Assert.That(editor.DockHost.Layout.Value, Is.SameAs(transitionRoot));
+
+        var external = new FakeToolContext("external-during-defaults");
+        Assert.That(await editor.OpenToolTabAsync(external), Is.False);
+        Assert.That(external.DisposeCount, Is.EqualTo(1));
+
+        release.TrySetResult();
+        await reset.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [AvaloniaTest]
+    public async Task SnapshotDuringTransitionIsRejected()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditorForNewScene("tooltab-stable-snapshot");
+        var context = new FakeToolContext("stable-snapshot");
+        Assert.That(await editor.OpenToolTabAsync(context), Is.True);
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        context.OnDispose = async () =>
+        {
+            entered.TrySetResult();
+            await release.Task;
+        };
+
+        Task reset = editor.DockHost.ResetLayoutAsync();
+        await entered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        var during = new JsonObject();
+
+        Assert.Throws<InvalidOperationException>(() => editor.DockHost.WriteToJson(during));
+        Assert.Throws<InvalidOperationException>(() => editor.DockHost.CaptureLayout());
+        release.TrySetResult();
+        await reset.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [AvaloniaTest]
+    public async Task EditorCloseWaitsForLayoutTransitionAndStillTearsDown()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditorForNewScene("tooltab-close-transition");
+        EditorTabItem tab = TestShell.Editor.SelectedTabItem.Value!;
+        var context = new FakeToolContext("close-transition");
+        Assert.That(await editor.OpenToolTabAsync(context), Is.True);
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        context.OnDispose = async () =>
+        {
+            entered.TrySetResult();
+            await release.Task;
+        };
+
+        Task reset = editor.DockHost.ResetLayoutAsync();
+        await entered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Task close = TestShell.Editor.CloseTabItem(tab).AsTask();
+        Assert.That(close.IsCompleted, Is.False);
+        release.TrySetResult();
+
+        await reset.WaitAsync(TimeSpan.FromSeconds(5));
+        await close.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Multiple(() =>
+        {
+            Assert.That(context.DisposeCount, Is.EqualTo(1));
+            Assert.That(TestShell.Editor.TabItems, Does.Not.Contain(tab));
+        });
+    }
+
+    [AvaloniaTest]
+    public async Task ToolSerializerRunsOutsideHostGates()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditorForNewScene("tooltab-serializer-reentry");
+        var context = new FakeToolContext("serializer-reentry");
+        Assert.That(await editor.OpenToolTabAsync(context), Is.True);
+        bool serializedOnUiThread = false;
+        context.OnWrite = _ => serializedOnUiThread =
+            Avalonia.Threading.Dispatcher.UIThread.CheckAccess();
+
+        var json = new JsonObject();
+        Task serialization = Task.Run(() => editor.DockHost.WriteToJson(json));
+        DateTime deadline = DateTime.UtcNow.AddSeconds(5);
+        while (!serialization.IsCompleted && DateTime.UtcNow < deadline)
+        {
+            Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+            Thread.Sleep(1);
+        }
+        Assert.That(serialization.IsCompleted, Is.True);
+        serialization.GetAwaiter().GetResult();
+        Assert.That(serializedOnUiThread, Is.True);
+        Assert.That(json["DockLayout"], Is.Not.Null);
+        context.OnWrite = null;
+        await editor.CloseToolTabAsync(context);
+    }
+
     private sealed class FakeToolContext(string header, ToolTabExtension? extension = null) : IToolContext
     {
         public ReactivePropertySlim<string> HeaderSource { get; } = new(header);
@@ -174,6 +682,8 @@ public class ToolTabHeaderTests
         public IReadOnlyReactiveProperty<string> Header => HeaderSource;
 
         public Func<ValueTask>? OnDispose { get; set; }
+
+        public Action<JsonObject>? OnWrite { get; set; }
 
         public int DisposeCount { get; private set; }
 
@@ -194,6 +704,60 @@ public class ToolTabHeaderTests
 
         public void WriteToJson(JsonObject json)
         {
+            OnWrite?.Invoke(json);
+        }
+    }
+
+    private class BlockingToolExtension : ToolTabExtension
+    {
+        public TaskCompletionSource Entered { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _release = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public FakeToolContext? CreatedContext { get; private set; }
+
+        public void Release() => _release.TrySetResult();
+
+        public override bool CanMultiple => true;
+        public override string Name => "BlockingToolTab";
+        public override string DisplayName => "Blocking tool tab";
+        public override string? Header => "Blocking tool tab";
+
+        public override bool TryCreateContent(IEditorContext editorContext, [NotNullWhen(true)] out Control? control)
+        {
+            control = new Border();
+            return true;
+        }
+
+        public override bool TryCreateContext(IEditorContext editorContext, [NotNullWhen(true)] out IToolContext? context)
+        {
+            Entered.TrySetResult();
+            _release.Task.GetAwaiter().GetResult();
+            context = CreatedContext = new FakeToolContext("blocking", this);
+            return true;
+        }
+    }
+
+    private sealed class DefaultToolExtension : ToolTabExtension
+    {
+        public override bool CanMultiple => true;
+        public override string Name => "DefaultToolTab";
+        public override string DisplayName => "Default tool tab";
+        public override string? Header => "Default tool tab";
+        public override bool OpenByDefault => true;
+
+        public override bool TryCreateContent(
+            IEditorContext editorContext,
+            [NotNullWhen(true)] out Control? control)
+        {
+            control = new Border();
+            return true;
+        }
+
+        public override bool TryCreateContext(
+            IEditorContext editorContext,
+            [NotNullWhen(true)] out IToolContext? context)
+        {
+            context = new FakeToolContext("default", this);
+            return true;
         }
     }
 

--- a/tests/Beutl.HeadlessUITests/ToolTabHeaderTests.cs
+++ b/tests/Beutl.HeadlessUITests/ToolTabHeaderTests.cs
@@ -1105,6 +1105,7 @@ public class ToolTabHeaderTests
     {
         public CoreObject Object { get; } = new Scene(16, 16, "blocking");
         public EditorExtension Extension => SceneEditorExtension.Instance;
+        public IEditorContextCloseService CloseService { get; } = new UnownedCloseService();
         public IReactiveProperty<bool> IsEnabled { get; } = new ReactivePropertySlim<bool>(true);
         public IKnownEditorCommands? Commands => null;
         public async ValueTask DisposeAsync()
@@ -1117,6 +1118,12 @@ public class ToolTabHeaderTests
         public ValueTask<bool> OpenToolTabAsync(IToolContext item) => new(false);
         public ValueTask CloseToolTabAsync(IToolContext item) => ValueTask.CompletedTask;
         public object? GetService(Type serviceType) => null;
+    }
+
+    private sealed class UnownedCloseService : IEditorContextCloseService
+    {
+        public EditorContextCloseRequest RequestClose(IEditorContext context)
+            => new(EditorContextCloseRequestStatus.NotOwned, Task.CompletedTask);
     }
 
     private class BlockingToolExtension : ToolTabExtension

--- a/tests/Beutl.HeadlessUITests/ToolTabHeaderTests.cs
+++ b/tests/Beutl.HeadlessUITests/ToolTabHeaderTests.cs
@@ -18,6 +18,8 @@ namespace Beutl.HeadlessUITests;
 [TestFixture, NonParallelizable]
 public class ToolTabHeaderTests
 {
+    private const int DefaultDisposalExtensionPackageId = 923_841;
+
     private static string NewWorkspace(string name)
     {
         string location = Path.Combine(BeutlHomeIsolation.CurrentHome!, name);
@@ -589,6 +591,123 @@ public class ToolTabHeaderTests
     }
 
     [AvaloniaTest]
+    public async Task DefaultContextCanSynchronouslyRequestEditorDisposalWithoutDeadlock()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditorForNewScene("tooltab-default-dispose-reentry");
+        EditorTabItem ownerTab = TestShell.Editor.SelectedTabItem.Value!;
+        var extension = new DisposingDefaultToolExtension(disposeCalls: 2);
+        editor.DockHost.DefaultExtensionsOverride = [extension];
+
+        await editor.DockHost.ResetLayoutAsync().WaitAsync(TimeSpan.FromSeconds(5));
+        await editor.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(extension.ContextCreationCount, Is.EqualTo(1));
+            Assert.That(extension.CreatedContext?.DisposeCount, Is.EqualTo(1));
+            Assert.That(TestShell.Editor.TabItems, Does.Not.Contain(ownerTab));
+            Assert.That(TestShell.Editor.SelectedTabItem.Value, Is.Not.SameAs(ownerTab));
+        });
+    }
+
+    [AvaloniaTest]
+    public async Task DefaultContextStartedForClosingEditorIsRejectedAndConsumed()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditorForNewScene("tooltab-default-dispose-admission");
+        var extension = new DisposingDefaultToolExtension(waitForDisposal: false);
+        editor.DockHost.DefaultExtensionsOverride = [extension];
+
+        await editor.DockHost.ResetLayoutAsync().WaitAsync(TimeSpan.FromSeconds(5));
+        await editor.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(extension.ContextCreationCount, Is.EqualTo(1));
+            Assert.That(extension.CreatedContext?.DisposeCount, Is.EqualTo(1));
+            Assert.That(editor.DockHost.Factory.EnumerateTools(), Does.Not.Contain(
+                Has.Property(nameof(BeutlToolDockable.ToolContext))
+                    .SameAs(extension.CreatedContext)));
+        });
+    }
+
+    [AvaloniaTest]
+    public async Task InitialDefaultContextCanSynchronouslyRequestEditorDisposal()
+    {
+        await TestReset.ResetShellAsync();
+        var extension = new DisposingDefaultToolExtension();
+        TestShell.Extensions.AddExtensions(
+            DefaultDisposalExtensionPackageId,
+            [extension]);
+        try
+        {
+            Project project = (await TestShell.Project.CreateProject(
+                640,
+                480,
+                30,
+                44100,
+                "tooltab-initial-default-dispose",
+                NewWorkspace("tooltab-initial-default-dispose")))!;
+            HeadlessTestHelpers.Settle();
+            Scene scene = project.Items.OfType<Scene>().First();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(extension.ContextCreationCount, Is.GreaterThanOrEqualTo(1));
+                Assert.That(extension.CreatedContexts, Is.All.Matches<FakeToolContext>(
+                    context => context.DisposeCount == 1));
+                Assert.That(TestShell.Editor.TryGetTabItem(scene, out _), Is.False);
+            });
+        }
+        finally
+        {
+            _ = TestShell.Extensions.RemoveExtensions(DefaultDisposalExtensionPackageId);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task DefaultFactoryCanSynchronouslyCloseEarlierDefaultWithoutDeadlock()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditorForNewScene("tooltab-default-close-reentry");
+        var first = new TrackedDefaultToolExtension("first", 0);
+        var second = new ClosingDefaultToolExtension(() => first.CreatedContext, 1);
+        editor.DockHost.DefaultExtensionsOverride = [first, second];
+
+        await editor.DockHost.ResetLayoutAsync().WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(first.CreatedContext?.DisposeCount, Is.EqualTo(1));
+            Assert.That(second.CreatedContext?.DisposeCount, Is.Zero);
+            Assert.That(editor.DockHost.Factory.EnumerateTools(), Has.One.Matches<BeutlToolDockable>(
+                tool => ReferenceEquals(tool.ToolContext, second.CreatedContext)));
+        });
+    }
+
+    [AvaloniaTest]
+    public async Task ExtensionReturningFalseWithContextIsDisposed()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditorForNewScene("tooltab-false-context");
+        var extension = new FalseWithContextToolExtension();
+
+        bool opened = await editor.DockHost.OpenToolTabFromExtensionAsync(
+            extension,
+            editor.DockHost.Factory.FindFirstToolDock());
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(opened, Is.False);
+            Assert.That(extension.CreatedContext, Is.Not.Null);
+            Assert.That(extension.CreatedContext!.DisposeCount, Is.EqualTo(1));
+            Assert.That(editor.DockHost.Factory.EnumerateTools(), Does.Not.Contain(
+                Has.Property(nameof(BeutlToolDockable.ToolContext)).SameAs(extension.CreatedContext)));
+        });
+    }
+
+    [AvaloniaTest]
     public async Task SnapshotDuringTransitionIsRejected()
     {
         await TestReset.ResetShellAsync();
@@ -758,6 +877,130 @@ public class ToolTabHeaderTests
         {
             context = new FakeToolContext("default", this);
             return true;
+        }
+    }
+
+    private sealed class DisposingDefaultToolExtension(
+        bool waitForDisposal = true,
+        int disposeCalls = 1) : ToolTabExtension
+    {
+        public int ContextCreationCount { get; private set; }
+
+        public FakeToolContext? CreatedContext { get; private set; }
+
+        public List<FakeToolContext> CreatedContexts { get; } = [];
+
+        public override bool CanMultiple => true;
+        public override string Name => "DisposingDefaultToolTab";
+        public override string DisplayName => "Disposing default tool tab";
+        public override string? Header => "Disposing default tool tab";
+        public override bool OpenByDefault => true;
+
+        public override bool TryCreateContent(
+            IEditorContext editorContext,
+            [NotNullWhen(true)] out Control? control)
+        {
+            control = new Border();
+            return true;
+        }
+
+        public override bool TryCreateContext(
+            IEditorContext editorContext,
+            [NotNullWhen(true)] out IToolContext? context)
+        {
+            ContextCreationCount++;
+            for (int i = 0; i < disposeCalls; i++)
+            {
+                ValueTask disposal = editorContext.DisposeAsync();
+                if (waitForDisposal)
+                    disposal.AsTask().GetAwaiter().GetResult();
+            }
+            context = CreatedContext = new FakeToolContext("disposing-default", this);
+            CreatedContexts.Add(CreatedContext);
+            return true;
+        }
+    }
+
+    private sealed class TrackedDefaultToolExtension(string suffix, int order) : ToolTabExtension
+    {
+        public FakeToolContext? CreatedContext { get; private set; }
+        public override bool CanMultiple => true;
+        public override string Name => $"TrackedDefault{suffix}";
+        public override string DisplayName => Name;
+        public override string? Header => Name;
+        public override bool OpenByDefault => true;
+        public override int DefaultOrder => order;
+
+        public override bool TryCreateContent(
+            IEditorContext editorContext,
+            [NotNullWhen(true)] out Control? control)
+        {
+            control = new Border();
+            return true;
+        }
+
+        public override bool TryCreateContext(
+            IEditorContext editorContext,
+            [NotNullWhen(true)] out IToolContext? context)
+        {
+            context = CreatedContext = new FakeToolContext(Name, this);
+            return true;
+        }
+    }
+
+    private sealed class ClosingDefaultToolExtension(
+        Func<FakeToolContext?> first,
+        int order) : ToolTabExtension
+    {
+        public FakeToolContext? CreatedContext { get; private set; }
+        public override bool CanMultiple => true;
+        public override string Name => "ClosingDefault";
+        public override string DisplayName => Name;
+        public override string? Header => Name;
+        public override bool OpenByDefault => true;
+        public override int DefaultOrder => order;
+
+        public override bool TryCreateContent(
+            IEditorContext editorContext,
+            [NotNullWhen(true)] out Control? control)
+        {
+            control = new Border();
+            return true;
+        }
+
+        public override bool TryCreateContext(
+            IEditorContext editorContext,
+            [NotNullWhen(true)] out IToolContext? context)
+        {
+            editorContext.CloseToolTabAsync(first()!).AsTask().GetAwaiter().GetResult();
+            context = CreatedContext = new FakeToolContext(Name, this);
+            return true;
+        }
+    }
+
+    private sealed class FalseWithContextToolExtension : ToolTabExtension
+    {
+        public FakeToolContext? CreatedContext { get; private set; }
+
+        public override bool CanMultiple => true;
+        public override string Name => "FalseWithContext";
+        public override string DisplayName => Name;
+        public override string? Header => Name;
+
+        public override bool TryCreateContent(
+            IEditorContext editorContext,
+            [NotNullWhen(true)] out Control? control)
+        {
+            control = null;
+            return false;
+        }
+
+        public override bool TryCreateContext(
+            IEditorContext editorContext,
+            [NotNullWhen(true)] out IToolContext? context)
+        {
+            context = CreatedContext = new FakeToolContext(Name, this);
+            return false;
         }
     }
 

--- a/tests/Beutl.HeadlessUITests/ToolTabHeaderTests.cs
+++ b/tests/Beutl.HeadlessUITests/ToolTabHeaderTests.cs
@@ -163,8 +163,7 @@ public class ToolTabHeaderTests
         EditViewModel editor = await OpenEditorForNewScene("tooltab-reentrant-editor-dispose");
         var context = new FakeToolContext("editor dispose");
         Assert.That(await editor.OpenToolTabAsync(context), Is.True);
-        var closeService = (IEditorContextCloseService)editor.GetService(
-            typeof(IEditorContextCloseService))!;
+        IEditorContextCloseService closeService = editor.CloseService;
         EditorContextCloseRequest closeRequest = default;
         context.OnDispose = () =>
         {
@@ -1245,9 +1244,7 @@ public class ToolTabHeaderTests
 
         private static void RequestEditorClose(IEditorContext editorContext)
         {
-            var closeService = (IEditorContextCloseService?)editorContext.GetService(
-                typeof(IEditorContextCloseService));
-            _ = closeService?.RequestClose(editorContext);
+            _ = editorContext.CloseService.RequestClose(editorContext);
         }
     }
 
@@ -1282,8 +1279,7 @@ public class ToolTabHeaderTests
             [NotNullWhen(true)] out IToolContext? context)
         {
             ContextCreationCount++;
-            var closeService = (IEditorContextCloseService)editorContext.GetService(
-                typeof(IEditorContextCloseService))!;
+            IEditorContextCloseService closeService = editorContext.CloseService;
             for (int i = 0; i < disposeCalls; i++)
             {
                 EditorContextCloseRequest request = closeService.RequestClose(editorContext);

--- a/tests/Beutl.HeadlessUITests/ToolTabHeaderTests.cs
+++ b/tests/Beutl.HeadlessUITests/ToolTabHeaderTests.cs
@@ -5,6 +5,7 @@ using Avalonia.Headless.NUnit;
 using Beutl.Extensibility;
 using Beutl.ProjectSystem;
 using Beutl.Services;
+using Beutl.Services.PrimitiveImpls;
 using Beutl.Testing.Headless;
 using Beutl.ViewModels;
 using Beutl.ViewModels.Dock;
@@ -19,6 +20,7 @@ namespace Beutl.HeadlessUITests;
 public class ToolTabHeaderTests
 {
     private const int DefaultDisposalExtensionPackageId = 923_841;
+    private const int RestoreReentryExtensionPackageId = 923_842;
 
     private static string NewWorkspace(string name)
     {
@@ -667,6 +669,261 @@ public class ToolTabHeaderTests
     }
 
     [AvaloniaTest]
+    public async Task RestoredContextCanSynchronouslyRequestEditorDisposalDuringCreation()
+    {
+        await TestReset.ResetShellAsync();
+        var extension = new RestoreReentryToolExtension();
+        TestShell.Extensions.AddExtensions(RestoreReentryExtensionPackageId, [extension]);
+        try
+        {
+            EditViewModel editor = await OpenEditorForNewScene("tooltab-restore-create-reentry");
+            Assert.That(await editor.DockHost.OpenToolTabFromExtensionAsync(
+                extension,
+                editor.DockHost.Factory.FindFirstToolDock()), Is.True);
+            JsonObject layout = editor.DockHost.CaptureLayout();
+            extension.DisposeInCreate = true;
+
+            Task<bool> restore = editor.DockHost.ApplyLayoutAsync(layout);
+            Assert.That(await restore.WaitAsync(TimeSpan.FromSeconds(5)), Is.False);
+            await editor.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.That(editor.DockHost.FindToolContext(extension.GetType()), Is.Null);
+        }
+        finally
+        {
+            _ = TestShell.Extensions.RemoveExtensions(RestoreReentryExtensionPackageId);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task RestoredContextCanSynchronouslyRequestEditorDisposalDuringStateRead()
+    {
+        await TestReset.ResetShellAsync();
+        var extension = new RestoreReentryToolExtension();
+        TestShell.Extensions.AddExtensions(RestoreReentryExtensionPackageId, [extension]);
+        try
+        {
+            EditViewModel editor = await OpenEditorForNewScene("tooltab-restore-read-reentry");
+            Assert.That(await editor.DockHost.OpenToolTabFromExtensionAsync(
+                extension,
+                editor.DockHost.Factory.FindFirstToolDock()), Is.True);
+            var saved = new JsonObject();
+            editor.DockHost.WriteToJson(saved);
+            extension.DisposeInRead = true;
+
+            Task<bool> restore = editor.DockHost.ReadFromJsonAsync(saved);
+            Assert.That(await restore.WaitAsync(TimeSpan.FromSeconds(5)), Is.False);
+            await editor.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.That(editor.DockHost.FindToolContext(extension.GetType()), Is.Null);
+        }
+        finally
+        {
+            _ = TestShell.Extensions.RemoveExtensions(RestoreReentryExtensionPackageId);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task RestoredContextThatClosesItselfIsNotPublished()
+    {
+        await TestReset.ResetShellAsync();
+        var extension = new RestoreReentryToolExtension();
+        TestShell.Extensions.AddExtensions(RestoreReentryExtensionPackageId, [extension]);
+        try
+        {
+            EditViewModel editor = await OpenEditorForNewScene("tooltab-restore-self-close");
+            Assert.That(await editor.DockHost.OpenToolTabFromExtensionAsync(
+                extension,
+                editor.DockHost.Factory.FindFirstToolDock()), Is.True);
+            var saved = new JsonObject();
+            editor.DockHost.WriteToJson(saved);
+            extension.CloseInRead = true;
+
+            Assert.That(await editor.DockHost.ReadFromJsonAsync(saved)
+                .WaitAsync(TimeSpan.FromSeconds(5)), Is.True);
+            Assert.That(editor.DockHost.FindToolContext(extension.GetType()), Is.Null);
+            await editor.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+        }
+        finally
+        {
+            _ = TestShell.Extensions.RemoveExtensions(RestoreReentryExtensionPackageId);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task PublicationCloseCallbackDoesNotDeadlockOrPublishDisposedTool()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditorForNewScene("tooltab-publication-close-reentry");
+        var extension = new RestoreReentryToolExtension();
+        TestShell.Extensions.AddExtensions(RestoreReentryExtensionPackageId, [extension]);
+        try
+        {
+            Assert.That(await editor.DockHost.OpenToolTabFromExtensionAsync(
+                extension,
+                editor.DockHost.Factory.FindFirstToolDock()), Is.True);
+            var saved = new JsonObject();
+            editor.DockHost.WriteToJson(saved);
+            editor.DockHost.BeforeLayoutPublication = restored =>
+            {
+                BeutlToolDockable? restoredTool = BeutlDockFactory.Traverse(restored)
+                    .OfType<BeutlToolDockable>()
+                    .FirstOrDefault(tool => tool.ToolContext.Extension == extension);
+                if (restoredTool?.ToolContext is { } context)
+                    editor.CloseToolTabAsync(context).AsTask().GetAwaiter().GetResult();
+            };
+
+            Assert.That(await editor.DockHost.ReadFromJsonAsync(saved)
+                .WaitAsync(TimeSpan.FromSeconds(5)), Is.True);
+            Assert.That(editor.DockHost.FindToolContext(extension.GetType()), Is.Null);
+            await editor.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+        }
+        finally
+        {
+            editor.DockHost.BeforeLayoutPublication = null;
+            _ = TestShell.Extensions.RemoveExtensions(RestoreReentryExtensionPackageId);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task DeferredPublicationCloseAttemptsEveryContextAfterDisposalFailures()
+    {
+        await TestReset.ResetShellAsync();
+        var extension = new RestoreReentryToolExtension();
+        TestShell.Extensions.AddExtensions(RestoreReentryExtensionPackageId, [extension]);
+        try
+        {
+            EditViewModel editor = await OpenEditorForNewScene("tooltab-publication-close-batch");
+            Assert.That(await editor.DockHost.OpenToolTabFromExtensionAsync(
+                extension,
+                editor.DockHost.Factory.FindFirstToolDock()), Is.True);
+            Assert.That(await editor.DockHost.OpenToolTabFromExtensionAsync(
+                extension,
+                editor.DockHost.Factory.FindFirstToolDock()), Is.True);
+            var saved = new JsonObject();
+            editor.DockHost.WriteToJson(saved);
+            int previousContexts = extension.CreatedContexts.Count;
+            extension.ThrowOnDispose = true;
+            editor.DockHost.BeforeLayoutPublication = restored =>
+            {
+                foreach (BeutlToolDockable tool in BeutlDockFactory.Traverse(restored)
+                    .OfType<BeutlToolDockable>()
+                    .Where(tool => tool.ToolContext.Extension == extension))
+                {
+                    editor.CloseToolTabAsync(tool.ToolContext).AsTask().GetAwaiter().GetResult();
+                }
+            };
+
+            Assert.That(await editor.DockHost.ReadFromJsonAsync(saved)
+                .WaitAsync(TimeSpan.FromSeconds(5)), Is.True);
+            FakeToolContext[] restoredContexts = extension.CreatedContexts
+                .Skip(previousContexts)
+                .ToArray();
+            Assert.Multiple(() =>
+            {
+                Assert.That(restoredContexts, Has.Length.EqualTo(2));
+                Assert.That(restoredContexts, Has.All.Matches<FakeToolContext>(context => context.DisposeCount == 1));
+                Assert.That(editor.DockHost.FindToolContext(extension.GetType()), Is.Null);
+            });
+            await editor.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+        }
+        finally
+        {
+            _ = TestShell.Extensions.RemoveExtensions(RestoreReentryExtensionPackageId);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task DelayedOwnerCallbackCloseAfterApplyUsesNormalAdmission()
+    {
+        await TestReset.ResetShellAsync();
+        var extension = new RestoreReentryToolExtension
+        {
+            DelayCloseFromRead = true,
+        };
+        TestShell.Extensions.AddExtensions(RestoreReentryExtensionPackageId, [extension]);
+        try
+        {
+            EditViewModel editor = await OpenEditorForNewScene("tooltab-delayed-owner-close");
+            Assert.That(await editor.DockHost.OpenToolTabFromExtensionAsync(
+                extension,
+                editor.DockHost.Factory.FindFirstToolDock()), Is.True);
+            var saved = new JsonObject();
+            editor.DockHost.WriteToJson(saved);
+
+            Assert.That(await editor.DockHost.ReadFromJsonAsync(saved)
+                .WaitAsync(TimeSpan.FromSeconds(5)), Is.True);
+            await extension.DelayedCloseStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            extension.ReleaseDelayedClose.TrySetResult();
+            await extension.DelayedCloseCompleted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            Assert.That(editor.DockHost.FindToolContext(extension.GetType()), Is.Null);
+            await editor.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+        }
+        finally
+        {
+            extension.ReleaseDelayedClose.TrySetResult();
+            _ = TestShell.Extensions.RemoveExtensions(RestoreReentryExtensionPackageId);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task ReplacementEditContextDisposedBeforePublicationIsRejected()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel owner = await OpenEditorForNewScene("tooltab-replacement-admission");
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        // Block the old context through a replacement callback while the new EditViewModel is
+        // disposed before its publication reservation can be consumed.
+        var replacementScene = new Scene(16, 16, "replacement-admission")
+        {
+            Uri = new Uri(Path.Combine(BeutlHomeIsolation.CurrentHome!, "replacement-admission.scene"))
+        };
+        Assert.That(SceneEditorExtension.Instance.TryCreateContext(
+            replacementScene,
+            new EditorContextServices(TestShell.Editor, owner.ExtensionProvider),
+            out IEditorContext? replacementContext), Is.True);
+        var replacement = (EditViewModel)replacementContext!;
+        var oldBlocking = new BlockingEditorContext(entered, release);
+        var blockingTab = new EditorTabItem(oldBlocking);
+        TestShell.Editor.AddTabItem(blockingTab);
+        Task<bool> replace = blockingTab.ReplaceContextAsync(replacement).AsTask();
+        await entered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        _ = replacement.DisposeAsync();
+        release.TrySetResult();
+
+        Assert.That(await replace.WaitAsync(TimeSpan.FromSeconds(5)), Is.False);
+        Assert.That(blockingTab.Context.Value, Is.Null);
+        await blockingTab.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+        await owner.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [AvaloniaTest]
+    public async Task ShutdownAdmissionRejectsResetAndApplyWhileDisposalDrains()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditorForNewScene("tooltab-shutdown-admission");
+        var context = new FakeToolContext("shutdown-block");
+        Assert.That(await editor.OpenToolTabAsync(context), Is.True);
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        context.OnDispose = async () =>
+        {
+            entered.TrySetResult();
+            await release.Task;
+        };
+        JsonObject layout = editor.DockHost.CaptureLayout();
+        Task dispose = editor.DisposeAsync().AsTask();
+        await entered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Task reset = editor.DockHost.ResetLayoutAsync();
+        Assert.That(reset.IsCompleted, Is.True);
+        await reset.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.That(await editor.DockHost.ApplyLayoutAsync(layout).WaitAsync(TimeSpan.FromSeconds(5)), Is.False);
+        release.TrySetResult();
+        await dispose.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [AvaloniaTest]
     public async Task DefaultFactoryCanSynchronouslyCloseEarlierDefaultWithoutDeadlock()
     {
         await TestReset.ResetShellAsync();
@@ -804,6 +1061,8 @@ public class ToolTabHeaderTests
 
         public Action<JsonObject>? OnWrite { get; set; }
 
+        public Action<JsonObject>? OnRead { get; set; }
+
         public int DisposeCount { get; private set; }
 
         // Keep HeaderSource alive to test the dockable's unsubscribe.
@@ -819,12 +1078,33 @@ public class ToolTabHeaderTests
 
         public void ReadFromJson(JsonObject json)
         {
+            OnRead?.Invoke(json);
         }
 
         public void WriteToJson(JsonObject json)
         {
             OnWrite?.Invoke(json);
         }
+    }
+
+    private sealed class BlockingEditorContext(
+        TaskCompletionSource entered,
+        TaskCompletionSource release) : IEditorContext
+    {
+        public CoreObject Object { get; } = new Scene(16, 16, "blocking");
+        public EditorExtension Extension => SceneEditorExtension.Instance;
+        public IReactiveProperty<bool> IsEnabled { get; } = new ReactivePropertySlim<bool>(true);
+        public IKnownEditorCommands? Commands => null;
+        public async ValueTask DisposeAsync()
+        {
+            entered.TrySetResult();
+            await release.Task;
+        }
+        public T? FindToolTab<T>(Func<T, bool> condition) where T : IToolContext => default;
+        public T? FindToolTab<T>() where T : IToolContext => default;
+        public ValueTask<bool> OpenToolTabAsync(IToolContext item) => new(false);
+        public ValueTask CloseToolTabAsync(IToolContext item) => ValueTask.CompletedTask;
+        public object? GetService(Type serviceType) => null;
     }
 
     private class BlockingToolExtension : ToolTabExtension
@@ -876,6 +1156,76 @@ public class ToolTabHeaderTests
             [NotNullWhen(true)] out IToolContext? context)
         {
             context = new FakeToolContext("default", this);
+            return true;
+        }
+    }
+
+    private sealed class RestoreReentryToolExtension : ToolTabExtension
+    {
+        public bool DisposeInCreate { get; set; }
+        public bool DisposeInRead { get; set; }
+        public bool CloseInRead { get; set; }
+        public bool DelayCloseFromRead { get; set; }
+        public bool ThrowOnDispose { get; set; }
+        public List<FakeToolContext> CreatedContexts { get; } = [];
+        public TaskCompletionSource DelayedCloseStarted { get; } = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        public TaskCompletionSource ReleaseDelayedClose { get; } = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        public TaskCompletionSource DelayedCloseCompleted { get; } = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public override bool CanMultiple => true;
+        public override string Name => "RestoreReentryToolTab";
+        public override string DisplayName => "Restore reentry tool tab";
+        public override string? Header => "Restore reentry tool tab";
+
+        public override bool TryCreateContent(
+            IEditorContext editorContext,
+            [NotNullWhen(true)] out Control? control)
+        {
+            control = new Border();
+            return true;
+        }
+
+        public override bool TryCreateContext(
+            IEditorContext editorContext,
+            [NotNullWhen(true)] out IToolContext? context)
+        {
+            if (DisposeInCreate)
+                editorContext.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            var created = new FakeToolContext("restore reentry", this);
+            CreatedContexts.Add(created);
+            if (ThrowOnDispose)
+            {
+                created.OnDispose = () => ValueTask.FromException(
+                    new InvalidOperationException("deferred close failed"));
+            }
+            if (DisposeInRead)
+                created.OnRead = _ => editorContext.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            if (CloseInRead)
+                created.OnRead = _ => editorContext.CloseToolTabAsync(created).AsTask().GetAwaiter().GetResult();
+            if (DelayCloseFromRead)
+            {
+                created.OnRead = _json =>
+                {
+                    _ = Task.Run(async () =>
+                    {
+                        try
+                        {
+                            DelayedCloseStarted.TrySetResult();
+                            await ReleaseDelayedClose.Task;
+                            await editorContext.CloseToolTabAsync(created);
+                            DelayedCloseCompleted.TrySetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            DelayedCloseCompleted.TrySetException(ex);
+                        }
+                    });
+                };
+            }
+            context = created;
             return true;
         }
     }

--- a/tests/Beutl.HeadlessUITests/ToolTabHeaderTests.cs
+++ b/tests/Beutl.HeadlessUITests/ToolTabHeaderTests.cs
@@ -163,10 +163,17 @@ public class ToolTabHeaderTests
         EditViewModel editor = await OpenEditorForNewScene("tooltab-reentrant-editor-dispose");
         var context = new FakeToolContext("editor dispose");
         Assert.That(await editor.OpenToolTabAsync(context), Is.True);
-        context.OnDispose = () => editor.DisposeAsync();
+        var closeService = (IEditorContextCloseService)editor.GetService(
+            typeof(IEditorContextCloseService))!;
+        EditorContextCloseRequest closeRequest = default;
+        context.OnDispose = () =>
+        {
+            closeRequest = closeService.RequestClose(editor);
+            return ValueTask.CompletedTask;
+        };
 
         await editor.CloseToolTabAsync(context).AsTask().WaitAsync(TimeSpan.FromSeconds(5));
-        await editor.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+        await closeRequest.Completion.WaitAsync(TimeSpan.FromSeconds(5));
 
         Assert.That(context.DisposeCount, Is.EqualTo(1));
     }
@@ -593,7 +600,7 @@ public class ToolTabHeaderTests
     }
 
     [AvaloniaTest]
-    public async Task DefaultContextCanSynchronouslyRequestEditorDisposalWithoutDeadlock()
+    public async Task DefaultContextCanRequestEditorCloseWithoutDeadlock()
     {
         await TestReset.ResetShellAsync();
         EditViewModel editor = await OpenEditorForNewScene("tooltab-default-dispose-reentry");
@@ -607,6 +614,8 @@ public class ToolTabHeaderTests
         Assert.Multiple(() =>
         {
             Assert.That(extension.ContextCreationCount, Is.EqualTo(1));
+            Assert.That(extension.CloseRequests, Is.Not.Empty);
+            Assert.That(extension.CloseRequestsWerePending, Is.True);
             Assert.That(extension.CreatedContext?.DisposeCount, Is.EqualTo(1));
             Assert.That(TestShell.Editor.TabItems, Does.Not.Contain(ownerTab));
             Assert.That(TestShell.Editor.SelectedTabItem.Value, Is.Not.SameAs(ownerTab));
@@ -618,7 +627,7 @@ public class ToolTabHeaderTests
     {
         await TestReset.ResetShellAsync();
         EditViewModel editor = await OpenEditorForNewScene("tooltab-default-dispose-admission");
-        var extension = new DisposingDefaultToolExtension(waitForDisposal: false);
+        var extension = new DisposingDefaultToolExtension();
         editor.DockHost.DefaultExtensionsOverride = [extension];
 
         await editor.DockHost.ResetLayoutAsync().WaitAsync(TimeSpan.FromSeconds(5));
@@ -627,6 +636,7 @@ public class ToolTabHeaderTests
         Assert.Multiple(() =>
         {
             Assert.That(extension.ContextCreationCount, Is.EqualTo(1));
+            Assert.That(extension.CloseRequests, Is.Not.Empty);
             Assert.That(extension.CreatedContext?.DisposeCount, Is.EqualTo(1));
             Assert.That(editor.DockHost.Factory.EnumerateTools(), Does.Not.Contain(
                 Has.Property(nameof(BeutlToolDockable.ToolContext))
@@ -635,7 +645,7 @@ public class ToolTabHeaderTests
     }
 
     [AvaloniaTest]
-    public async Task InitialDefaultContextCanSynchronouslyRequestEditorDisposal()
+    public async Task InitialDefaultContextCanRequestEditorClose()
     {
         await TestReset.ResetShellAsync();
         var extension = new DisposingDefaultToolExtension();
@@ -657,6 +667,8 @@ public class ToolTabHeaderTests
             Assert.Multiple(() =>
             {
                 Assert.That(extension.ContextCreationCount, Is.GreaterThanOrEqualTo(1));
+                Assert.That(extension.CloseRequests, Is.Not.Empty);
+                Assert.That(extension.CloseRequestsWerePending, Is.True);
                 Assert.That(extension.CreatedContexts, Is.All.Matches<FakeToolContext>(
                     context => context.DisposeCount == 1));
                 Assert.That(TestShell.Editor.TryGetTabItem(scene, out _), Is.False);
@@ -1193,7 +1205,7 @@ public class ToolTabHeaderTests
             [NotNullWhen(true)] out IToolContext? context)
         {
             if (DisposeInCreate)
-                editorContext.DisposeAsync().AsTask().GetAwaiter().GetResult();
+                RequestEditorClose(editorContext);
             var created = new FakeToolContext("restore reentry", this);
             CreatedContexts.Add(created);
             if (ThrowOnDispose)
@@ -1202,7 +1214,7 @@ public class ToolTabHeaderTests
                     new InvalidOperationException("deferred close failed"));
             }
             if (DisposeInRead)
-                created.OnRead = _ => editorContext.DisposeAsync().AsTask().GetAwaiter().GetResult();
+                created.OnRead = _ => RequestEditorClose(editorContext);
             if (CloseInRead)
                 created.OnRead = _ => editorContext.CloseToolTabAsync(created).AsTask().GetAwaiter().GetResult();
             if (DelayCloseFromRead)
@@ -1228,17 +1240,26 @@ public class ToolTabHeaderTests
             context = created;
             return true;
         }
+
+        private static void RequestEditorClose(IEditorContext editorContext)
+        {
+            var closeService = (IEditorContextCloseService?)editorContext.GetService(
+                typeof(IEditorContextCloseService));
+            _ = closeService?.RequestClose(editorContext);
+        }
     }
 
-    private sealed class DisposingDefaultToolExtension(
-        bool waitForDisposal = true,
-        int disposeCalls = 1) : ToolTabExtension
+    private sealed class DisposingDefaultToolExtension(int disposeCalls = 1) : ToolTabExtension
     {
         public int ContextCreationCount { get; private set; }
 
         public FakeToolContext? CreatedContext { get; private set; }
 
         public List<FakeToolContext> CreatedContexts { get; } = [];
+
+        public List<EditorContextCloseRequest> CloseRequests { get; } = [];
+
+        public bool CloseRequestsWerePending { get; private set; } = true;
 
         public override bool CanMultiple => true;
         public override string Name => "DisposingDefaultToolTab";
@@ -1259,11 +1280,13 @@ public class ToolTabHeaderTests
             [NotNullWhen(true)] out IToolContext? context)
         {
             ContextCreationCount++;
+            var closeService = (IEditorContextCloseService)editorContext.GetService(
+                typeof(IEditorContextCloseService))!;
             for (int i = 0; i < disposeCalls; i++)
             {
-                ValueTask disposal = editorContext.DisposeAsync();
-                if (waitForDisposal)
-                    disposal.AsTask().GetAwaiter().GetResult();
+                EditorContextCloseRequest request = closeService.RequestClose(editorContext);
+                CloseRequests.Add(request);
+                CloseRequestsWerePending &= !request.Completion.IsCompleted;
             }
             context = CreatedContext = new FakeToolContext("disposing-default", this);
             CreatedContexts.Add(CreatedContext);

--- a/tests/Beutl.HeadlessUITests/ToolTabHeaderTests.cs
+++ b/tests/Beutl.HeadlessUITests/ToolTabHeaderTests.cs
@@ -895,7 +895,7 @@ public class ToolTabHeaderTests
             new EditorContextServices(TestShell.Editor, owner.ExtensionProvider),
             out IEditorContext? replacementContext), Is.True);
         var replacement = (EditViewModel)replacementContext!;
-        var oldBlocking = new BlockingEditorContext(entered, release);
+        var oldBlocking = new BlockingEditorContext(entered, release, TestShell.Editor);
         var blockingTab = new EditorTabItem(oldBlocking);
         TestShell.Editor.AddTabItem(blockingTab);
         Task<bool> replace = blockingTab.ReplaceContextAsync(replacement).AsTask();
@@ -1101,11 +1101,12 @@ public class ToolTabHeaderTests
 
     private sealed class BlockingEditorContext(
         TaskCompletionSource entered,
-        TaskCompletionSource release) : IEditorContext
+        TaskCompletionSource release,
+        IEditorContextCloseService closeService) : IEditorContext
     {
         public CoreObject Object { get; } = new Scene(16, 16, "blocking");
         public EditorExtension Extension => SceneEditorExtension.Instance;
-        public IEditorContextCloseService CloseService { get; } = new UnownedCloseService();
+        public IEditorContextCloseService CloseService { get; } = closeService;
         public IReactiveProperty<bool> IsEnabled { get; } = new ReactivePropertySlim<bool>(true);
         public IKnownEditorCommands? Commands => null;
         public async ValueTask DisposeAsync()
@@ -1118,12 +1119,6 @@ public class ToolTabHeaderTests
         public ValueTask<bool> OpenToolTabAsync(IToolContext item) => new(false);
         public ValueTask CloseToolTabAsync(IToolContext item) => ValueTask.CompletedTask;
         public object? GetService(Type serviceType) => null;
-    }
-
-    private sealed class UnownedCloseService : IEditorContextCloseService
-    {
-        public EditorContextCloseRequest RequestClose(IEditorContext context)
-            => new(EditorContextCloseRequestStatus.NotOwned, Task.CompletedTask);
     }
 
     private class BlockingToolExtension : ToolTabExtension

--- a/tests/Beutl.HeadlessUITests/ToolTabHeaderTests.cs
+++ b/tests/Beutl.HeadlessUITests/ToolTabHeaderTests.cs
@@ -264,8 +264,16 @@ public class ToolTabHeaderTests
         editor.DockHost.Factory.CloseDockable(dockable);
 
         Assert.That(tracked, Is.Not.Null);
-        Assert.CatchAsync<Exception>(async () =>
-            await tracked!.WaitAsync(TimeSpan.FromSeconds(5)));
+        Exception? failure = null;
+        try
+        {
+            await tracked!.WaitAsync(TimeSpan.FromSeconds(5));
+        }
+        catch (Exception ex) when (ex is not TimeoutException)
+        {
+            failure = ex;
+        }
+        Assert.That(failure, Is.Not.Null);
         Assert.That(context.DisposeCount, Is.EqualTo(1));
     }
 
@@ -795,6 +803,44 @@ public class ToolTabHeaderTests
     }
 
     [AvaloniaTest]
+    public async Task Scene_activation_waits_for_restored_tool_teardown()
+    {
+        await TestReset.ResetShellAsync();
+        var extension = new RestoreReentryToolExtension();
+        TestShell.Extensions.AddExtensions(RestoreReentryExtensionPackageId, [extension]);
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        try
+        {
+            EditViewModel editor = await OpenEditorForNewScene("scene-restore-drain");
+            Scene scene = editor.Scene;
+            Assert.That(await editor.DockHost.OpenToolTabFromExtensionAsync(
+                extension, editor.DockHost.Factory.FindFirstToolDock()), Is.True);
+            await TestShell.Editor.CloseTabItem(TestShell.Editor.SelectedTabItem.Value!);
+            extension.CloseInRead = true;
+            extension.OnDispose = async () =>
+            {
+                entered.TrySetResult();
+                await release.Task;
+            };
+            Task activation = TestShell.Editor.ActivateTabItemAsync(scene);
+            await entered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.That(activation.IsCompleted, Is.False);
+            Assert.That(TestShell.Editor.TryGetTabItem(scene, out _), Is.False);
+            release.TrySetResult();
+            await activation.WaitAsync(TimeSpan.FromSeconds(5));
+            var restored = (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value!;
+            Assert.That(restored.Initialization.IsCompletedSuccessfully, Is.True);
+            Assert.That(restored.DockHost.FindToolContext(extension.GetType()), Is.Null);
+        }
+        finally
+        {
+            release.TrySetResult();
+            _ = TestShell.Extensions.RemoveExtensions(RestoreReentryExtensionPackageId);
+        }
+    }
+
+    [AvaloniaTest]
     public async Task PublicationCloseCallbackDoesNotDeadlockOrPublishDisposedTool()
     {
         await TestReset.ResetShellAsync();
@@ -1210,6 +1256,7 @@ public class ToolTabHeaderTests
 
     private sealed class RestoreReentryToolExtension : ToolTabExtension
     {
+        public Func<ValueTask>? OnDispose { get; set; }
         public bool DisposeInCreate { get; set; }
         public bool DisposeInRead { get; set; }
         public bool CloseInRead { get; set; }
@@ -1243,6 +1290,7 @@ public class ToolTabHeaderTests
             if (DisposeInCreate)
                 RequestEditorClose(editorContext);
             var created = new FakeToolContext("restore reentry", this);
+            created.OnDispose = OnDispose;
             CreatedContexts.Add(created);
             if (ThrowOnDispose)
             {

--- a/tests/Beutl.HeadlessUITests/ToolTabHeaderTests.cs
+++ b/tests/Beutl.HeadlessUITests/ToolTabHeaderTests.cs
@@ -2,6 +2,7 @@
 using System.Text.Json.Nodes;
 using Avalonia.Controls;
 using Avalonia.Headless.NUnit;
+using Beutl.Api.Services;
 using Beutl.Extensibility;
 using Beutl.ProjectSystem;
 using Beutl.Services;
@@ -36,7 +37,7 @@ public class ToolTabHeaderTests
         HeadlessTestHelpers.Settle();
         Scene scene = project.Items.OfType<Scene>().First();
 
-        TestShell.Editor.ActivateTabItem(scene);
+        await TestShell.Editor.ActivateTabItemAsync(scene);
         HeadlessTestHelpers.Settle();
         return (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value!;
     }
@@ -477,6 +478,10 @@ public class ToolTabHeaderTests
         outgoing.OnDispose = async () =>
         {
             Assert.That(await editor.OpenToolTabAsync(fresh), Is.False);
+            Assert.That(
+                fresh.DisposeCount,
+                Is.EqualTo(1),
+                "A rejected fresh context must finish disposal before OpenToolTabAsync returns.");
         };
 
         await editor.DockHost.ResetLayoutAsync().WaitAsync(TimeSpan.FromSeconds(5));
@@ -484,6 +489,36 @@ public class ToolTabHeaderTests
         Assert.That(fresh.DisposeCount, Is.EqualTo(1));
         Assert.That(editor.DockHost.Factory.EnumerateTools(), Does.Not.Contain(
             Has.Property(nameof(BeutlToolDockable.ToolContext)).SameAs(fresh)));
+    }
+
+    [AvaloniaTest]
+    public async Task ToolContextCannotBeOpenedOrClosedByAnotherEditorHost()
+    {
+        await TestReset.ResetShellAsync();
+        var firstService = new EditorService(new ExtensionProvider());
+        var secondService = new EditorService(new ExtensionProvider());
+        var firstScene = new Scene(16, 16, string.Empty)
+        {
+            Uri = new Uri(Path.Combine(Path.GetTempPath(), "first-tool-host.scene"))
+        };
+        var secondScene = new Scene(16, 16, string.Empty)
+        {
+            Uri = new Uri(Path.Combine(Path.GetTempPath(), "second-tool-host.scene"))
+        };
+        await using var firstEditor = new EditViewModel(firstScene, firstService, firstService);
+        await using var secondEditor = new EditViewModel(secondScene, secondService, secondService);
+        var context = new FakeToolContext("exclusive-tool");
+
+        Assert.That(await firstEditor.OpenToolTabAsync(context), Is.True);
+        Assert.That(await secondEditor.OpenToolTabAsync(context), Is.False);
+        Assert.That(context.DisposeCount, Is.Zero);
+
+        await secondEditor.CloseToolTabAsync(context);
+        Assert.That(context.DisposeCount, Is.Zero);
+        Assert.That(firstEditor.FindToolTab<FakeToolContext>(), Is.SameAs(context));
+
+        await firstEditor.CloseToolTabAsync(context);
+        Assert.That(context.DisposeCount, Is.EqualTo(1));
     }
 
     [AvaloniaTest]
@@ -889,10 +924,10 @@ public class ToolTabHeaderTests
         {
             Uri = new Uri(Path.Combine(BeutlHomeIsolation.CurrentHome!, "replacement-admission.scene"))
         };
-        Assert.That(SceneEditorExtension.Instance.TryCreateContext(
+        IEditorContext? replacementContext = await SceneEditorExtension.Instance.CreateContextAsync(
             replacementScene,
-            new EditorContextServices(TestShell.Editor, owner.ExtensionProvider),
-            out IEditorContext? replacementContext), Is.True);
+            new EditorContextServices(TestShell.Editor, owner.ExtensionProvider));
+        Assert.That(replacementContext, Is.Not.Null);
         var replacement = (EditViewModel)replacementContext!;
         var oldBlocking = new BlockingEditorContext(entered, release, TestShell.Editor);
         var blockingTab = new EditorTabItem(oldBlocking);

--- a/tests/Beutl.HeadlessUITests/TutorialServiceAsyncPrerequisiteTests.cs
+++ b/tests/Beutl.HeadlessUITests/TutorialServiceAsyncPrerequisiteTests.cs
@@ -1,0 +1,96 @@
+﻿using Avalonia.Headless.NUnit;
+using Beutl.Services.Tutorials;
+
+namespace Beutl.HeadlessUITests;
+
+[TestFixture]
+public sealed class TutorialServiceAsyncPrerequisiteTests
+{
+    [AvaloniaTest]
+    public async Task StartTutorialWaitsForAsyncCanStartAndStopsWhenFalse()
+    {
+        await TestReset.ResetShellAsync();
+        var gate = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var service = new TutorialServiceHandler();
+        service.Register(Tutorial("async-false", () => gate.Task));
+
+        Task start = service.StartTutorial("async-false");
+        Assert.That(start.IsCompleted, Is.False);
+        Assert.That(service.GetCurrentState(), Is.Null);
+
+        gate.SetResult(false);
+        await start.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.That(service.GetCurrentState(), Is.Null);
+    }
+
+    [AvaloniaTest]
+    public async Task StartTutorialRechecksCanStartAfterFulfillingPrerequisites()
+    {
+        await TestReset.ResetShellAsync();
+        bool ready = false;
+        int checks = 0;
+        int fulfills = 0;
+        var service = new TutorialServiceHandler();
+        service.Register(Tutorial(
+            "async-recheck",
+            () =>
+            {
+                checks++;
+                return Task.FromResult(ready);
+            },
+            () =>
+            {
+                fulfills++;
+                ready = true;
+                return Task.FromResult(true);
+            }));
+
+        await service.StartTutorial("async-recheck", autoFulfillPrerequisites: true)
+            .WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(checks, Is.EqualTo(2));
+            Assert.That(fulfills, Is.EqualTo(1));
+            Assert.That(service.GetCurrentState()?.Definition.Id, Is.EqualTo("async-recheck"));
+        });
+        service.CancelTutorial();
+    }
+
+    [AvaloniaTest]
+    public async Task StartTutorialDoesNotStartWhenAsyncCanStartThrows()
+    {
+        await TestReset.ResetShellAsync();
+        var service = new TutorialServiceHandler();
+        service.Register(Tutorial(
+            "async-error",
+            static () => Task.FromException<bool>(new InvalidOperationException("failed"))));
+
+        Assert.DoesNotThrowAsync(async () =>
+            await service.StartTutorial("async-error").WaitAsync(TimeSpan.FromSeconds(5)));
+        Assert.That(service.GetCurrentState(), Is.Null);
+    }
+
+    private static TutorialDefinition Tutorial(
+        string id,
+        Func<Task<bool>> canStart,
+        Func<Task<bool>>? fulfill = null)
+        => new()
+        {
+            Id = id,
+            Title = id,
+            Description = id,
+            CanStart = canStart,
+            FulfillPrerequisites = fulfill,
+            Steps =
+            [
+                new TutorialStep
+                {
+                    Id = "step",
+                    Title = "Step",
+                    Content = "Content",
+                },
+            ],
+        };
+}

--- a/tests/Beutl.HeadlessUITests/VersionControlRestoreTests.cs
+++ b/tests/Beutl.HeadlessUITests/VersionControlRestoreTests.cs
@@ -277,7 +277,7 @@ public class VersionControlRestoreTests
             coordinator.ConfirmRestoreAsync = _ => Task.FromResult(true);
             await WaitUntilAsync(() => ReferenceEquals(coordinator.CurrentService, backend));
 
-            TestShell.Editor.TabItems.Add(new EditorTabItem(
+            TestShell.Editor.TryAddTabItem(new EditorTabItem(
                 new BlockingDisposeEditorContext(
                     new Scene { Uri = new Uri(Path.Combine(projectRoot, "blocking.scene")) },
                     disposeStarted,
@@ -927,7 +927,7 @@ public class VersionControlRestoreTests
                 serviceFactory: candidate => candidate is null ? discovery : tracked);
             await WaitUntilAsync(() => ReferenceEquals(coordinator.CurrentService, tracked));
 
-            TestShell.Editor.TabItems.Add(new EditorTabItem(
+            TestShell.Editor.TryAddTabItem(new EditorTabItem(
                 new BlockingDisposeEditorContext(
                     new Scene { Uri = new Uri(Path.Combine(projectRoot, "blocking.scene")) },
                     disposeStarted,
@@ -1257,7 +1257,8 @@ public class VersionControlRestoreTests
             var commands = new PassiveSaveCommands();
             var context = new PassiveEditorContext(project, commands);
             var editorService = new EditorService(new ExtensionProvider());
-            editorService.TabItems.Add(new EditorTabItem(context));
+            context.CloseService = editorService;
+            editorService.TryAddTabItem(new EditorTabItem(context));
             coordinator = new VersionControlCoordinator(
                 TestShell.Project,
                 editorService,
@@ -1334,7 +1335,8 @@ public class VersionControlRestoreTests
             var commands = new PassiveSaveCommands();
             var context = new PassiveEditorContext(project, commands);
             var editorService = new EditorService(new ExtensionProvider());
-            editorService.TabItems.Add(new EditorTabItem(context));
+            context.CloseService = editorService;
+            editorService.TryAddTabItem(new EditorTabItem(context));
             coordinator = new VersionControlCoordinator(
                 TestShell.Project,
                 editorService,
@@ -1409,7 +1411,8 @@ public class VersionControlRestoreTests
             var commands = new PassiveSaveCommands();
             var context = new PassiveEditorContext(project, commands);
             var editorService = new EditorService(new ExtensionProvider());
-            editorService.TabItems.Add(new EditorTabItem(context));
+            context.CloseService = editorService;
+            editorService.TryAddTabItem(new EditorTabItem(context));
             coordinator = new VersionControlCoordinator(
                 TestShell.Project,
                 editorService,
@@ -5508,8 +5511,8 @@ public class VersionControlRestoreTests
             };
             var editorService = new EditorService(new ExtensionProvider());
             var failedCommands = new FailedSaveCommands();
-            editorService.TabItems.Add(new EditorTabItem(
-                new FailedSaveEditorContext(project, failedCommands)));
+            editorService.TryAddTabItem(new EditorTabItem(
+                new FailedSaveEditorContext(project, failedCommands) { CloseService = editorService }));
             coordinator = new VersionControlCoordinator(
                 TestShell.Project,
                 editorService,
@@ -5780,8 +5783,8 @@ public class VersionControlRestoreTests
             var backend = new PullCycleTestBackend(repository, repository, tip);
             var editorService = new EditorService(new ExtensionProvider());
             var failedCommands = new FailedSaveCommands();
-            editorService.TabItems.Add(new EditorTabItem(
-                new FailedSaveEditorContext(project, failedCommands)));
+            editorService.TryAddTabItem(new EditorTabItem(
+                new FailedSaveEditorContext(project, failedCommands) { CloseService = editorService }));
             coordinator = new VersionControlCoordinator(
                 TestShell.Project,
                 editorService,
@@ -10652,7 +10655,7 @@ public class VersionControlRestoreTests
         Assert.That(initialized, Is.True);
 
         Scene scene = project.Items.OfType<Scene>().Single();
-        TestShell.Editor.ActivateTabItem(scene);
+        await TestShell.Editor.ActivateTabItemAsync(scene);
         HeadlessTestHelpers.Settle();
         var editor = (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
         return (project, editor);
@@ -10912,6 +10915,10 @@ public class VersionControlRestoreTests
         CoreObject obj,
         PassiveSaveCommands commands) : IEditorContext
     {
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+        public IEditorContextCloseService CloseService { get; set; } = TestShell.Editor;
+
         public CoreObject Object { get; } = obj;
 
         public EditorExtension Extension => SceneEditorExtension.Instance;
@@ -10931,10 +10938,11 @@ public class VersionControlRestoreTests
             where T : IToolContext
             => default;
 
-        public bool OpenToolTab(IToolContext item) => false;
+        public ValueTask<bool> OpenToolTabAsync(IToolContext item) => ValueTask.FromResult(false);
 
-        public void CloseToolTab(IToolContext item)
+        public ValueTask CloseToolTabAsync(IToolContext item)
         {
+            return ValueTask.CompletedTask;
         }
     }
 
@@ -10943,6 +10951,8 @@ public class VersionControlRestoreTests
         TaskCompletionSource disposeStarted,
         Task releaseDispose) : IEditorContext
     {
+        public IEditorContextCloseService CloseService { get; set; } = TestShell.Editor;
+
         public CoreObject Object { get; } = obj;
 
         public EditorExtension Extension => SceneEditorExtension.Instance;
@@ -10962,10 +10972,11 @@ public class VersionControlRestoreTests
             where T : IToolContext
             => default;
 
-        public bool OpenToolTab(IToolContext item) => false;
+        public ValueTask<bool> OpenToolTabAsync(IToolContext item) => ValueTask.FromResult(false);
 
-        public void CloseToolTab(IToolContext item)
+        public ValueTask CloseToolTabAsync(IToolContext item)
         {
+            return ValueTask.CompletedTask;
         }
 
         public async ValueTask DisposeAsync()
@@ -10990,6 +11001,10 @@ public class VersionControlRestoreTests
         CoreObject obj,
         FailedSaveCommands commands) : IEditorContext
     {
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+        public IEditorContextCloseService CloseService { get; set; } = TestShell.Editor;
+
         public CoreObject Object { get; } = obj;
 
         public EditorExtension Extension => SceneEditorExtension.Instance;
@@ -11009,10 +11024,11 @@ public class VersionControlRestoreTests
             where T : IToolContext
             => default;
 
-        public bool OpenToolTab(IToolContext item) => false;
+        public ValueTask<bool> OpenToolTabAsync(IToolContext item) => ValueTask.FromResult(false);
 
-        public void CloseToolTab(IToolContext item)
+        public ValueTask CloseToolTabAsync(IToolContext item)
         {
+            return ValueTask.CompletedTask;
         }
     }
 

--- a/tests/Beutl.HeadlessUITests/VersionControlSaveTests.cs
+++ b/tests/Beutl.HeadlessUITests/VersionControlSaveTests.cs
@@ -103,7 +103,7 @@ public class VersionControlSaveTests
             {
                 Uri = new Uri(Path.Combine(projectRoot, "failed.scene")),
             };
-            TestShell.Editor.TabItems.Add(new EditorTabItem(
+            TestShell.Editor.TryAddTabItem(new EditorTabItem(
                 new FailedSaveEditorContext(failedItem, failedCommands)));
             project.Variables["partially-saved"] = "true";
 
@@ -154,7 +154,7 @@ public class VersionControlSaveTests
                 "explicit-save",
                 location))!;
             Scene scene = project.Items.OfType<Scene>().Single();
-            TestShell.Editor.ActivateTabItem(scene);
+            await TestShell.Editor.ActivateTabItemAsync(scene);
             HeadlessTestHelpers.Settle();
             var editor = (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
             var adder = (IElementAdder)editor.GetService(typeof(IElementAdder))!;
@@ -214,7 +214,7 @@ public class VersionControlSaveTests
             Assert.That(await CountCommitsAsync(gitPath, projectRoot), Is.EqualTo(1));
 
             Scene scene = project.Items.OfType<Scene>().Single();
-            TestShell.Editor.ActivateTabItem(scene);
+            await TestShell.Editor.ActivateTabItemAsync(scene);
             HeadlessTestHelpers.Settle();
             var editor = (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
             Assert.That(
@@ -242,7 +242,7 @@ public class VersionControlSaveTests
             });
 
             await File.WriteAllTextAsync(Path.Combine(projectRoot, "close-marker.txt"), "close\n");
-            TestShell.MainViewModel.MenuBar.CloseProject.Execute();
+            await TestShell.MainViewModel.MenuBar.CloseProject.ExecuteAsync();
             int afterClose = await CountCommitsAsync(gitPath, projectRoot);
             int closeSnapshots = await CountCloseSnapshotsAsync(gitPath, projectRoot);
 
@@ -308,7 +308,7 @@ public class VersionControlSaveTests
 
             string projectRoot = Path.GetDirectoryName(project.Uri!.LocalPath)!;
             Scene scene = project.Items.OfType<Scene>().Single();
-            TestShell.Editor.ActivateTabItem(scene);
+            await TestShell.Editor.ActivateTabItemAsync(scene);
             HeadlessTestHelpers.Settle();
             var editor = (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
             var adder = (IElementAdder)editor.GetService(typeof(IElementAdder))!;
@@ -474,7 +474,7 @@ public class VersionControlSaveTests
             string projectFile = project.Uri!.LocalPath;
             string projectRoot = Path.GetDirectoryName(projectFile)!;
             int initialCommitCount = await CountCommitsAsync(gitPath, projectRoot);
-            TestShell.MainViewModel.MenuBar.CloseProject.Execute();
+            await TestShell.MainViewModel.MenuBar.CloseProject.ExecuteAsync();
             File.Delete(Path.Combine(projectRoot, ".gitignore"));
             File.Delete(Path.Combine(projectRoot, ".gitattributes"));
 
@@ -621,8 +621,8 @@ public class VersionControlSaveTests
             Uri = new Uri(Path.Combine(projectRoot, "blocking.scene")),
         };
         var tabItem = new EditorTabItem(new FailedSaveEditorContext(blockingItem, blocking));
-        TestShell.Editor.TabItems.Add(tabItem);
-        TestShell.Editor.SelectedTabItem.Value = tabItem;
+        TestShell.Editor.TryAddTabItem(tabItem);
+        TestShell.Editor.ActivateTabItem(tabItem);
         HeadlessTestHelpers.Settle();
         return (project, blocking);
     }
@@ -779,7 +779,7 @@ public class VersionControlSaveTests
             string projectRoot = Path.GetDirectoryName(project.Uri!.LocalPath)!;
 
             Scene scene = project.Items.OfType<Scene>().Single();
-            TestShell.Editor.ActivateTabItem(scene);
+            await TestShell.Editor.ActivateTabItemAsync(scene);
             HeadlessTestHelpers.Settle();
             var editor = (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
             var adder = (IElementAdder)editor.GetService(typeof(IElementAdder))!;
@@ -859,14 +859,14 @@ public class VersionControlSaveTests
             string projectRoot = Path.GetDirectoryName(project.Uri!.LocalPath)!;
             Scene scene = project.Items.OfType<Scene>().Single();
             string scenePath = ToRepositoryPath(projectRoot, scene.Uri!.LocalPath);
-            TestShell.Editor.ActivateTabItem(scene);
+            await TestShell.Editor.ActivateTabItemAsync(scene);
             HeadlessTestHelpers.Settle();
             var editor = (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
             var adder = (IElementAdder)editor.GetService(typeof(IElementAdder))!;
             await AddRectangleAsync(adder);
             HeadlessTestHelpers.Settle();
 
-            TestShell.MainViewModel.MenuBar.CloseProject.Execute();
+            await TestShell.MainViewModel.MenuBar.CloseProject.ExecuteAsync();
 
             string committedScene = await RunGitAsync(
                 gitPath,
@@ -1174,9 +1174,9 @@ public class VersionControlSaveTests
             };
             var failedContext = new FailedSaveEditorContext(failedItem, failedCommands);
             var failedTab = new EditorTabItem(failedContext);
-            TestShell.Editor.TabItems.Add(failedTab);
+            TestShell.Editor.TryAddTabItem(failedTab);
 
-            bool disposed = TestShell.MainViewModel.TryDisposeForWindowClose();
+            bool disposed = await TestShell.MainViewModel.TryDisposeForWindowCloseAsync();
 
             int closeSnapshots = await CountCloseSnapshotsAsync(gitPath, projectRoot);
             int commitsAfterClose = await CountCommitsAsync(gitPath, projectRoot);
@@ -1204,7 +1204,7 @@ public class VersionControlSaveTests
                 Is.False);
             int commitsAfterFailedPackageSave = await CountCommitsAsync(gitPath, projectRoot);
             config.AutoCommitOnClose = true;
-            Assert.DoesNotThrow(TestShell.Project.CloseProject);
+            Assert.That(await TestShell.MainViewModel.TryDisposeForWindowCloseAsync(), Is.False);
             Assert.Multiple(() =>
             {
                 Assert.That(failedCommands.SaveCalls, Is.EqualTo(3));
@@ -1347,6 +1347,10 @@ public class VersionControlSaveTests
         CoreObject obj,
         IKnownEditorCommands commands) : IEditorContext
     {
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+        public IEditorContextCloseService CloseService { get; set; } = TestShell.Editor;
+
         public CoreObject Object { get; } = obj;
 
         public EditorExtension Extension => SceneEditorExtension.Instance;
@@ -1369,10 +1373,11 @@ public class VersionControlSaveTests
             return default;
         }
 
-        public bool OpenToolTab(IToolContext item) => false;
+        public ValueTask<bool> OpenToolTabAsync(IToolContext item) => ValueTask.FromResult(false);
 
-        public void CloseToolTab(IToolContext item)
+        public ValueTask CloseToolTabAsync(IToolContext item)
         {
+            return ValueTask.CompletedTask;
         }
     }
 

--- a/tests/Beutl.HeadlessUITests/VersionControlTabViewTests.cs
+++ b/tests/Beutl.HeadlessUITests/VersionControlTabViewTests.cs
@@ -303,7 +303,7 @@ public class VersionControlTabViewTests
                 TestShell.VersionControl.CurrentService!;
             TestShell.Editor.PublishProjectVersionControlService(null);
             Scene scene = project.Items.OfType<Scene>().Single();
-            TestShell.Editor.ActivateTabItem(scene);
+            await TestShell.Editor.ActivateTabItemAsync(scene);
             HeadlessTestHelpers.Settle();
             IEditorContext editorContext =
                 TestShell.Editor.SelectedTabItem.Value!.Context.Value;
@@ -312,7 +312,7 @@ public class VersionControlTabViewTests
                     editorContext,
                     out IToolContext? context),
                 Is.True);
-            using var viewModel = (VersionControlTabViewModel)context!;
+            await using var viewModel = (VersionControlTabViewModel)context!;
             var view = new VersionControlTabView { DataContext = viewModel };
             window.Content = view;
             window.Show();
@@ -376,7 +376,7 @@ public class VersionControlTabViewTests
                 "untracked",
                 location))!;
             Scene scene = project.Items.OfType<Scene>().Single();
-            TestShell.Editor.ActivateTabItem(scene);
+            await TestShell.Editor.ActivateTabItemAsync(scene);
             HeadlessTestHelpers.Settle();
             IEditorContext editorContext = TestShell.Editor.SelectedTabItem.Value!.Context.Value;
 
@@ -385,7 +385,7 @@ public class VersionControlTabViewTests
                     editorContext,
                     out IToolContext? context),
                 Is.True);
-            using var viewModel = (VersionControlTabViewModel)context!;
+            await using var viewModel = (VersionControlTabViewModel)context!;
             var view = new VersionControlTabView { DataContext = viewModel };
             var handler = new RecordingCommandHandler();
             window.DataContext = handler;
@@ -876,12 +876,12 @@ public class VersionControlTabViewTests
                         "headless@example.invalid"))),
                 Is.True);
             Scene scene = project.Items.OfType<Scene>().Single();
-            TestShell.Editor.ActivateTabItem(scene);
+            await TestShell.Editor.ActivateTabItemAsync(scene);
             HeadlessTestHelpers.Settle();
             IEditorContext editorContext =
                 TestShell.Editor.SelectedTabItem.Value!.Context.Value;
             var coordinator = new PendingRecoveryCoordinator();
-            using var viewModel = new VersionControlTabViewModel(
+            await using var viewModel = new VersionControlTabViewModel(
                 VersionControlTabExtension.Instance,
                 editorContext,
                 TestShell.Editor.ProjectVersionControlService,

--- a/tests/Beutl.HeadlessUITests/VideoFileImportTests.cs
+++ b/tests/Beutl.HeadlessUITests/VideoFileImportTests.cs
@@ -57,7 +57,7 @@ public class VideoFileImportTests
         HeadlessTestHelpers.Settle();
         Scene scene = project.Items.OfType<Scene>().First();
 
-        TestShell.Editor.ActivateTabItem(scene);
+        await TestShell.Editor.ActivateTabItemAsync(scene);
         HeadlessTestHelpers.Settle();
 
         EditorTabItem tab = TestShell.Editor.SelectedTabItem.Value!;

--- a/tests/Beutl.HeadlessUITests/VideoFileImportTests.cs
+++ b/tests/Beutl.HeadlessUITests/VideoFileImportTests.cs
@@ -61,7 +61,7 @@ public class VideoFileImportTests
         HeadlessTestHelpers.Settle();
 
         EditorTabItem tab = TestShell.Editor.SelectedTabItem.Value!;
-        return (EditViewModel)tab.Context.Value;
+        return (EditViewModel)tab.Context.Value!;
     }
 
     [AvaloniaTest]

--- a/tests/Beutl.PublicApiContractTests/Beutl.PublicApiContractTests.csproj
+++ b/tests/Beutl.PublicApiContractTests/Beutl.PublicApiContractTests.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <Using Include="NUnit.Framework" />
+    <Compile Include="../../samples/PackageSample/SampleEditorExtension.cs" Link="Samples/SampleEditorExtension.cs" />
   </ItemGroup>
 
   <ItemGroup>
@@ -30,6 +31,7 @@
     <ProjectReference Include="..\..\src\Beutl.Api\Beutl.Api.csproj" />
     <ProjectReference Include="..\..\src\Beutl.Editor\Beutl.Editor.csproj" />
     <ProjectReference Include="..\..\src\Beutl.Extensibility\Beutl.Extensibility.csproj" />
+    <ProjectReference Include="..\..\src\Beutl.ProjectSystem\Beutl.ProjectSystem.csproj" />
     <!-- Match the analyzer reference used by out-of-tree plugins. -->
     <ProjectReference Include="..\..\src\Beutl.Engine.SourceGenerators\Beutl.Engine.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>

--- a/tests/Beutl.PublicApiContractTests/Beutl.PublicApiContractTests.csproj
+++ b/tests/Beutl.PublicApiContractTests/Beutl.PublicApiContractTests.csproj
@@ -6,10 +6,13 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Avalonia" />
+    <PackageReference Include="FluentAvaloniaUI" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />
     <PackageReference Include="Refit" />
+    <PackageReference Include="ReactiveProperty" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Beutl.PublicApiContractTests/EditorLifecycleAuthoringContractTests.cs
+++ b/tests/Beutl.PublicApiContractTests/EditorLifecycleAuthoringContractTests.cs
@@ -1,0 +1,180 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Nodes;
+using Avalonia.Controls;
+using Avalonia.Platform.Storage;
+using Beutl.Extensibility;
+using FluentAvalonia.UI.Controls;
+using Reactive.Bindings;
+
+namespace Beutl.PublicApiContractTests;
+
+[TestFixture]
+public sealed class EditorLifecycleAuthoringContractTests
+{
+    [Test]
+    public async Task ExternalHost_CanOwnAndCloseAsyncEditorContexts()
+    {
+        var hostToken = new EditorContextHostToken();
+        var closeService = new ExternalCloseService(hostToken);
+        var services = new ExternalEditorContextServices(closeService);
+        var context = new ExternalEditorContext(services.CloseService);
+        var tool = new ExternalToolContext();
+        var extension = new ExternalEditorExtension();
+
+        IEditorContext? authoredContext = await extension.CreateContextAsync(null!, services);
+        Assert.That(authoredContext, Is.Not.Null);
+        await authoredContext!.DisposeAsync();
+
+        Assert.That(services.TryGetService<IEditorContextCloseService>(out var resolved), Is.True);
+        Assert.That(resolved, Is.SameAs(closeService));
+        Assert.That(hostToken.TryAcquireContext(context, out var lease), Is.True);
+        Assert.That(hostToken.TryAcquireContext(context, out var duplicateLease), Is.False);
+        Assert.That(duplicateLease, Is.Null);
+        Assert.That(new EditorContextHostToken().TryAcquireContext(context, out _), Is.False);
+
+        Assert.That(await context.OpenToolTabAsync(tool), Is.True);
+        Assert.That(context.FindToolTab<ExternalToolContext>(), Is.SameAs(tool));
+
+        EditorContextCloseRequest request = context.CloseService.RequestClose(context);
+        Assert.That(request.Status, Is.EqualTo(EditorContextCloseRequestStatus.Accepted));
+        await request.Completion;
+
+        await context.CloseToolTabAsync(tool);
+        Assert.That(tool.DisposeCount, Is.EqualTo(1));
+
+        var claimedTool = new ExternalToolContext();
+        var firstToolHost = new ToolContextHostToken();
+        var secondToolHost = new ToolContextHostToken();
+        Assert.That(firstToolHost.TryAcquireContext(claimedTool, out var toolLease), Is.True);
+        Assert.That(secondToolHost.TryAcquireContext(claimedTool, out var competingToolLease), Is.False);
+        Assert.That(competingToolLease, Is.Null);
+        await claimedTool.DisposeAsync();
+        toolLease!.Dispose();
+
+        await context.DisposeAsync();
+        lease!.Dispose();
+        Assert.That(context.DisposeCount, Is.EqualTo(1));
+    }
+
+    private sealed class ExternalEditorContextServices(IEditorContextCloseService closeService)
+        : IEditorContextServices
+    {
+        public IExtensionProvider ExtensionProvider => null!;
+
+        public IEditorContextCloseService CloseService { get; } = closeService;
+
+        public bool TryGetService<T>([NotNullWhen(true)] out T? service)
+            where T : class
+        {
+            service = CloseService as T;
+            return service is not null;
+        }
+    }
+
+    private sealed class ExternalEditorExtension : EditorExtension
+    {
+        public override FilePickerFileType GetFilePickerFileType() => new("External");
+
+        public override IconSource? GetIcon() => null;
+
+        public override bool TryCreateEditor(
+            CoreObject obj,
+            [NotNullWhen(true)] out Control? editor)
+        {
+            editor = null;
+            return false;
+        }
+
+        public override ValueTask<IEditorContext?> CreateContextAsync(
+            CoreObject obj,
+            IEditorContextServices services)
+            => ValueTask.FromResult<IEditorContext?>(new ExternalEditorContext(services.CloseService));
+
+        public override bool MatchFileExtension(string ext) => false;
+    }
+
+    private sealed class ExternalCloseService(EditorContextHostToken hostToken)
+        : IEditorContextCloseService
+    {
+        public EditorContextHostToken HostToken { get; } = hostToken;
+
+        public EditorContextCloseRequest RequestClose(IEditorContext context)
+            => new(EditorContextCloseRequestStatus.Accepted, Task.CompletedTask);
+    }
+
+    private sealed class ExternalEditorContext(IEditorContextCloseService closeService)
+        : IEditorContext
+    {
+        private IToolContext? _tool;
+
+        public int DisposeCount { get; private set; }
+
+        public IEditorContextCloseService CloseService { get; } = closeService;
+
+        public CoreObject Object => null!;
+
+        public EditorExtension Extension => null!;
+
+        public IReactiveProperty<bool> IsEnabled { get; } = new ReactiveProperty<bool>(true);
+
+        public IKnownEditorCommands? Commands => null;
+
+        public ValueTask DisposeAsync()
+        {
+            DisposeCount++;
+            return ValueTask.CompletedTask;
+        }
+
+        public T? FindToolTab<T>(Func<T, bool> condition)
+            where T : IToolContext
+            => _tool is T typed && condition(typed) ? typed : default;
+
+        public T? FindToolTab<T>()
+            where T : IToolContext
+            => _tool is T typed ? typed : default;
+
+        public ValueTask<bool> OpenToolTabAsync(IToolContext item)
+        {
+            _tool = item;
+            return ValueTask.FromResult(true);
+        }
+
+        public async ValueTask CloseToolTabAsync(IToolContext item)
+        {
+            if (ReferenceEquals(_tool, item))
+            {
+                _tool = null;
+                await item.DisposeAsync();
+            }
+        }
+
+        public object? GetService(Type serviceType) => null;
+    }
+
+    private sealed class ExternalToolContext : IToolContext
+    {
+        public int DisposeCount { get; private set; }
+
+        public ToolTabExtension Extension => null!;
+
+        public IReactiveProperty<bool> IsSelected { get; } = new ReactiveProperty<bool>();
+
+        public IReadOnlyReactiveProperty<string> Header { get; } = new ReactiveProperty<string>("External");
+
+        public ValueTask DisposeAsync()
+        {
+            DisposeCount++;
+            return ValueTask.CompletedTask;
+        }
+
+        public void ReadFromJson(JsonObject json)
+        {
+        }
+
+        public void WriteToJson(JsonObject json)
+        {
+        }
+
+        public object? GetService(Type serviceType) => null;
+    }
+}

--- a/tests/Beutl.PublicApiContractTests/OutputExtensionAuthoringContractTests.cs
+++ b/tests/Beutl.PublicApiContractTests/OutputExtensionAuthoringContractTests.cs
@@ -15,7 +15,7 @@ public sealed class OutputExtensionAuthoringContractTests : PublicApiContractTes
     {
         AssertDoesNotHaveFriendAccess(typeof(OutputExtension).Assembly);
 
-        var editor = new TestEditorContext();
+        await using var editor = new TestEditorContext();
         var extension = new TestOutputExtension();
         var execution = new TestOutputExecutionController();
         var outputOperations = new TestOutputOperationLeaseProvider();
@@ -156,6 +156,14 @@ public sealed class OutputExtensionAuthoringContractTests : PublicApiContractTes
 
     private sealed class TestEditorContext : IEditorContext
     {
+        public IEditorContextCloseService CloseService { get; } = new TestCloseService();
+
+        public ValueTask DisposeAsync()
+        {
+            IsEnabled.Dispose();
+            return ValueTask.CompletedTask;
+        }
+
         public CoreObject Object { get; } = new TestCoreObject();
 
         public EditorExtension Extension => null!;
@@ -172,14 +180,19 @@ public sealed class OutputExtensionAuthoringContractTests : PublicApiContractTes
             where T : IToolContext
             => default;
 
-        public bool OpenToolTab(IToolContext item) => false;
+        public ValueTask<bool> OpenToolTabAsync(IToolContext item) => ValueTask.FromResult(false);
 
-        public void CloseToolTab(IToolContext item)
-        {
-        }
+        public ValueTask CloseToolTabAsync(IToolContext item) => ValueTask.CompletedTask;
 
         public object? GetService(Type serviceType) => null;
     }
 
     private sealed class TestCoreObject : CoreObject;
+
+    private sealed class TestCloseService : IEditorContextCloseService
+    {
+        public EditorContextHostToken HostToken { get; } = new();
+
+        public EditorContextCloseRequest RequestClose(IEditorContext context) => default;
+    }
 }

--- a/tests/Beutl.PublicApiContractTests/SampleToolOwnershipTests.cs
+++ b/tests/Beutl.PublicApiContractTests/SampleToolOwnershipTests.cs
@@ -1,0 +1,62 @@
+﻿using System.Text.Json.Nodes;
+using Beutl.Extensibility;
+using Beutl.ProjectSystem;
+using PackageSample;
+using Reactive.Bindings;
+
+namespace Beutl.PublicApiContractTests;
+
+[TestFixture]
+public class SampleToolOwnershipTests
+{
+    [Test]
+    public async Task Sample_host_preserves_foreign_ownership_and_holds_its_lease_until_disposal()
+    {
+        string path = Path.GetTempFileName();
+        try
+        {
+            var scene = new Scene { Uri = new Uri(path) };
+            await using var editor = new TextEditorContext(scene, new SampleEditorExtension(), new CloseService());
+            var tool = new BlockingTool();
+            var foreign = new ToolContextHostToken();
+            Assert.That(foreign.TryAcquireContext(tool, out ToolContextOwnershipLease? lease), Is.True);
+            using (lease)
+            {
+                Assert.That(await editor.OpenToolTabAsync(tool), Is.False);
+                Assert.That(tool.DisposeCalls, Is.Zero);
+            }
+
+            Task<bool> opening = editor.OpenToolTabAsync(tool).AsTask();
+            Assert.That(tool.DisposeCalls, Is.EqualTo(1));
+            Assert.That(foreign.TryAcquireContext(tool, out _), Is.False);
+            tool.Release.TrySetResult();
+            Assert.That(await opening, Is.False);
+            Assert.That(foreign.TryAcquireContext(tool, out lease), Is.True);
+            lease!.Dispose();
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    private sealed class CloseService : IEditorContextCloseService
+    {
+        public EditorContextHostToken HostToken { get; } = new();
+        public EditorContextCloseRequest RequestClose(IEditorContext context)
+            => new(EditorContextCloseRequestStatus.NotOwned, Task.CompletedTask);
+    }
+
+    private sealed class BlockingTool : IToolContext
+    {
+        public readonly TaskCompletionSource Release = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public int DisposeCalls { get; private set; }
+        public ToolTabExtension Extension => throw new NotSupportedException();
+        public IReactiveProperty<bool> IsSelected { get; } = new ReactivePropertySlim<bool>();
+        public IReadOnlyReactiveProperty<string> Header { get; } = new ReactivePropertySlim<string>("Test");
+        public async ValueTask DisposeAsync() { DisposeCalls++; await Release.Task; }
+        public object? GetService(Type serviceType) => null;
+        public void ReadFromJson(JsonObject json) { }
+        public void WriteToJson(JsonObject json) { }
+    }
+}

--- a/tests/Beutl.UnitTests/Core/CoreListTests.cs
+++ b/tests/Beutl.UnitTests/Core/CoreListTests.cs
@@ -40,6 +40,20 @@ public class CoreListTests
     }
 
     [Test]
+    public void AddRangeSpan_PublishesAnExactStableSnapshot()
+    {
+        var list = new CoreList<int>();
+        System.Collections.IList? published = null;
+        list.CollectionChanged += (_, e) => published = e.NewItems;
+        int[] items = [10, 20, 30];
+
+        list.AddRange(items.AsSpan());
+        items.AsSpan().Fill(-1);
+
+        Assert.That(published, Is.EqualTo(new[] { 10, 20, 30 }));
+    }
+
+    [Test]
     public void Indexer_SettingNewValue_FiresReplaceAndDetached()
     {
         var list = new CoreList<int>(new[] { 1, 2, 3 });

--- a/tests/Beutl.UnitTests/Core/CoreListTests.cs
+++ b/tests/Beutl.UnitTests/Core/CoreListTests.cs
@@ -44,13 +44,25 @@ public class CoreListTests
     {
         var list = new CoreList<int>();
         System.Collections.IList? published = null;
+        var attached = new List<int>();
         list.CollectionChanged += (_, e) => published = e.NewItems;
         int[] items = [10, 20, 30];
+        list.Attached += item =>
+        {
+            attached.Add(item);
+            if (item == 10)
+                items.AsSpan().Fill(-1);
+        };
 
         list.AddRange(items.AsSpan());
-        items.AsSpan().Fill(-1);
 
-        Assert.That(published, Is.EqualTo(new[] { 10, 20, 30 }));
+        Assert.Multiple(() =>
+        {
+            Assert.That(list, Is.EqualTo(new[] { 10, 20, 30 }));
+            Assert.That(attached, Is.EqualTo(new[] { 10, 20, 30 }));
+            Assert.That(published, Is.EqualTo(new[] { 10, 20, 30 }));
+            Assert.That(items, Is.All.EqualTo(-1));
+        });
     }
 
     [Test]

--- a/tests/Beutl.UnitTests/Editor/AudioVisualizerLifetimeTests.cs
+++ b/tests/Beutl.UnitTests/Editor/AudioVisualizerLifetimeTests.cs
@@ -1,0 +1,51 @@
+﻿using System.Reactive.Subjects;
+using System.Reflection;
+using Beutl.Editor.Components.AudioVisualizerTab;
+using Beutl.Editor.Components.AudioVisualizerTab.ViewModels;
+using Beutl.Editor.Models;
+using Beutl.Editor.Services;
+using Beutl.Extensibility;
+using Moq;
+using Reactive.Bindings;
+
+namespace Beutl.UnitTests.Editor;
+
+[TestFixture]
+public class AudioVisualizerLifetimeTests
+{
+    [Test]
+    public async Task Dispose_cancels_and_drains_composition_without_publishing_late_audio()
+    {
+        using var frames = new Subject<AudioFrameSnapshot>();
+        var player = new Mock<IPreviewPlayer>();
+        player.SetupGet(x => x.AudioFramePushed).Returns(frames);
+        player.SetupGet(x => x.IsPlaying).Returns(new ReactivePropertySlim<bool>(false));
+        var clock = new Mock<IEditorClock>();
+        clock.SetupGet(x => x.CurrentTime).Returns(new ReactivePropertySlim<TimeSpan>(TimeSpan.FromSeconds(1)));
+        var completion = new TaskCompletionSource<AudioFrameSnapshot?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        CancellationToken composeToken = default;
+        player.Setup(x => x.ComposeAudioAsync(It.IsAny<TimeSpan>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
+            .Callback<TimeSpan, TimeSpan, CancellationToken>((_, _, ct) => composeToken = ct)
+            .Returns(completion.Task);
+        var editor = new Mock<IEditorContext>();
+        editor.Setup(x => x.GetService(typeof(IPreviewPlayer))).Returns(player.Object);
+        editor.Setup(x => x.GetService(typeof(IEditorClock))).Returns(clock.Object);
+        var vm = new AudioVisualizerTabViewModel(editor.Object, AudioVisualizerTabExtension.Instance);
+        int snapshots = 0;
+        vm.SnapshotUpdated += (_, _) => snapshots++;
+        var method = typeof(AudioVisualizerTabViewModel).GetMethod("ComposeSnapshotOnIdleAsync", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        Task compose = (Task)method.Invoke(vm, null)!;
+        Task disposal = vm.DisposeAsync().AsTask();
+        Assert.Multiple(() =>
+        {
+            Assert.That(composeToken.IsCancellationRequested, Is.True);
+            Assert.That(disposal.IsCompleted, Is.False);
+        });
+        completion.SetResult(new AudioFrameSnapshot([1, 1], 48000, 2, TimeSpan.Zero));
+        await Task.WhenAll(compose, disposal).WaitAsync(TimeSpan.FromSeconds(5));
+        frames.OnNext(new AudioFrameSnapshot([1, 1], 48000, 2, TimeSpan.Zero));
+        Assert.That(snapshots, Is.Zero);
+        Assert.That(vm.RingBuffer.TotalWritten, Is.Zero);
+        await vm.DisposeAsync();
+    }
+}

--- a/tests/Beutl.UnitTests/Editor/PreviewSettingsTabPreviewSourceModeTests.cs
+++ b/tests/Beutl.UnitTests/Editor/PreviewSettingsTabPreviewSourceModeTests.cs
@@ -31,20 +31,20 @@ public sealed class PreviewSettingsTabPreviewSourceModeTests
     }
 
     [Test]
-    public void PreviewSourceMode_ReflectsConfigAsInt()
+    public async Task PreviewSourceMode_ReflectsConfigAsInt()
     {
         GlobalConfiguration.Instance.EditorConfig.PreviewSourceMode = PreviewSourceMode.ForceOriginal;
 
-        using PreviewSettingsTabViewModel vm = CreateViewModel();
+        await using PreviewSettingsTabViewModel vm = CreateViewModel();
 
         Assert.That(vm.PreviewSourceMode.Value, Is.EqualTo((int)PreviewSourceMode.ForceOriginal));
     }
 
     [Test]
-    public void SettingIntValue_UpdatesConfigEnum()
+    public async Task SettingIntValue_UpdatesConfigEnum()
     {
         GlobalConfiguration.Instance.EditorConfig.PreviewSourceMode = PreviewSourceMode.PreferProxy;
-        using PreviewSettingsTabViewModel vm = CreateViewModel();
+        await using PreviewSettingsTabViewModel vm = CreateViewModel();
 
         // The ComboBox writes back the selected index as an int; the enum setting must follow.
         vm.PreviewSourceMode.Value = (int)PreviewSourceMode.ForceOriginal;
@@ -56,10 +56,10 @@ public sealed class PreviewSettingsTabPreviewSourceModeTests
     // A ComboBox with no selection reports SelectedIndex -1; the write-back must not persist an undefined
     // enum (which never equals PreferProxy and would silently disable proxy preview).
     [Test]
-    public void SettingOutOfRangeIndex_LeavesConfigUnchanged()
+    public async Task SettingOutOfRangeIndex_LeavesConfigUnchanged()
     {
         GlobalConfiguration.Instance.EditorConfig.PreviewSourceMode = PreviewSourceMode.ForceOriginal;
-        using PreviewSettingsTabViewModel vm = CreateViewModel();
+        await using PreviewSettingsTabViewModel vm = CreateViewModel();
 
         vm.PreviewSourceMode.Value = -1;
 

--- a/tests/Beutl.UnitTests/Editor/ProxiesTabViewModelTests.cs
+++ b/tests/Beutl.UnitTests/Editor/ProxiesTabViewModelTests.cs
@@ -21,7 +21,7 @@ namespace Beutl.UnitTests.Editor;
 public sealed class ProxiesTabViewModelTests
 {
     [Test]
-    public void Refresh_BuildsReadySummaryAndClipDisplay()
+    public async Task Refresh_BuildsReadySummaryAndClipDisplay()
     {
         string root = CreateRoot();
         string sourcePath = CreateSourceFile(root, "clip.mov", 2048);
@@ -40,7 +40,7 @@ public sealed class ProxiesTabViewModelTests
             now,
             null));
 
-        using var viewModel = new ProxiesTabViewModel(CreateContext(root, store, sourcePath));
+        await using var viewModel = new ProxiesTabViewModel(CreateContext(root, store, sourcePath));
 
         ProxyClipViewModel clip = viewModel.Clips.Single();
         Assert.Multiple(() =>
@@ -69,7 +69,7 @@ public sealed class ProxiesTabViewModelTests
     }
 
     [Test]
-    public void Refresh_UsesRunningEvictionCapForStoreCapDisplay()
+    public async Task Refresh_UsesRunningEvictionCapForStoreCapDisplay()
     {
         string root = CreateRoot();
         string sourcePath = CreateSourceFile(root, "clip.mov", 2048);
@@ -77,7 +77,7 @@ public sealed class ProxiesTabViewModelTests
         var context = CreateContext(root, store, sourcePath);
         context.AddService<IProxyStoreCapInfo>(new TestProxyStoreCapInfo(12L * 1024 * 1024 * 1024));
 
-        using var viewModel = new ProxiesTabViewModel(context);
+        await using var viewModel = new ProxiesTabViewModel(context);
 
         Assert.That(viewModel.StoreCapText.Value, Is.EqualTo("12 GB"));
     }
@@ -85,7 +85,7 @@ public sealed class ProxiesTabViewModelTests
     // Changing only the store cap in Settings while the tab is open must refresh StoreCapText; no other
     // signal on the open tab reflects a cap-only change until an unrelated store / job / scene refresh.
     [Test]
-    public void ProxyConfigCapChange_RefreshesStoreCapText()
+    public async Task ProxyConfigCapChange_RefreshesStoreCapText()
     {
         string root = CreateRoot();
         string sourcePath = CreateSourceFile(root, "clip.mov", 2048);
@@ -95,7 +95,7 @@ public sealed class ProxiesTabViewModelTests
         try
         {
             config.MaxTotalBytes = 10L * 1024 * 1024 * 1024;
-            using var viewModel = new ProxiesTabViewModel(CreateContext(root, store, sourcePath));
+            await using var viewModel = new ProxiesTabViewModel(CreateContext(root, store, sourcePath));
             Assert.That(viewModel.StoreCapText.Value, Is.EqualTo("10 GB"), "sanity: the tab shows the cap it was built with");
 
             config.MaxTotalBytes = 20L * 1024 * 1024 * 1024;
@@ -109,7 +109,7 @@ public sealed class ProxiesTabViewModelTests
     }
 
     [Test]
-    public void Refresh_SeparatesStaleAndMissingClips()
+    public async Task Refresh_SeparatesStaleAndMissingClips()
     {
         string root = CreateRoot();
         string staleSourcePath = CreateSourceFile(root, "stale.mov", 1024);
@@ -130,7 +130,7 @@ public sealed class ProxiesTabViewModelTests
         File.AppendAllBytes(staleSourcePath, [1]);
         File.SetLastWriteTimeUtc(staleSourcePath, DateTime.UtcNow.AddMinutes(1));
 
-        using var viewModel = new ProxiesTabViewModel(CreateContext(root, store, staleSourcePath, missingSourcePath));
+        await using var viewModel = new ProxiesTabViewModel(CreateContext(root, store, staleSourcePath, missingSourcePath));
 
         Assert.Multiple(() =>
         {
@@ -143,7 +143,7 @@ public sealed class ProxiesTabViewModelTests
     }
 
     [Test]
-    public void Refresh_SelectsGeneratedPresetWhenConfiguredDefaultIsMissing()
+    public async Task Refresh_SelectsGeneratedPresetWhenConfiguredDefaultIsMissing()
     {
         string root = CreateRoot();
         string sourcePath = CreateSourceFile(root, "clip.mov", 2048);
@@ -162,7 +162,7 @@ public sealed class ProxiesTabViewModelTests
             now,
             null));
 
-        using var viewModel = new ProxiesTabViewModel(CreateContext(root, store, sourcePath));
+        await using var viewModel = new ProxiesTabViewModel(CreateContext(root, store, sourcePath));
 
         ProxyClipViewModel clip = viewModel.Clips.Single();
         Assert.Multiple(() =>
@@ -191,13 +191,13 @@ public sealed class ProxiesTabViewModelTests
     }
 
     [Test]
-    public void Refresh_IncludesVideoSourceNodeSources()
+    public async Task Refresh_IncludesVideoSourceNodeSources()
     {
         string root = CreateRoot();
         string sourcePath = CreateSourceFile(root, "graph.mov", 1024);
         var store = new ProxyStore(Path.Combine(root, "proxies"));
 
-        using var viewModel = new ProxiesTabViewModel(CreateGraphContext(root, store, sourcePath));
+        await using var viewModel = new ProxiesTabViewModel(CreateGraphContext(root, store, sourcePath));
 
         Assert.Multiple(() =>
         {
@@ -207,7 +207,7 @@ public sealed class ProxiesTabViewModelTests
     }
 
     [Test]
-    public void Refresh_IncludesNestedSceneVideoSources()
+    public async Task Refresh_IncludesNestedSceneVideoSources()
     {
         string root = CreateRoot();
         string sourcePath = CreateSourceFile(root, "nested.mov", 1024);
@@ -219,7 +219,7 @@ public sealed class ProxiesTabViewModelTests
         sceneDrawable.ReferencedScene.CurrentValue = childScene;
         AddObject(parentScene, root, sceneDrawable);
 
-        using var viewModel = new ProxiesTabViewModel(CreateContext(parentScene, store));
+        await using var viewModel = new ProxiesTabViewModel(CreateContext(parentScene, store));
 
         Assert.Multiple(() =>
         {
@@ -229,7 +229,7 @@ public sealed class ProxiesTabViewModelTests
     }
 
     [Test]
-    public void Refresh_IncludesOfflineSourceWhenStoreHasExistingEntry()
+    public async Task Refresh_IncludesOfflineSourceWhenStoreHasExistingEntry()
     {
         string root = CreateRoot();
         string sourcePath = CreateSourceFile(root, "offline.mov", 1024);
@@ -250,7 +250,7 @@ public sealed class ProxiesTabViewModelTests
         RegisterProxyEntry(store, entry);
         File.Delete(sourcePath);
 
-        using var viewModel = new ProxiesTabViewModel(CreateContext(root, store, sourcePath));
+        await using var viewModel = new ProxiesTabViewModel(CreateContext(root, store, sourcePath));
 
         ProxyClipViewModel clip = viewModel.Clips.Single();
         Assert.Multiple(() =>
@@ -266,7 +266,7 @@ public sealed class ProxiesTabViewModelTests
     // (ranked like the resolver) rather than an earlier-enumerated Failed/Stale entry, so its state and
     // per-row delete/regenerate target the usable proxy.
     [Test]
-    public void Refresh_OfflineSourceWithMultipleEntries_BindsRowToReadyEntry()
+    public async Task Refresh_OfflineSourceWithMultipleEntries_BindsRowToReadyEntry()
     {
         string root = CreateRoot();
         string sourcePath = CreateSourceFile(root, "offline.mov", 1024);
@@ -288,7 +288,7 @@ public sealed class ProxiesTabViewModelTests
             new PixelSize(1920, 1080), new PixelSize(480, 270), now, now, null));
         File.Delete(sourcePath);
 
-        using var viewModel = new ProxiesTabViewModel(CreateContext(root, store, sourcePath));
+        await using var viewModel = new ProxiesTabViewModel(CreateContext(root, store, sourcePath));
 
         ProxyClipViewModel clip = viewModel.Clips.Single();
         Assert.Multiple(() =>
@@ -302,7 +302,7 @@ public sealed class ProxiesTabViewModelTests
     // the newest version (mirroring ProxyResolver.ResolveByPath), even when an older version's proxy is
     // denser — otherwise delete/regenerate would target a stale proxy the preview no longer decodes.
     [Test]
-    public void Refresh_OfflineSourceWithReadyEntriesFromDifferentVersions_BindsNewest()
+    public async Task Refresh_OfflineSourceWithReadyEntriesFromDifferentVersions_BindsNewest()
     {
         string root = CreateRoot();
         string sourcePath = CreateSourceFile(root, "offline.mov", 1024);
@@ -331,7 +331,7 @@ public sealed class ProxiesTabViewModelTests
             // Default preset Half: the denser old Half is under the cap, so density-only ranking would
             // bind the old version; the newest-version filter must beat that and bind the new Quarter.
             config.DefaultPreset = (int)ProxyPreset.Half;
-            using var viewModel = new ProxiesTabViewModel(CreateContext(root, store, sourcePath));
+            await using var viewModel = new ProxiesTabViewModel(CreateContext(root, store, sourcePath));
 
             ProxyClipViewModel clip = viewModel.Clips.Single();
             Assert.That(clip.Source, Is.EqualTo(newFp), "the row must bind to the newest source version, not a denser older proxy");
@@ -346,7 +346,7 @@ public sealed class ProxiesTabViewModelTests
     // proxy lingers, the row must bind to the newest source's state, not the stale older Ready — matching
     // the preview, which serves no proxy for the current source.
     [Test]
-    public void Refresh_OfflineSourceWithNewerFailedVersion_BindsNewestNotOldReady()
+    public async Task Refresh_OfflineSourceWithNewerFailedVersion_BindsNewestNotOldReady()
     {
         string root = CreateRoot();
         string sourcePath = CreateSourceFile(root, "offline.mov", 1024);
@@ -368,7 +368,7 @@ public sealed class ProxiesTabViewModelTests
             new PixelSize(1920, 1080), new PixelSize(480, 270), newTime, newTime, "boom"));
         File.Delete(sourcePath);
 
-        using var viewModel = new ProxiesTabViewModel(CreateContext(root, store, sourcePath));
+        await using var viewModel = new ProxiesTabViewModel(CreateContext(root, store, sourcePath));
 
         ProxyClipViewModel clip = viewModel.Clips.Single();
         Assert.Multiple(() =>
@@ -382,7 +382,7 @@ public sealed class ProxiesTabViewModelTests
     // decoding picks: the densest within the default-preset density cap (mirroring ProxyResolver), not
     // simply the densest overall.
     [Test]
-    public void Refresh_OfflineSourceWithMultipleReadyEntries_BindsWithinDefaultPresetDensityCap()
+    public async Task Refresh_OfflineSourceWithMultipleReadyEntries_BindsWithinDefaultPresetDensityCap()
     {
         string root = CreateRoot();
         string sourcePath = CreateSourceFile(root, "offline.mov", 1024);
@@ -405,7 +405,7 @@ public sealed class ProxiesTabViewModelTests
         {
             // Cap at Quarter (density 0.25): the capped pick is the Quarter proxy, not the denser Half.
             config.DefaultPreset = (int)ProxyPreset.Quarter;
-            using var viewModel = new ProxiesTabViewModel(CreateContext(root, store, sourcePath));
+            await using var viewModel = new ProxiesTabViewModel(CreateContext(root, store, sourcePath));
 
             Assert.That(viewModel.Clips.Single().Preset.Value, Is.EqualTo(ProxyPreset.Quarter),
                 "the row must bind to the density-capped Quarter proxy preview would decode, not the densest Half");
@@ -417,7 +417,7 @@ public sealed class ProxiesTabViewModelTests
     }
 
     [Test]
-    public void Refresh_IncludesAnimatedSourceVideoValues()
+    public async Task Refresh_IncludesAnimatedSourceVideoValues()
     {
         string root = CreateRoot();
         string firstPath = CreateSourceFile(root, "first.mov", 1024);
@@ -435,7 +435,7 @@ public sealed class ProxiesTabViewModelTests
         drawable.Source.Animation = animation;
         AddObject(scene, root, drawable);
 
-        using var viewModel = new ProxiesTabViewModel(CreateContext(scene, store));
+        await using var viewModel = new ProxiesTabViewModel(CreateContext(scene, store));
 
         Assert.That(
             viewModel.Clips.Select(static clip => clip.FileName),
@@ -464,7 +464,7 @@ public sealed class ProxiesTabViewModelTests
         RegisterProxyEntry(store, entry);
         var queue = new TestProxyJobQueue();
 
-        using var viewModel = new ProxiesTabViewModel(CreateContext(root, store, queue, sourcePath));
+        await using var viewModel = new ProxiesTabViewModel(CreateContext(root, store, queue, sourcePath));
 
         await viewModel.RegenerateAsync(viewModel.Clips.Single());
 
@@ -476,7 +476,7 @@ public sealed class ProxiesTabViewModelTests
     }
 
     [Test]
-    public void Refresh_AttachesPendingQueueJobToMatchingClip()
+    public async Task Refresh_AttachesPendingQueueJobToMatchingClip()
     {
         string root = CreateRoot();
         string sourcePath = CreateSourceFile(root, "queued.mov", 4096);
@@ -489,7 +489,7 @@ public sealed class ProxiesTabViewModelTests
         };
         var queue = new TestProxyJobQueue(job);
 
-        using var viewModel = new ProxiesTabViewModel(CreateContext(root, store, queue, sourcePath));
+        await using var viewModel = new ProxiesTabViewModel(CreateContext(root, store, queue, sourcePath));
 
         ProxyClipViewModel clip = viewModel.Clips.Single();
         Assert.Multiple(() =>
@@ -507,7 +507,7 @@ public sealed class ProxiesTabViewModelTests
     }
 
     [Test]
-    public void Refresh_IncludesSourcesFromAllProjectScenes()
+    public async Task Refresh_IncludesSourcesFromAllProjectScenes()
     {
         string root = CreateRoot();
         string path1 = CreateSourceFile(root, "scene1.mov", 1024);
@@ -521,7 +521,7 @@ public sealed class ProxiesTabViewModelTests
         project.Items.Add(scene1);
         project.Items.Add(scene2);
 
-        using var viewModel = new ProxiesTabViewModel(CreateContext(scene1, store));
+        await using var viewModel = new ProxiesTabViewModel(CreateContext(scene1, store));
 
         Assert.That(
             viewModel.Clips.Select(static clip => clip.FileName),
@@ -531,7 +531,7 @@ public sealed class ProxiesTabViewModelTests
     // A clip referencing media through a symlink whose target was moved/deleted must still match its
     // stored entry (keyed on the resolved target) rather than dropping off the tab.
     [Test]
-    public void Refresh_SymlinkedSourceWithMovedTarget_StaysMatchedToStoredEntry()
+    public async Task Refresh_SymlinkedSourceWithMovedTarget_StaysMatchedToStoredEntry()
     {
         string root = CreateRoot();
         string target = CreateSourceFile(root, "target.mov", 1024);
@@ -566,7 +566,7 @@ public sealed class ProxiesTabViewModelTests
         var scene = CreateScene(root, "symlink.scene");
         AddSourceVideo(scene, root, link);
 
-        using var viewModel = new ProxiesTabViewModel(CreateContext(scene, store));
+        await using var viewModel = new ProxiesTabViewModel(CreateContext(scene, store));
 
         Assert.That(viewModel.Clips.Select(static clip => clip.FileName), Does.Contain("link.mov"));
     }
@@ -574,7 +574,7 @@ public sealed class ProxiesTabViewModelTests
     // Project-wide actions scan every scene, so an edit in a scene other than the tab's own must
     // still refresh the clip list.
     [Test]
-    public void SceneEdited_InAnotherProjectScene_RefreshesClipList()
+    public async Task SceneEdited_InAnotherProjectScene_RefreshesClipList()
     {
         string root = CreateRoot();
         string path1 = CreateSourceFile(root, "scene1.mov", 1024);
@@ -587,7 +587,7 @@ public sealed class ProxiesTabViewModelTests
         project.Items.Add(scene1);
         project.Items.Add(scene2);
 
-        using var viewModel = new ProxiesTabViewModel(CreateContext(scene1, store))
+        await using var viewModel = new ProxiesTabViewModel(CreateContext(scene1, store))
         {
             RefreshScheduler = static action => action(),
         };
@@ -601,7 +601,7 @@ public sealed class ProxiesTabViewModelTests
     }
 
     [Test]
-    public void OnStoreChanged_TouchEvent_PreservesClipSelection()
+    public async Task OnStoreChanged_TouchEvent_PreservesClipSelection()
     {
         string root = CreateRoot();
         string sourcePath = CreateSourceFile(root, "clip.mov", 1024);
@@ -620,7 +620,7 @@ public sealed class ProxiesTabViewModelTests
             now,
             null));
 
-        using var viewModel = new ProxiesTabViewModel(CreateContext(root, store, sourcePath))
+        await using var viewModel = new ProxiesTabViewModel(CreateContext(root, store, sourcePath))
         {
             // Run the coalesced rebuild synchronously: with the real (never-pumped) test dispatcher
             // a scheduled rebuild would silently not run and the assertion below would be vacuous.
@@ -640,13 +640,13 @@ public sealed class ProxiesTabViewModelTests
     }
 
     [Test]
-    public void OnStoreChanged_RegisteredEvent_PreservesClipSelection()
+    public async Task OnStoreChanged_RegisteredEvent_PreservesClipSelection()
     {
         string root = CreateRoot();
         string sourcePath = CreateSourceFile(root, "clip.mov", 1024);
         var store = new ProxyStore(Path.Combine(root, "proxies"));
 
-        using var viewModel = new ProxiesTabViewModel(CreateContext(root, store, sourcePath))
+        await using var viewModel = new ProxiesTabViewModel(CreateContext(root, store, sourcePath))
         {
             RefreshScheduler = static action => action(),
         };
@@ -681,7 +681,7 @@ public sealed class ProxiesTabViewModelTests
         var store = new ProxyStore(Path.Combine(root, "proxies"));
         var queue = new TestProxyJobQueue();
 
-        using var viewModel = new ProxiesTabViewModel(CreateContext(root, store, queue, sourcePath));
+        await using var viewModel = new ProxiesTabViewModel(CreateContext(root, store, queue, sourcePath));
         ProxyClipViewModel clip = viewModel.Clips.Single();
         ProxyJob job = await queue.EnqueueAsync(clip.Source, clip.Preset.Value);
 
@@ -692,7 +692,7 @@ public sealed class ProxiesTabViewModelTests
     }
 
     [Test]
-    public void DefaultPresetChanged_UpdatesRowsOnPreviousDefault_KeepsExplicitChoices()
+    public async Task DefaultPresetChanged_UpdatesRowsOnPreviousDefault_KeepsExplicitChoices()
     {
         string root = CreateRoot();
         string firstPath = CreateSourceFile(root, "first.mov", 1024);
@@ -703,7 +703,7 @@ public sealed class ProxiesTabViewModelTests
         try
         {
             config.DefaultPreset = (int)ProxyPreset.Quarter;
-            using var viewModel = new ProxiesTabViewModel(CreateContext(root, store, firstPath, secondPath));
+            await using var viewModel = new ProxiesTabViewModel(CreateContext(root, store, firstPath, secondPath));
             ProxyClipViewModel following = viewModel.Clips[0];
             ProxyClipViewModel explicitChoice = viewModel.Clips[1];
             explicitChoice.Preset.Value = ProxyPreset.Eighth;
@@ -726,7 +726,7 @@ public sealed class ProxiesTabViewModelTests
     // that choice when the default later changes — the old value-equality sweep overwrote it because it
     // could not tell an explicit pick from a row merely showing the default.
     [Test]
-    public void DefaultPresetChanged_KeepsExplicitChoiceEqualToOldDefault()
+    public async Task DefaultPresetChanged_KeepsExplicitChoiceEqualToOldDefault()
     {
         string root = CreateRoot();
         string firstPath = CreateSourceFile(root, "first.mov", 1024);
@@ -737,7 +737,7 @@ public sealed class ProxiesTabViewModelTests
         try
         {
             config.DefaultPreset = (int)ProxyPreset.Quarter;
-            using var viewModel = new ProxiesTabViewModel(CreateContext(root, store, firstPath, secondPath));
+            await using var viewModel = new ProxiesTabViewModel(CreateContext(root, store, firstPath, secondPath));
             ProxyClipViewModel following = viewModel.Clips[0];
             ProxyClipViewModel explicitEqual = viewModel.Clips[1];
             // Change away and back so the row explicitly lands on Quarter (the current default) via a real
@@ -764,7 +764,7 @@ public sealed class ProxiesTabViewModelTests
     // list rebuilds, the now proxy-less row must revert to following the default (it re-derives its state)
     // rather than staying stuck on the old preset when the default later changes.
     [Test]
-    public void DefaultPresetChanged_ProxyPinnedRowRevertsToFollowingAfterProxyDeleted()
+    public async Task DefaultPresetChanged_ProxyPinnedRowRevertsToFollowingAfterProxyDeleted()
     {
         string root = CreateRoot();
         string sourcePath = CreateSourceFile(root, "clip.mov", 1024);
@@ -780,7 +780,7 @@ public sealed class ProxiesTabViewModelTests
                 fingerprint, ProxyPreset.Quarter, ProxyState.Ready, "hash/quarter.mp4", 512,
                 new PixelSize(1920, 1080), new PixelSize(480, 270), now, now, null));
 
-            using var viewModel = new ProxiesTabViewModel(CreateContext(root, store, sourcePath))
+            await using var viewModel = new ProxiesTabViewModel(CreateContext(root, store, sourcePath))
             {
                 RefreshScheduler = static action => action(),
             };
@@ -808,7 +808,7 @@ public sealed class ProxiesTabViewModelTests
     // A symlink and its target resolve to the same AbsolutePath but different LocalPaths; after an explicit
     // preset pick on the merged row, dropping the symlink element (leaving the target) must keep the choice.
     [Test]
-    public void Refresh_ExplicitChoiceSurvivesPathSpellingChange_KeyedByAbsolutePath()
+    public async Task Refresh_ExplicitChoiceSurvivesPathSpellingChange_KeyedByAbsolutePath()
     {
         string root = CreateRoot();
         string target = CreateSourceFile(root, "target.mov", 1024);
@@ -831,7 +831,7 @@ public sealed class ProxiesTabViewModelTests
         scene.Children.Add(linkElement);
         scene.Children.Add(targetElement);
 
-        using var viewModel = new ProxiesTabViewModel(CreateContext(scene, store))
+        await using var viewModel = new ProxiesTabViewModel(CreateContext(scene, store))
         {
             RefreshScheduler = static action => action(),
         };
@@ -855,7 +855,7 @@ public sealed class ProxiesTabViewModelTests
     // Generate All / Delete act on Clips, so the list must track project edits made while the tab
     // is open — not just proxy store/queue events.
     [Test]
-    public void SceneEdited_AddingAndRemovingVideoElements_RebuildsClipList()
+    public async Task SceneEdited_AddingAndRemovingVideoElements_RebuildsClipList()
     {
         string root = CreateRoot();
         string firstPath = CreateSourceFile(root, "first.mov", 1024);
@@ -867,7 +867,7 @@ public sealed class ProxiesTabViewModelTests
         };
         scene.Children.Add(CreateVideoElement(root, firstPath));
 
-        using var viewModel = new ProxiesTabViewModel(CreateContext(scene, store))
+        await using var viewModel = new ProxiesTabViewModel(CreateContext(scene, store))
         {
             RefreshScheduler = static action => action(),
         };
@@ -882,7 +882,7 @@ public sealed class ProxiesTabViewModelTests
     }
 
     [Test]
-    public void Delete_WhenProxyFileCannotBeDeleted_SurfacesFailureInStatusMessage()
+    public async Task Delete_WhenProxyFileCannotBeDeleted_SurfacesFailureInStatusMessage()
     {
         string root = CreateRoot();
         string sourcePath = CreateSourceFile(root, "clip.mov", 1024);
@@ -901,7 +901,7 @@ public sealed class ProxiesTabViewModelTests
             now,
             null));
 
-        using var viewModel = new ProxiesTabViewModel(CreateContext(root, new UndeletableStore(store), sourcePath));
+        await using var viewModel = new ProxiesTabViewModel(CreateContext(root, new UndeletableStore(store), sourcePath));
         ProxyClipViewModel clip = viewModel.Clips.Single();
 
         viewModel.Delete(clip);
@@ -913,7 +913,7 @@ public sealed class ProxiesTabViewModelTests
     // .mp4 (a sharing violation while preview decodes it) is a real failure the UI must surface, even
     // though Delete returned true.
     [Test]
-    public void Delete_WhenProxyFileSurvivesDelete_SurfacesFailureInStatusMessage()
+    public async Task Delete_WhenProxyFileSurvivesDelete_SurfacesFailureInStatusMessage()
     {
         string root = CreateRoot();
         string sourcePath = CreateSourceFile(root, "clip.mov", 1024);
@@ -932,7 +932,7 @@ public sealed class ProxiesTabViewModelTests
             now,
             null));
 
-        using var viewModel = new ProxiesTabViewModel(CreateContext(root, new OrphanFileStore(inner), sourcePath));
+        await using var viewModel = new ProxiesTabViewModel(CreateContext(root, new OrphanFileStore(inner), sourcePath));
         ProxyClipViewModel clip = viewModel.Clips.Single();
 
         viewModel.Delete(clip);
@@ -941,13 +941,13 @@ public sealed class ProxiesTabViewModelTests
     }
 
     [Test]
-    public void Delete_WhenEntryAlreadyGone_DoesNotReportFailure()
+    public async Task Delete_WhenEntryAlreadyGone_DoesNotReportFailure()
     {
         string root = CreateRoot();
         string sourcePath = CreateSourceFile(root, "clip.mov", 1024);
         var store = new ProxyStore(Path.Combine(root, "proxies"));
 
-        using var viewModel = new ProxiesTabViewModel(CreateContext(root, store, sourcePath));
+        await using var viewModel = new ProxiesTabViewModel(CreateContext(root, store, sourcePath));
         ProxyClipViewModel clip = viewModel.Clips.Single();
 
         // No entry is registered, so Delete returns false for "not found" — a benign race,
@@ -958,7 +958,7 @@ public sealed class ProxiesTabViewModelTests
     }
 
     [Test]
-    public void Delete_CancelsJobKeyedOnStaleEntrySource()
+    public async Task Delete_CancelsJobKeyedOnStaleEntrySource()
     {
         string root = CreateRoot();
         string sourcePath = CreateSourceFile(root, "clip.mov", 1024);
@@ -987,7 +987,7 @@ public sealed class ProxiesTabViewModelTests
 
         var job = new ProxyJob(stale, ProxyPreset.Quarter);
         var queue = new TestProxyJobQueue(job);
-        using var viewModel = new ProxiesTabViewModel(CreateContext(root, store, queue, sourcePath));
+        await using var viewModel = new ProxiesTabViewModel(CreateContext(root, store, queue, sourcePath));
         ProxyClipViewModel clip = viewModel.Clips.Single();
         Assume.That(clip.EntrySource, Is.EqualTo(stale));
         Assume.That(clip.Source, Is.Not.EqualTo(stale));
@@ -1000,13 +1000,13 @@ public sealed class ProxiesTabViewModelTests
     }
 
     [Test]
-    public void ToggleSelection_InvertsClipSelection()
+    public async Task ToggleSelection_InvertsClipSelection()
     {
         string root = CreateRoot();
         string sourcePath = CreateSourceFile(root, "clip.mov", 1024);
         var store = new ProxyStore(Path.Combine(root, "proxies"));
 
-        using var viewModel = new ProxiesTabViewModel(CreateContext(root, store, sourcePath));
+        await using var viewModel = new ProxiesTabViewModel(CreateContext(root, store, sourcePath));
 
         ProxyClipViewModel clip = viewModel.Clips.Single();
         clip.ToggleSelection();
@@ -1049,7 +1049,7 @@ public sealed class ProxiesTabViewModelTests
             null);
         RegisterProxyEntry(store, entry);
 
-        using var viewModel = new ProxiesTabViewModel(CreateContext(root, store, sourcePath));
+        await using var viewModel = new ProxiesTabViewModel(CreateContext(root, store, sourcePath));
         int? confirmedCount = null;
         viewModel.ConfirmDeleteAllForProjectAsync = count =>
         {
@@ -1079,7 +1079,7 @@ public sealed class ProxiesTabViewModelTests
             new PixelSize(1920, 1080), new PixelSize(480, 270), now, now, null);
         RegisterProxyEntry(store, quarter);
 
-        using var viewModel = new ProxiesTabViewModel(CreateContext(root, store, sourcePath));
+        await using var viewModel = new ProxiesTabViewModel(CreateContext(root, store, sourcePath));
 
         var half = new ProxyEntry(
             fingerprint, ProxyPreset.Half, ProxyState.Ready, "hash/half.mp4", 3072,
@@ -1129,7 +1129,7 @@ public sealed class ProxiesTabViewModelTests
         var currentJob = new ProxyJob(current, ProxyPreset.Quarter);
         var queue = new TestProxyJobQueue(currentJob);
 
-        using var viewModel = new ProxiesTabViewModel(CreateContext(root, store, queue, sourcePath));
+        await using var viewModel = new ProxiesTabViewModel(CreateContext(root, store, queue, sourcePath));
         viewModel.ConfirmDeleteAllForProjectAsync = _ => Task.FromResult(true);
 
         await viewModel.DeleteAllForProjectCommand.ExecuteAsync();
@@ -1162,7 +1162,7 @@ public sealed class ProxiesTabViewModelTests
             null);
         RegisterProxyEntry(store, entry);
 
-        using var viewModel = new ProxiesTabViewModel(CreateContext(root, store, sourcePath));
+        await using var viewModel = new ProxiesTabViewModel(CreateContext(root, store, sourcePath));
         bool confirmationRequested = false;
         viewModel.ConfirmDeleteAllForProjectAsync = _ =>
         {
@@ -1188,7 +1188,7 @@ public sealed class ProxiesTabViewModelTests
         ProxyFingerprint fingerprint = ProxyFingerprint.FromFile(sourcePath);
         var queue = new TestProxyJobQueue();
 
-        using var viewModel = new ProxiesTabViewModel(CreateContext(root, store, queue, sourcePath));
+        await using var viewModel = new ProxiesTabViewModel(CreateContext(root, store, queue, sourcePath));
         ProxyClipViewModel clip = viewModel.Clips.Single();
 
         clip.Preset.Value = ProxyPreset.Quarter;
@@ -1228,7 +1228,7 @@ public sealed class ProxiesTabViewModelTests
             null));
         var queue = new TestProxyJobQueue();
 
-        using var viewModel = new ProxiesTabViewModel(CreateContext(root, store, queue, path));
+        await using var viewModel = new ProxiesTabViewModel(CreateContext(root, store, queue, path));
 
         await viewModel.GenerateAllCommand.ExecuteAsync();
 
@@ -1260,7 +1260,7 @@ public sealed class ProxiesTabViewModelTests
             null));
         var queue = new TestProxyJobQueue();
 
-        using var viewModel = new ProxiesTabViewModel(CreateContext(root, store, queue, path));
+        await using var viewModel = new ProxiesTabViewModel(CreateContext(root, store, queue, path));
 
         await viewModel.GenerateAllCommand.ExecuteAsync();
 
@@ -1301,7 +1301,7 @@ public sealed class ProxiesTabViewModelTests
             null));
         var queue = new TestProxyJobQueue();
 
-        using var viewModel = new ProxiesTabViewModel(CreateContext(root, store, queue, heavyPath, lightPath));
+        await using var viewModel = new ProxiesTabViewModel(CreateContext(root, store, queue, heavyPath, lightPath));
 
         await viewModel.GenerateAllCommand.ExecuteAsync();
 
@@ -1340,7 +1340,7 @@ public sealed class ProxiesTabViewModelTests
         ProxyFingerprint foregroundFingerprint = ProxyFingerprint.FromFile(foregroundPath);
         var queue = new TestProxyJobQueue();
 
-        using var viewModel = new ProxiesTabViewModel(CreateContext(root, store, queue, heavyPath, foregroundPath));
+        await using var viewModel = new ProxiesTabViewModel(CreateContext(root, store, queue, heavyPath, foregroundPath));
 
         await viewModel.GenerateAllCommand.ExecuteAsync();
         ProxyClipViewModel foregroundClip = viewModel.Clips.Single(static c => c.FileName == "foreground.mov");
@@ -1363,7 +1363,7 @@ public sealed class ProxiesTabViewModelTests
         var store = new ProxyStore(Path.Combine(root, "proxies"));
         var queue = new TestProxyJobQueue();
 
-        using var viewModel = new ProxiesTabViewModel(CreateContext(root, store, queue, firstPath, secondPath));
+        await using var viewModel = new ProxiesTabViewModel(CreateContext(root, store, queue, firstPath, secondPath));
 
         await viewModel.GenerateAllCommand.ExecuteAsync();
 
@@ -1642,14 +1642,17 @@ public sealed class ProxiesTabViewModelTests
             return default;
         }
 
-        public bool OpenToolTab(IToolContext item)
+        public ValueTask<bool> OpenToolTabAsync(IToolContext item)
         {
-            return false;
+            return new ValueTask<bool>(false);
         }
 
-        public void CloseToolTab(IToolContext item)
+        public ValueTask CloseToolTabAsync(IToolContext item)
         {
+            return ValueTask.CompletedTask;
         }
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
     }
 
     private sealed class TestProxyJobQueue(params ProxyJob[] pendingJobs) : IProxyJobQueue

--- a/tests/Beutl.UnitTests/Editor/ProxiesTabViewModelTests.cs
+++ b/tests/Beutl.UnitTests/Editor/ProxiesTabViewModelTests.cs
@@ -1609,6 +1609,8 @@ public sealed class ProxiesTabViewModelTests
 
     private sealed class TestEditorContext(CoreObject obj) : IEditorContext
     {
+        public IEditorContextCloseService CloseService => TestEditorContextCloseService.Instance;
+
         private readonly Dictionary<Type, object> _services = [];
 
         public CoreObject Object { get; } = obj;

--- a/tests/Beutl.UnitTests/Editor/SceneSettingsTabViewModelTests.cs
+++ b/tests/Beutl.UnitTests/Editor/SceneSettingsTabViewModelTests.cs
@@ -58,7 +58,7 @@ public class SceneSettingsTabViewModelTests
         editorContext.AddService<ITimelineOptionsProvider>(timelineOptionsProvider);
         editorContext.AddService<IPreviewPlayer>(previewPlayer);
 
-        using var viewModel = new SceneSettingsTabViewModel(editorContext)
+        await using var viewModel = new SceneSettingsTabViewModel(editorContext)
         {
             Width =
             {
@@ -122,7 +122,7 @@ public class SceneSettingsTabViewModelTests
         editorContext.AddService<ITimelineOptionsProvider>(timelineOptionsProvider);
         editorContext.AddService<IPreviewPlayer>(previewPlayer);
 
-        using var viewModel = new SceneSettingsTabViewModel(editorContext)
+        await using var viewModel = new SceneSettingsTabViewModel(editorContext)
         {
             Width =
             {
@@ -219,14 +219,17 @@ public class SceneSettingsTabViewModelTests
             return default;
         }
 
-        public bool OpenToolTab(IToolContext item)
+        public ValueTask<bool> OpenToolTabAsync(IToolContext item)
         {
-            return false;
+            return new ValueTask<bool>(false);
         }
 
-        public void CloseToolTab(IToolContext item)
+        public ValueTask CloseToolTabAsync(IToolContext item)
         {
+            return ValueTask.CompletedTask;
         }
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
     }
 
     private sealed class TestTimelineOptionsProvider(Scene scene) : ITimelineOptionsProvider

--- a/tests/Beutl.UnitTests/Editor/SceneSettingsTabViewModelTests.cs
+++ b/tests/Beutl.UnitTests/Editor/SceneSettingsTabViewModelTests.cs
@@ -186,6 +186,8 @@ public class SceneSettingsTabViewModelTests
 
     private sealed class TestEditorContext(CoreObject obj) : IEditorContext
     {
+        public IEditorContextCloseService CloseService => TestEditorContextCloseService.Instance;
+
         private readonly Dictionary<Type, object> _services = [];
 
         public CoreObject Object { get; } = obj;

--- a/tests/Beutl.UnitTests/Editor/SceneSettingsTabViewModelTests.cs
+++ b/tests/Beutl.UnitTests/Editor/SceneSettingsTabViewModelTests.cs
@@ -101,6 +101,29 @@ public class SceneSettingsTabViewModelTests
         });
     }
 
+    [Test]
+    public async Task Disposal_waits_for_apply_paused_before_scene_mutation()
+    {
+        var scene = new Scene(640, 480, string.Empty);
+        var settings = new CaptureSceneSettingsService();
+        var player = new BlockingPreviewPlayer();
+        var context = new TestEditorContext(scene);
+        context.AddService(scene);
+        context.AddService<ISceneSettingsService>(settings);
+        context.AddService<ITimelineOptionsProvider>(new TestTimelineOptionsProvider(scene));
+        context.AddService<IPreviewPlayer>(player);
+        var viewModel = new SceneSettingsTabViewModel(context);
+        viewModel.Width.Value = 800;
+        viewModel.DurationInput.Value = "00:00:05";
+        Task apply = viewModel.Apply.ExecuteAsync();
+        await player.PauseStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Task disposal = viewModel.DisposeAsync().AsTask();
+        Assert.That(disposal.IsCompleted, Is.False);
+        player.CompletePause();
+        await Task.WhenAll(apply, disposal).WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.That(settings.CallCount, Is.EqualTo(1));
+    }
+
     [TestCase(0, 600, "00:00:03", "00:00:12", TestName = "Apply_DoesNotCommitAndNotifies_WhenWidthBecomesZeroWhilePausing")]
     [TestCase(800, 0, "00:00:03", "00:00:12", TestName = "Apply_DoesNotCommitAndNotifies_WhenHeightBecomesZeroWhilePausing")]
     [TestCase(800, 600, "-00:00:01", "00:00:12", TestName = "Apply_DoesNotCommitAndNotifies_WhenStartBecomesNegativeWhilePausing")]

--- a/tests/Beutl.UnitTests/Editor/TerminalTabViewModelTests.cs
+++ b/tests/Beutl.UnitTests/Editor/TerminalTabViewModelTests.cs
@@ -162,12 +162,12 @@ public class TerminalTabViewModelTests
     }
 
     [Test]
-    public void Header_NumbersEachInstance()
+    public async Task Header_NumbersEachInstance()
     {
         var scene = new Scene(640, 480, string.Empty);
         var editorContext = new TestEditorContext(scene);
-        using var first = new TerminalTabViewModel(editorContext);
-        using var second = new TerminalTabViewModel(editorContext);
+        await using var first = new TerminalTabViewModel(editorContext);
+        await using var second = new TerminalTabViewModel(editorContext);
 
         Assert.Multiple(() =>
         {
@@ -178,10 +178,10 @@ public class TerminalTabViewModelTests
     }
 
     [Test]
-    public void Header_AppendsTheTitleTheShellReports()
+    public async Task Header_AppendsTheTitleTheShellReports()
     {
         var scene = new Scene(640, 480, string.Empty);
-        using var viewModel = new TerminalTabViewModel(new TestEditorContext(scene));
+        await using var viewModel = new TerminalTabViewModel(new TestEditorContext(scene));
         string numbered = viewModel.Header.Value;
 
         viewModel.TerminalTitle.Value = "  vim Program.cs  ";
@@ -192,15 +192,15 @@ public class TerminalTabViewModelTests
     }
 
     [Test]
-    public void Instance_numbers_stay_unique_across_a_view_state_round_trip()
+    public async Task Instance_numbers_stay_unique_across_a_view_state_round_trip()
     {
         var scene = new Scene(640, 480, string.Empty);
         var editorContext = new TestEditorContext(scene);
-        using var sceneA = new TerminalTabViewModel(editorContext);
+        await using var sceneA = new TerminalTabViewModel(editorContext);
         var json = new JsonObject();
         sceneA.WriteToJson(json);
 
-        using var sceneB = new TerminalTabViewModel(editorContext);
+        await using var sceneB = new TerminalTabViewModel(editorContext);
         sceneB.ReadFromJson(json);
 
         Assert.Multiple(() =>
@@ -212,7 +212,7 @@ public class TerminalTabViewModelTests
     }
 
     [Test]
-    public void Dispose_RaisesDisposedOnce()
+    public async Task Dispose_RaisesDisposedOnce()
     {
         var scene = new Scene(640, 480, string.Empty);
         var editorContext = new TestEditorContext(scene);
@@ -220,8 +220,8 @@ public class TerminalTabViewModelTests
         int disposedCount = 0;
         viewModel.Disposed += (_, _) => disposedCount++;
 
-        viewModel.Dispose();
-        viewModel.Dispose();
+        await viewModel.DisposeAsync();
+        await viewModel.DisposeAsync();
 
         Assert.Multiple(() =>
         {
@@ -265,13 +265,16 @@ public class TerminalTabViewModelTests
             return default;
         }
 
-        public bool OpenToolTab(IToolContext item)
+        public ValueTask<bool> OpenToolTabAsync(IToolContext item)
         {
-            return false;
+            return new ValueTask<bool>(false);
         }
 
-        public void CloseToolTab(IToolContext item)
+        public ValueTask CloseToolTabAsync(IToolContext item)
         {
+            return ValueTask.CompletedTask;
         }
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
     }
 }

--- a/tests/Beutl.UnitTests/Editor/TerminalTabViewModelTests.cs
+++ b/tests/Beutl.UnitTests/Editor/TerminalTabViewModelTests.cs
@@ -232,6 +232,8 @@ public class TerminalTabViewModelTests
 
     private sealed class TestEditorContext(CoreObject obj) : IEditorContext
     {
+        public IEditorContextCloseService CloseService => TestEditorContextCloseService.Instance;
+
         private readonly Dictionary<Type, object> _services = [];
 
         public CoreObject Object { get; } = obj;

--- a/tests/Beutl.UnitTests/Editor/TestEditorContextCloseService.cs
+++ b/tests/Beutl.UnitTests/Editor/TestEditorContextCloseService.cs
@@ -6,6 +6,8 @@ internal sealed class TestEditorContextCloseService : IEditorContextCloseService
 {
     public static TestEditorContextCloseService Instance { get; } = new();
 
+    public EditorContextHostToken HostToken { get; } = new();
+
     public EditorContextCloseRequest RequestClose(IEditorContext context)
         => new(EditorContextCloseRequestStatus.NotOwned, Task.CompletedTask);
 }

--- a/tests/Beutl.UnitTests/Editor/TestEditorContextCloseService.cs
+++ b/tests/Beutl.UnitTests/Editor/TestEditorContextCloseService.cs
@@ -1,0 +1,11 @@
+﻿using Beutl.Extensibility;
+
+namespace Beutl.UnitTests.Editor;
+
+internal sealed class TestEditorContextCloseService : IEditorContextCloseService
+{
+    public static TestEditorContextCloseService Instance { get; } = new();
+
+    public EditorContextCloseRequest RequestClose(IEditorContext context)
+        => new(EditorContextCloseRequestStatus.NotOwned, Task.CompletedTask);
+}

--- a/tests/Beutl.UnitTests/Editor/TimelineTabViewModelShortcutTests.cs
+++ b/tests/Beutl.UnitTests/Editor/TimelineTabViewModelShortcutTests.cs
@@ -450,13 +450,16 @@ public class TimelineTabViewModelShortcutTests
             return default;
         }
 
-        public bool OpenToolTab(IToolContext item)
+        public ValueTask<bool> OpenToolTabAsync(IToolContext item)
         {
-            return false;
+            return new ValueTask<bool>(false);
         }
 
-        public void CloseToolTab(IToolContext item)
+        public ValueTask CloseToolTabAsync(IToolContext item)
         {
+            return ValueTask.CompletedTask;
         }
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
     }
 }

--- a/tests/Beutl.UnitTests/Editor/TimelineTabViewModelShortcutTests.cs
+++ b/tests/Beutl.UnitTests/Editor/TimelineTabViewModelShortcutTests.cs
@@ -417,6 +417,8 @@ public class TimelineTabViewModelShortcutTests
 
     private sealed class TestEditorContext(CoreObject obj) : IEditorContext
     {
+        public IEditorContextCloseService CloseService => TestEditorContextCloseService.Instance;
+
         private readonly Dictionary<Type, object> _services = [];
 
         public CoreObject Object { get; } = obj;

--- a/tests/Beutl.UnitTests/Editor/TimelineTabViewModelTests.cs
+++ b/tests/Beutl.UnitTests/Editor/TimelineTabViewModelTests.cs
@@ -151,6 +151,8 @@ public class TimelineTabViewModelTests
 
     private sealed class TestEditorContext(CoreObject obj) : IEditorContext
     {
+        public IEditorContextCloseService CloseService => TestEditorContextCloseService.Instance;
+
         private readonly Dictionary<Type, object> _services = [];
 
         public CoreObject Object { get; } = obj;

--- a/tests/Beutl.UnitTests/Editor/TimelineTabViewModelTests.cs
+++ b/tests/Beutl.UnitTests/Editor/TimelineTabViewModelTests.cs
@@ -15,9 +15,9 @@ namespace Beutl.UnitTests.Editor;
 public class TimelineTabViewModelTests
 {
     [Test]
-    public void DirectRazorModeSet_ClearsActiveTrimMode()
+    public async Task DirectRazorModeSet_ClearsActiveTrimMode()
     {
-        using TimelineTabViewModel viewModel = CreateViewModel();
+        await using TimelineTabViewModel viewModel = CreateViewModel();
         viewModel.IsSlipMode.Value = true;
 
         viewModel.IsRazorMode.Value = true;
@@ -32,9 +32,9 @@ public class TimelineTabViewModelTests
     }
 
     [Test]
-    public void DirectTrimModeSet_ClearsRazorAndOtherTrimModes()
+    public async Task DirectTrimModeSet_ClearsRazorAndOtherTrimModes()
     {
-        using TimelineTabViewModel viewModel = CreateViewModel();
+        await using TimelineTabViewModel viewModel = CreateViewModel();
         viewModel.IsRazorMode.Value = true;
 
         viewModel.IsRollMode.Value = true;
@@ -61,9 +61,9 @@ public class TimelineTabViewModelTests
     // The V/Escape gestures are shared by every Exit* command; the dispatcher relies on
     // CanExecute being true only for the active mode to fall through to the right one.
     [Test]
-    public void CanExecute_ExitCommands_TrueOnlyForActiveMode()
+    public async Task CanExecute_ExitCommands_TrueOnlyForActiveMode()
     {
-        using TimelineTabViewModel viewModel = CreateViewModel();
+        await using TimelineTabViewModel viewModel = CreateViewModel();
         viewModel.IsRollMode.Value = true;
 
         Assert.Multiple(() =>
@@ -76,9 +76,9 @@ public class TimelineTabViewModelTests
     }
 
     [Test]
-    public void CanExecute_ExitCommands_AllFalseWhenNoModeActive()
+    public async Task CanExecute_ExitCommands_AllFalseWhenNoModeActive()
     {
-        using TimelineTabViewModel viewModel = CreateViewModel();
+        await using TimelineTabViewModel viewModel = CreateViewModel();
 
         Assert.Multiple(() =>
         {
@@ -92,9 +92,9 @@ public class TimelineTabViewModelTests
     // A live tracked-layer-top subscription is what closes the loop — without a subscriber the
     // synchronous Height emits reach nothing and no re-entry happens at all.
     [Test]
-    public void CalculateLayerTop_DeepLayer_WithTrackedSubscriber_GrowsWithoutRecursing()
+    public async Task CalculateLayerTop_DeepLayer_WithTrackedSubscriber_GrowsWithoutRecursing()
     {
-        using TimelineTabViewModel viewModel = CreateViewModel();
+        await using TimelineTabViewModel viewModel = CreateViewModel();
         using IDisposable subscription = viewModel.GetTrackedLayerTopObservable(1).Subscribe(_ => { });
 
         double top = viewModel.CalculateLayerTop(2000);
@@ -111,9 +111,9 @@ public class TimelineTabViewModelTests
     // The subscriber's own layer is above the growth, so every new header's height feeds it and
     // it must still end holding the completed sum, not a partial one.
     [Test]
-    public void TrackedLayerTop_DeepSubscriber_EndsWithCompletedSum()
+    public async Task TrackedLayerTop_DeepSubscriber_EndsWithCompletedSum()
     {
-        using TimelineTabViewModel viewModel = CreateViewModel();
+        await using TimelineTabViewModel viewModel = CreateViewModel();
         double observed = double.NaN;
         using IDisposable subscription = viewModel.GetTrackedLayerTopObservable(2000)
             .Subscribe(v => observed = v);
@@ -124,9 +124,9 @@ public class TimelineTabViewModelTests
     }
 
     [Test]
-    public void ToLayerNumber_FarBelowLastHeader_WithTrackedSubscriber_GrowsWithoutRecursing()
+    public async Task ToLayerNumber_FarBelowLastHeader_WithTrackedSubscriber_GrowsWithoutRecursing()
     {
-        using TimelineTabViewModel viewModel = CreateViewModel();
+        await using TimelineTabViewModel viewModel = CreateViewModel();
         using IDisposable subscription = viewModel.GetTrackedLayerTopObservable(1).Subscribe(_ => { });
         double deepOffset = viewModel.CalculateLayerTop(1) * 2000;
 
@@ -184,14 +184,17 @@ public class TimelineTabViewModelTests
             return default;
         }
 
-        public bool OpenToolTab(IToolContext item)
+        public ValueTask<bool> OpenToolTabAsync(IToolContext item)
         {
-            return false;
+            return new ValueTask<bool>(false);
         }
 
-        public void CloseToolTab(IToolContext item)
+        public ValueTask CloseToolTabAsync(IToolContext item)
         {
+            return ValueTask.CompletedTask;
         }
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
     }
 
     private sealed class TestTimelineOptionsProvider(Scene scene) : ITimelineOptionsProvider

--- a/tests/Beutl.UnitTests/Editor/ToolTabReuseTests.cs
+++ b/tests/Beutl.UnitTests/Editor/ToolTabReuseTests.cs
@@ -109,6 +109,8 @@ public class ToolTabReuseTests
 
     private sealed class TestEditorContext(params FakeTab[] tabs) : IEditorContext
     {
+        public IEditorContextCloseService CloseService => TestEditorContextCloseService.Instance;
+
         public CoreObject Object => null!;
 
         public EditorExtension Extension => null!;

--- a/tests/Beutl.UnitTests/Editor/ToolTabReuseTests.cs
+++ b/tests/Beutl.UnitTests/Editor/ToolTabReuseTests.cs
@@ -94,9 +94,7 @@ public class ToolTabReuseTests
 
         public IReadOnlyReactiveProperty<string> Header { get; } = new ReactivePropertySlim<string>("fake");
 
-        public void Dispose()
-        {
-        }
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
         public object? GetService(Type serviceType) => null;
 
@@ -133,11 +131,14 @@ public class ToolTabReuseTests
             return FindToolTab<T>(_ => true);
         }
 
-        public bool OpenToolTab(IToolContext item) => true;
+        public ValueTask<bool> OpenToolTabAsync(IToolContext item) => new(true);
 
-        public void CloseToolTab(IToolContext item)
+        public ValueTask CloseToolTabAsync(IToolContext item)
         {
+            return ValueTask.CompletedTask;
         }
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
         public void Dispose()
         {

--- a/tests/Beutl.UnitTests/Editor/VersionControl/VersionControlTabViewModelTests.cs
+++ b/tests/Beutl.UnitTests/Editor/VersionControl/VersionControlTabViewModelTests.cs
@@ -18,7 +18,7 @@ public class VersionControlTabViewModelTests
         Mock<IProjectVersionControlService> service = CreateServiceMock();
         service.Setup(x => x.GetAvailabilityAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(GitAvailability.NotInstalled);
-        using VersionControlTabViewModel viewModel = CreateViewModel(service.Object);
+        await using VersionControlTabViewModel viewModel = CreateViewModel(service.Object);
 
         await viewModel.Initialization;
 
@@ -54,7 +54,7 @@ public class VersionControlTabViewModelTests
                 "/usr/bin/git",
                 new Version(2, 22, 1),
                 LfsInstalled: false));
-        using VersionControlTabViewModel viewModel = CreateViewModel(service.Object);
+        await using VersionControlTabViewModel viewModel = CreateViewModel(service.Object);
 
         await viewModel.Initialization;
 
@@ -74,7 +74,7 @@ public class VersionControlTabViewModelTests
     {
         Mock<IProjectVersionControlService> service = CreateServiceMock();
         service.SetupGet(x => x.Repository).Returns((RepositoryInfo?)null);
-        using VersionControlTabViewModel viewModel = CreateViewModel(service.Object);
+        await using VersionControlTabViewModel viewModel = CreateViewModel(service.Object);
 
         await viewModel.Initialization;
 
@@ -103,7 +103,7 @@ public class VersionControlTabViewModelTests
             .ReturnsAsync([commit]);
         using var serviceSource =
             new ReactivePropertySlim<IProjectVersionControlService?>(null);
-        using var viewModel = new VersionControlTabViewModel(
+        await using var viewModel = new VersionControlTabViewModel(
             Mock.Of<ToolTabExtension>(),
             Mock.Of<IEditorContext>(),
             serviceSource,
@@ -154,7 +154,7 @@ public class VersionControlTabViewModelTests
             .ReturnsAsync([commitB]);
         using var serviceSource =
             new ReactivePropertySlim<IProjectVersionControlService?>(serviceA.Object);
-        using var viewModel = new VersionControlTabViewModel(
+        await using var viewModel = new VersionControlTabViewModel(
             Mock.Of<ToolTabExtension>(),
             Mock.Of<IEditorContext>(),
             serviceSource,
@@ -214,7 +214,7 @@ public class VersionControlTabViewModelTests
         RepositoryInfo? repository = null;
         Mock<IProjectVersionControlService> service = CreateServiceMock();
         service.SetupGet(x => x.Repository).Returns(() => repository);
-        using VersionControlTabViewModel viewModel = CreateViewModel(service.Object);
+        await using VersionControlTabViewModel viewModel = CreateViewModel(service.Object);
         int requestCount = 0;
         viewModel.RequestEnableVersionControlAsync = () =>
         {
@@ -241,7 +241,7 @@ public class VersionControlTabViewModelTests
     {
         Mock<IProjectVersionControlService> service = CreateServiceMock();
         service.SetupGet(x => x.Repository).Returns(() => null);
-        using VersionControlTabViewModel viewModel = CreateViewModel(service.Object);
+        await using VersionControlTabViewModel viewModel = CreateViewModel(service.Object);
         var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         bool runningWhileRequested = false;
         string? labelWhileRequested = null;
@@ -278,7 +278,7 @@ public class VersionControlTabViewModelTests
     {
         Mock<IProjectVersionControlService> service = CreateServiceMock();
         service.SetupGet(x => x.Repository).Returns(() => null);
-        using VersionControlTabViewModel viewModel = CreateViewModel(service.Object);
+        await using VersionControlTabViewModel viewModel = CreateViewModel(service.Object);
         viewModel.RequestEnableVersionControlAsync = () =>
             Task.FromException(new InvalidOperationException("simulated failure"));
         await viewModel.Initialization;
@@ -298,7 +298,7 @@ public class VersionControlTabViewModelTests
         Mock<IProjectVersionControlService> service = CreateServiceMock();
         service.Setup(x => x.GetAvailabilityAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(GitAvailability.NotInstalled);
-        using VersionControlTabViewModel viewModel = CreateViewModel(service.Object);
+        await using VersionControlTabViewModel viewModel = CreateViewModel(service.Object);
         Uri? launchedUri = null;
         viewModel.LaunchUriAsync = uri =>
         {
@@ -325,7 +325,7 @@ public class VersionControlTabViewModelTests
                 0,
                 [new FileChange("project.bep", FileChangeStatus.Modified)],
                 HasConflicts: true));
-        using VersionControlTabViewModel viewModel = CreateViewModel(service.Object);
+        await using VersionControlTabViewModel viewModel = CreateViewModel(service.Object);
 
         await viewModel.Initialization;
 
@@ -362,7 +362,7 @@ public class VersionControlTabViewModelTests
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync((int skip, int take, CancellationToken _) =>
                 commits.Skip(skip).Take(take).ToArray());
-        using VersionControlTabViewModel viewModel = CreateViewModel(service.Object);
+        await using VersionControlTabViewModel viewModel = CreateViewModel(service.Object);
 
         await viewModel.Initialization;
 
@@ -408,7 +408,7 @@ public class VersionControlTabViewModelTests
                 It.IsAny<string>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync([]);
-        using VersionControlTabViewModel viewModel = CreateViewModel(service.Object);
+        await using VersionControlTabViewModel viewModel = CreateViewModel(service.Object);
         await viewModel.Initialization;
         await viewModel.LoadMoreAsync();
         VersionControlCommitViewModel[] loadedCommits = [.. viewModel.Commits];
@@ -463,7 +463,7 @@ public class VersionControlTabViewModelTests
                 It.IsAny<string>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync([]);
-        using VersionControlTabViewModel viewModel = CreateViewModel(service.Object);
+        await using VersionControlTabViewModel viewModel = CreateViewModel(service.Object);
         await viewModel.Initialization;
         VersionControlCommitViewModel originalSelection = viewModel.Commits[1];
         await viewModel.OpenCommitDetailAsync(originalSelection);
@@ -539,7 +539,7 @@ public class VersionControlTabViewModelTests
 
                 return Task.FromResult<IReadOnlyList<RemoteInfo>>([latestRemote]);
             });
-        using VersionControlTabViewModel viewModel = CreateViewModel(service.Object);
+        await using VersionControlTabViewModel viewModel = CreateViewModel(service.Object);
         await viewModel.Initialization;
 
         service.Raise(
@@ -703,7 +703,7 @@ public class VersionControlTabViewModelTests
                 .ReturnsAsync(testCase.HasRemote
                     ? [new RemoteInfo("origin", "https://example.invalid/repo.git")]
                     : []);
-            using VersionControlTabViewModel viewModel = CreateViewModel(
+            await using VersionControlTabViewModel viewModel = CreateViewModel(
                 service.Object,
                 Mock.Of<IProjectVersionControlCoordinator>());
             await viewModel.Initialization;
@@ -757,7 +757,7 @@ public class VersionControlTabViewModelTests
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync([]);
         Action? pendingUiAction = null;
-        using var viewModel = new VersionControlTabViewModel(
+        await using var viewModel = new VersionControlTabViewModel(
             Mock.Of<ToolTabExtension>(),
             Mock.Of<IEditorContext>(),
             CreateServiceSource(service.Object),
@@ -815,7 +815,7 @@ public class VersionControlTabViewModelTests
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync([]);
         Action? pendingUiAction = null;
-        using var viewModel = new VersionControlTabViewModel(
+        await using var viewModel = new VersionControlTabViewModel(
             Mock.Of<ToolTabExtension>(),
             Mock.Of<IEditorContext>(),
             CreateServiceSource(service.Object),
@@ -872,7 +872,7 @@ public class VersionControlTabViewModelTests
                 It.IsAny<int>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync([]);
-        using var viewModel = new VersionControlTabViewModel(
+        await using var viewModel = new VersionControlTabViewModel(
             Mock.Of<ToolTabExtension>(),
             Mock.Of<IEditorContext>(),
             CreateServiceSource(service.Object),
@@ -912,7 +912,7 @@ public class VersionControlTabViewModelTests
                 It.IsAny<CancellationToken>()))
             .Callback(() => currentRecoveries = [])
             .ReturnsAsync(new ProjectRecoveryResult.RestoredOriginal());
-        using VersionControlTabViewModel viewModel = CreateViewModel(
+        await using VersionControlTabViewModel viewModel = CreateViewModel(
             service.Object,
             coordinator.Object);
         await viewModel.Initialization;
@@ -965,7 +965,7 @@ public class VersionControlTabViewModelTests
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ProjectRecoveryResult.FailedPreserved(
                 "refs/beutl/safety/test-checkpoint"));
-        using VersionControlTabViewModel viewModel = CreateViewModel(
+        await using VersionControlTabViewModel viewModel = CreateViewModel(
             service.Object,
             coordinator.Object);
         await viewModel.Initialization;
@@ -985,7 +985,7 @@ public class VersionControlTabViewModelTests
         coordinator.Setup(x => x.GetPendingPullRecoveriesAsync(
                 It.IsAny<CancellationToken>()))
             .Returns(() => query());
-        using VersionControlTabViewModel viewModel = CreateViewModel(
+        await using VersionControlTabViewModel viewModel = CreateViewModel(
             service.Object,
             coordinator.Object);
         await viewModel.Initialization;
@@ -1026,7 +1026,7 @@ public class VersionControlTabViewModelTests
         coordinator.Setup(x => x.GetPendingPullRecoveriesAsync(
                 It.IsAny<CancellationToken>()))
             .Returns(() => query());
-        using VersionControlTabViewModel viewModel = CreateViewModel(
+        await using VersionControlTabViewModel viewModel = CreateViewModel(
             service.Object,
             coordinator.Object);
         await viewModel.Initialization;
@@ -1068,7 +1068,7 @@ public class VersionControlTabViewModelTests
                 file.Path,
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync("--- a/project.bep\n+++ b/project.bep\n-old\n+new\n unchanged\n");
-        using VersionControlTabViewModel viewModel = CreateViewModel(service.Object);
+        await using VersionControlTabViewModel viewModel = CreateViewModel(service.Object);
         await viewModel.Initialization;
 
         VersionControlCommitViewModel commitViewModel = viewModel.Commits.Single();
@@ -1169,7 +1169,7 @@ public class VersionControlTabViewModelTests
                 secondCommit.Sha,
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync([secondFile]);
-        using VersionControlTabViewModel viewModel = CreateViewModel(service.Object);
+        await using VersionControlTabViewModel viewModel = CreateViewModel(service.Object);
         await viewModel.Initialization;
 
         Task firstSelection = viewModel.SelectCommitAsync(viewModel.Commits[0]);
@@ -1201,7 +1201,7 @@ public class VersionControlTabViewModelTests
                 commit.Sha,
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync([file]);
-        using VersionControlTabViewModel viewModel = CreateViewModel(service.Object);
+        await using VersionControlTabViewModel viewModel = CreateViewModel(service.Object);
         await viewModel.Initialization;
         VersionControlCommitViewModel selected = viewModel.Commits.Single();
 
@@ -1258,7 +1258,7 @@ public class VersionControlTabViewModelTests
                 restoreStarted.TrySetResult();
                 return restoreCompletion.Task;
             });
-        using VersionControlTabViewModel viewModel = CreateViewModel(
+        await using VersionControlTabViewModel viewModel = CreateViewModel(
             service.Object,
             coordinator.Object);
         await viewModel.Initialization;
@@ -1327,7 +1327,7 @@ public class VersionControlTabViewModelTests
             Task.FromResult<IReadOnlyList<ProjectRecoveryInfo>>([]));
         using var serviceSource =
             new ReactivePropertySlim<IProjectVersionControlService?>(originatingService.Object);
-        using var viewModel = new VersionControlTabViewModel(
+        await using var viewModel = new VersionControlTabViewModel(
             Mock.Of<ToolTabExtension>(),
             Mock.Of<IEditorContext>(),
             serviceSource,
@@ -1340,7 +1340,7 @@ public class VersionControlTabViewModelTests
             .WaitAsync(TimeSpan.FromSeconds(2));
         if (disposeViewModel)
         {
-            viewModel.Dispose();
+            await viewModel.DisposeAsync();
         }
         else
         {
@@ -1384,7 +1384,7 @@ public class VersionControlTabViewModelTests
             .ReturnsAsync(true);
         coordinator.SetReturnsDefault(
             Task.FromResult<IReadOnlyList<ProjectRecoveryInfo>>([]));
-        using var viewModel = new VersionControlTabViewModel(
+        await using var viewModel = new VersionControlTabViewModel(
             Mock.Of<ToolTabExtension>(),
             Mock.Of<IEditorContext>(),
             CreateServiceSource(service.Object),
@@ -1448,7 +1448,7 @@ public class VersionControlTabViewModelTests
             TaskCreationOptions.RunContinuationsAsynchronously);
         using var serviceSource =
             new ReactivePropertySlim<IProjectVersionControlService?>(originatingService.Object);
-        using var viewModel = new VersionControlTabViewModel(
+        await using var viewModel = new VersionControlTabViewModel(
             Mock.Of<ToolTabExtension>(),
             Mock.Of<IEditorContext>(),
             serviceSource,
@@ -1467,7 +1467,7 @@ public class VersionControlTabViewModelTests
         await promptStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
         if (disposeViewModel)
         {
-            viewModel.Dispose();
+            await viewModel.DisposeAsync();
         }
         else
         {
@@ -1527,7 +1527,7 @@ public class VersionControlTabViewModelTests
             Task.FromResult<IReadOnlyList<ProjectRecoveryInfo>>([]));
         using var serviceSource =
             new ReactivePropertySlim<IProjectVersionControlService?>(originatingService.Object);
-        using var viewModel = new VersionControlTabViewModel(
+        await using var viewModel = new VersionControlTabViewModel(
             Mock.Of<ToolTabExtension>(),
             Mock.Of<IEditorContext>(),
             serviceSource,
@@ -1569,7 +1569,7 @@ public class VersionControlTabViewModelTests
                 "rough cut",
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(new CommitResult.NoChanges());
-        using var viewModel = CreateViewModel(service.Object, coordinator.Object);
+        await using var viewModel = CreateViewModel(service.Object, coordinator.Object);
         await viewModel.Initialization;
         viewModel.CommitMessage.Value = " rough cut ";
 
@@ -1603,7 +1603,7 @@ public class VersionControlTabViewModelTests
                 submissionStarted.TrySetResult();
                 return submissionCompletion.Task;
             });
-        using var viewModel = CreateViewModel(service.Object, coordinator.Object);
+        await using var viewModel = CreateViewModel(service.Object, coordinator.Object);
         await viewModel.Initialization;
         viewModel.CommitMessage.Value = " submitted message ";
 
@@ -1637,7 +1637,7 @@ public class VersionControlTabViewModelTests
                 "rough cut",
                 It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("hook rejected the commit"));
-        using var viewModel = CreateViewModel(service.Object, coordinator.Object);
+        await using var viewModel = CreateViewModel(service.Object, coordinator.Object);
         await viewModel.Initialization;
         viewModel.CommitMessage.Value = "rough cut";
 
@@ -1654,7 +1654,7 @@ public class VersionControlTabViewModelTests
                 "milestone",
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(new CommitResult.Committed(new CommitRevision.Unavailable()));
-        using var viewModel = CreateViewModel(service.Object, coordinator.Object);
+        await using var viewModel = CreateViewModel(service.Object, coordinator.Object);
         await viewModel.Initialization;
         viewModel.CommitMessage.Value = "milestone";
 
@@ -1685,7 +1685,7 @@ public class VersionControlTabViewModelTests
                 "milestone",
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(new CommitResult.Committed(new CommitRevision.Known(manual.Sha)));
-        using var viewModel = CreateViewModel(service.Object, coordinator.Object);
+        await using var viewModel = CreateViewModel(service.Object, coordinator.Object);
         await viewModel.Initialization;
         viewModel.CommitMessage.Value = "milestone";
 
@@ -1722,7 +1722,7 @@ public class VersionControlTabViewModelTests
                 It.IsAny<int>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(kinds.Select((kind, index) => CreateCommit(index, kind)).ToArray());
-        using VersionControlTabViewModel viewModel = CreateViewModel(service.Object);
+        await using VersionControlTabViewModel viewModel = CreateViewModel(service.Object);
 
         await viewModel.Initialization;
 
@@ -1797,7 +1797,7 @@ public class VersionControlTabViewModelTests
                 return Task.FromResult<RemoteOpResult>(new RemoteOpResult.Offline());
             });
         RemoteOpResult? shownResult = null;
-        using var viewModel = CreateViewModel(service.Object, coordinator.Object);
+        await using var viewModel = CreateViewModel(service.Object, coordinator.Object);
         viewModel.ShowRemoteResultAsync = result =>
         {
             shownResult = result;
@@ -1828,7 +1828,7 @@ public class VersionControlTabViewModelTests
             .ReturnsAsync(new RemoteOpResult.Offline());
         int notificationCalls = 0;
         using var source = new ReactivePropertySlim<IProjectVersionControlService?>(service.Object);
-        using var viewModel = new VersionControlTabViewModel(
+        await using var viewModel = new VersionControlTabViewModel(
             Mock.Of<ToolTabExtension>(),
             Mock.Of<IEditorContext>(),
             source,
@@ -1866,7 +1866,7 @@ public class VersionControlTabViewModelTests
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(new RemoteOpResult.Offline());
         int notificationCalls = 0;
-        using var viewModel = new VersionControlTabViewModel(
+        await using var viewModel = new VersionControlTabViewModel(
             Mock.Of<ToolTabExtension>(),
             Mock.Of<IEditorContext>(),
             CreateServiceSource(service.Object),
@@ -1883,7 +1883,7 @@ public class VersionControlTabViewModelTests
 
         Task push = viewModel.PushAsync();
         Assert.That(queuedUiActions, Has.Count.EqualTo(1));
-        viewModel.Dispose();
+        await viewModel.DisposeAsync();
         await push.WaitAsync(TimeSpan.FromSeconds(2));
         await viewModel.RemoteOperationCompletion.WaitAsync(TimeSpan.FromSeconds(2));
         queuedUiActions[0]();
@@ -1902,7 +1902,7 @@ public class VersionControlTabViewModelTests
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(new RemoteOpResult.Offline());
         int notificationCalls = 0;
-        using var viewModel = new VersionControlTabViewModel(
+        await using var viewModel = new VersionControlTabViewModel(
             Mock.Of<ToolTabExtension>(),
             Mock.Of<IEditorContext>(),
             CreateServiceSource(service.Object),
@@ -1957,7 +1957,7 @@ public class VersionControlTabViewModelTests
 
                 return new RemoteOpResult.Offline();
             });
-        using var viewModel = new VersionControlTabViewModel(
+        await using var viewModel = new VersionControlTabViewModel(
             Mock.Of<ToolTabExtension>(),
             Mock.Of<IEditorContext>(),
             CreateServiceSource(service.Object),
@@ -2001,7 +2001,7 @@ public class VersionControlTabViewModelTests
                 It.IsAny<IProgress<string>>(),
                 It.IsAny<CancellationToken>()))
             .ThrowsAsync(new VersionControlConflictedException(Strings.VersionControl_ConflictGuidance));
-        using var viewModel = CreateViewModel(service.Object, coordinator.Object);
+        await using var viewModel = CreateViewModel(service.Object, coordinator.Object);
         await viewModel.Initialization;
 
         viewModel.PushCommand.Execute(null);
@@ -2025,7 +2025,7 @@ public class VersionControlTabViewModelTests
         var coordinator = new Mock<IProjectVersionControlCoordinator>();
         coordinator.Setup(x => x.PullAsync(It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("backend fault"));
-        using var viewModel = CreateViewModel(service.Object, coordinator.Object);
+        await using var viewModel = CreateViewModel(service.Object, coordinator.Object);
         await viewModel.Initialization;
 
         viewModel.PullCommand.Execute(null);
@@ -2051,7 +2051,7 @@ public class VersionControlTabViewModelTests
                 It.IsAny<IProgress<string>>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(new RemoteOpResult.Success());
-        using var viewModel = CreateViewModel(service.Object, coordinator.Object);
+        await using var viewModel = CreateViewModel(service.Object, coordinator.Object);
         await viewModel.Initialization;
 
         viewModel.PushCommand.Execute(null);
@@ -2082,7 +2082,7 @@ public class VersionControlTabViewModelTests
         var coordinator = new Mock<IProjectVersionControlCoordinator>();
         coordinator.Setup(x => x.PushAsync(It.IsAny<IProgress<string>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new RemoteOpResult.Success());
-        using var viewModel = CreateViewModel(service.Object, coordinator.Object);
+        await using var viewModel = CreateViewModel(service.Object, coordinator.Object);
         await viewModel.Initialization;
 
         viewModel.PushCommand.Execute(null);
@@ -2116,7 +2116,7 @@ public class VersionControlTabViewModelTests
         coordinator.Setup(x => x.PushAsync(It.IsAny<IProgress<string>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new RemoteOpResult.Success());
         using var source = new ReactivePropertySlim<IProjectVersionControlService?>(service.Object);
-        using var viewModel = new VersionControlTabViewModel(
+        await using var viewModel = new VersionControlTabViewModel(
             Mock.Of<ToolTabExtension>(),
             Mock.Of<IEditorContext>(),
             source,
@@ -2155,7 +2155,7 @@ public class VersionControlTabViewModelTests
                 return new RemoteOpResult.Success();
             });
         using var source = new ReactivePropertySlim<IProjectVersionControlService?>(service.Object);
-        using var viewModel = new VersionControlTabViewModel(
+        await using var viewModel = new VersionControlTabViewModel(
             Mock.Of<ToolTabExtension>(), Mock.Of<IEditorContext>(), source,
             coordinator.Object, action => action());
         await viewModel.Initialization;
@@ -2181,7 +2181,7 @@ public class VersionControlTabViewModelTests
         coordinator.Setup(x => x.PushAsync(
                 It.IsAny<IProgress<string>>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("push fault"));
-        using var viewModel = CreateViewModel(service.Object, coordinator.Object);
+        await using var viewModel = CreateViewModel(service.Object, coordinator.Object);
         viewModel.RequestRemoteUrlAsync = (_, _) =>
             Task.FromResult<string?>("https://example.invalid/repo.git");
         await viewModel.Initialization;
@@ -2204,7 +2204,7 @@ public class VersionControlTabViewModelTests
         service.Setup(x => x.GetRemotesAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync([new RemoteInfo("origin", "https://example.invalid/old.git")]);
         var coordinator = new Mock<IProjectVersionControlCoordinator>();
-        using VersionControlTabViewModel viewModel = CreateViewModel(
+        await using VersionControlTabViewModel viewModel = CreateViewModel(
             service.Object,
             coordinator.Object);
         string? prefilledUrl = null;
@@ -2251,7 +2251,7 @@ public class VersionControlTabViewModelTests
                 Interlocked.Increment(ref setRemoteCalls);
                 return Task.CompletedTask;
             });
-        using var viewModel = new VersionControlTabViewModel(
+        await using var viewModel = new VersionControlTabViewModel(
             Mock.Of<ToolTabExtension>(),
             Mock.Of<IEditorContext>(),
             CreateServiceSource(service.Object),
@@ -2306,7 +2306,7 @@ public class VersionControlTabViewModelTests
         coordinator.Setup(x => x.PushAsync(
                 It.IsAny<IProgress<string>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new RemoteOpResult.Success());
-        using var viewModel = CreateViewModel(service.Object, coordinator.Object);
+        await using var viewModel = CreateViewModel(service.Object, coordinator.Object);
         viewModel.RequestRemoteUrlAsync = (_, _) =>
             Task.FromResult<string?>("https://example.invalid/new.git");
         await viewModel.Initialization;
@@ -2347,7 +2347,7 @@ public class VersionControlTabViewModelTests
         service.Setup(x => x.GetRemotesAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync([new RemoteInfo("origin", remoteUrl)]);
         var coordinator = new Mock<IProjectVersionControlCoordinator>();
-        using VersionControlTabViewModel viewModel = CreateViewModel(
+        await using VersionControlTabViewModel viewModel = CreateViewModel(
             service.Object,
             coordinator.Object);
         string? prefilledUrl = "not requested";
@@ -2381,7 +2381,7 @@ public class VersionControlTabViewModelTests
         service.Setup(x => x.GetRemotesAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync([new RemoteInfo("origin", RemoteUrl)]);
         var coordinator = new Mock<IProjectVersionControlCoordinator>();
-        using VersionControlTabViewModel viewModel = CreateViewModel(
+        await using VersionControlTabViewModel viewModel = CreateViewModel(
             service.Object,
             coordinator.Object);
         string? prefilledUrl = null;
@@ -2421,7 +2421,7 @@ public class VersionControlTabViewModelTests
             TaskCreationOptions.RunContinuationsAsynchronously);
         using var serviceSource =
             new ReactivePropertySlim<IProjectVersionControlService?>(originatingService.Object);
-        using var viewModel = new VersionControlTabViewModel(
+        await using var viewModel = new VersionControlTabViewModel(
             Mock.Of<ToolTabExtension>(),
             Mock.Of<IEditorContext>(),
             serviceSource,
@@ -2440,7 +2440,7 @@ public class VersionControlTabViewModelTests
         await promptStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
         if (disposeViewModel)
         {
-            viewModel.Dispose();
+            await viewModel.DisposeAsync();
         }
         else
         {
@@ -2474,7 +2474,7 @@ public class VersionControlTabViewModelTests
             TaskCreationOptions.RunContinuationsAsynchronously);
         var prompt = new TaskCompletionSource<string?>(
             TaskCreationOptions.RunContinuationsAsynchronously);
-        using var viewModel = CreateViewModel(service.Object, coordinator.Object);
+        await using var viewModel = CreateViewModel(service.Object, coordinator.Object);
         viewModel.RequestRemoteUrlAsync = (_, cancellationToken) =>
         {
             promptStarted.TrySetResult();
@@ -2489,7 +2489,7 @@ public class VersionControlTabViewModelTests
 
         Task configure = viewModel.SetRemoteAsync();
         await promptStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
-        viewModel.Dispose();
+        await viewModel.DisposeAsync();
 
         await promptCanceled.Task.WaitAsync(TimeSpan.FromSeconds(2));
         await configure.WaitAsync(TimeSpan.FromSeconds(2));
@@ -2519,7 +2519,7 @@ public class VersionControlTabViewModelTests
                 It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
         using var source = new ReactivePropertySlim<IProjectVersionControlService?>(service.Object);
-        using var viewModel = new VersionControlTabViewModel(
+        await using var viewModel = new VersionControlTabViewModel(
             Mock.Of<ToolTabExtension>(),
             Mock.Of<IEditorContext>(),
             source,
@@ -2578,7 +2578,7 @@ public class VersionControlTabViewModelTests
                 It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
         using var source = new ReactivePropertySlim<IProjectVersionControlService?>(service.Object);
-        using var viewModel = new VersionControlTabViewModel(
+        await using var viewModel = new VersionControlTabViewModel(
             Mock.Of<ToolTabExtension>(),
             Mock.Of<IEditorContext>(),
             source,
@@ -2636,7 +2636,7 @@ public class VersionControlTabViewModelTests
                 await setRemoteCompletion.Task;
             });
         using var source = new ReactivePropertySlim<IProjectVersionControlService?>(service.Object);
-        using var viewModel = new VersionControlTabViewModel(
+        await using var viewModel = new VersionControlTabViewModel(
             Mock.Of<ToolTabExtension>(),
             Mock.Of<IEditorContext>(),
             source,
@@ -2672,7 +2672,7 @@ public class VersionControlTabViewModelTests
                 It.IsAny<IProgress<string>>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(new RemoteOpResult.Success());
-        using VersionControlTabViewModel viewModel = CreateViewModel(
+        await using VersionControlTabViewModel viewModel = CreateViewModel(
             service.Object,
             coordinator.Object);
         string? prefilledUrl = "not requested";
@@ -2753,7 +2753,7 @@ public class VersionControlTabViewModelTests
                 await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
                 return new RemoteOpResult.Success();
             });
-        using var viewModel = CreateViewModel(service.Object, coordinator.Object);
+        await using var viewModel = CreateViewModel(service.Object, coordinator.Object);
         await viewModel.Initialization;
 
         Task pull = viewModel.PullAsync();
@@ -2786,7 +2786,7 @@ public class VersionControlTabViewModelTests
                 return Task.FromException(new ArgumentException(
                     "Remote URLs must not embed credentials."));
             });
-        using VersionControlTabViewModel viewModel = CreateViewModel(
+        await using VersionControlTabViewModel viewModel = CreateViewModel(
             service.Object,
             coordinator.Object);
         viewModel.RequestRemoteUrlAsync = (_, _) => Task.FromResult<string?>(remoteUrl);
@@ -2822,7 +2822,7 @@ public class VersionControlTabViewModelTests
                 setRemoteInvoked.TrySetResult();
                 return Task.CompletedTask;
             });
-        using VersionControlTabViewModel viewModel = CreateViewModel(
+        await using VersionControlTabViewModel viewModel = CreateViewModel(
             service.Object,
             coordinator.Object);
         viewModel.RequestRemoteUrlAsync = (_, _) =>
@@ -2865,7 +2865,7 @@ public class VersionControlTabViewModelTests
             .Returns(Task.CompletedTask);
         using var serviceSource =
             new ReactivePropertySlim<IProjectVersionControlService?>(service.Object);
-        using var viewModel = new VersionControlTabViewModel(
+        await using var viewModel = new VersionControlTabViewModel(
             Mock.Of<ToolTabExtension>(),
             Mock.Of<IEditorContext>(),
             serviceSource,


### PR DESCRIPTION
## Description

- Make editor-context creation and core-object activation fully asynchronous.
- Enforce exclusive editor and tool context ownership through host tokens and terminal leases.
- Expose context, selection, and tab collections through runtime-immutable read-only facades.
- Serialize project transition tails through recent-project updates and make application-root teardown failure-safe and awaitable.
- Snapshot span-backed CoreList additions before callbacks can mutate their source.
- Update migration guidance, package samples, and non-friend public API contract coverage.

## Affected areas

- `Beutl.Extensibility`, `Beutl`, `Beutl.Core`, PackageSample, and lifecycle tests.
- `AgentHost/EditorProjectSessionGateway.cs` contains only the mechanical await migration required by the breaking lifecycle API; this PR does not change AgentHost behavior.

## Breaking changes

- `EditorExtension.TryCreateContext` is replaced by `CreateContextAsync`.
- `IEditorContext` and `IToolContext` teardown is asynchronous, with editor and tool ownership leases.
- `EditorService.ActivateTabItem(CoreObject)` is replaced by `ActivateTabItemAsync(CoreObject)`.
- `EditorTabItem` construction is host-internal; context, selection, and tab collection surfaces are runtime-immutable facades.
- `MainViewModel` exposes terminal asynchronous disposal.

## Test plan

- `dotnet build Beutl.slnx -c Debug --nologo --no-restore` (passes; 22 existing warnings).
- 178 focused headless lifecycle tests passed across five fixtures.
- 210 `Beutl.PublicApiContractTests` passed.
- 17 `CoreListTests` passed.
- `samples/PackageSample/PackageSample.csproj` builds with 0 warnings and 0 errors.
- GPL/MIT diff scan and `git diff --check` passed.
- `dotnet format --verify-no-changes` reports only the existing MediaFoundation CA1416 diagnostics; no changed-file format diagnostics remain.

## Fixed issues

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Editor tabs, tool tabs, project transitions, and layout operations now complete asynchronously for more reliable activation, closing, and switching.
  * Added safer editor-context replacement and ownership handling to prevent conflicts during tab and extension changes.
  * Tutorial prerequisites can now perform asynchronous checks.
* **Bug Fixes**
  * Improved cleanup during shutdown, tab closure, project changes, layout failures, and in-progress editing operations.
  * Prevented stale searches, late updates, and invalid context access after disposal.
* **Documentation**
  * Added guidance for the updated asynchronous editor and tool context lifecycle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->