### PR TITLE
ci: reduce .NET workflow turnaround time

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -12,7 +12,12 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  build:
+  test:
+    name: test (${{ matrix.mode }})
+    strategy:
+      fail-fast: false
+      matrix:
+        mode: [coverage, validation]
     permissions:
       contents: read
 
@@ -119,7 +124,8 @@ jobs:
             done < <(git diff --name-only -z --diff-filter=ACMRTUXB "$CACHED_SHA" HEAD --)
           fi
 
-      - run: dotnet tool install -g dotnet-reportgenerator-globaltool
+      - if: matrix.mode == 'coverage'
+        run: dotnet tool install -g dotnet-reportgenerator-globaltool
 
       - name: Restore dependencies
         run: dotnet restore Beutl.slnx
@@ -145,6 +151,7 @@ jobs:
           key: dotnet-obj-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.dotnet-sdk.outputs.version }}-${{ hashFiles('global.json') }}-${{ github.sha }}
 
       - name: Test
+        if: matrix.mode == 'coverage'
         run: dotnet test Beutl.slnx --no-build --verbosity normal -f net10.0 --collect:"XPlat Code Coverage" --settings coverlet.runsettings
         env:
           # GPU golden tests must fail loudly (not Assert.Ignore) when the bundled
@@ -154,12 +161,13 @@ jobs:
       # A validation error names API misuse the driver is not required to diagnose - a render pass instance
       # begun inside another, a handle submitted to a device that never created it - so a suite that runs
       # green while reporting one has already entered undefined behaviour. The layer stays off for the run
-      # above because it costs time on all 7,000 tests and is only meaningful for the GPU-backed ones; this
-      # step turns it on for exactly those. VulkanTestEnvironment/GpuTestEnvironment compare the validation
+      # coverage run because it adds overhead; the validation matrix job enables it for the GPU-backed
+      # projects independently of coverage. VulkanTestEnvironment/GpuTestEnvironment compare the validation
       # log around every render-thread invocation, so an error fails the test that reported it, and
       # VulkanValidationGateTests fails if the layer was requested but did not load - a gate that cannot
       # observe anything must not pass quietly.
       - name: Install Vulkan validation layers
+        if: matrix.mode == 'validation'
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends vulkan-validationlayers
@@ -174,6 +182,7 @@ jobs:
       # that never reach the render thread only cost their own runtime, and the ones that do are checked.
       # KnownVulkanSkiaLayoutInterop is the one held-back category (#2263).
       - name: GPU tests under Vulkan validation
+        if: matrix.mode == 'validation'
         run: |
           dotnet test tests/Beutl.UnitTests/Beutl.UnitTests.csproj --no-build -f net10.0 \
             --filter "TestCategory!=KnownVulkanSkiaLayoutInterop"
@@ -184,6 +193,7 @@ jobs:
           BEUTL_VULKAN_VALIDATION: "1"
 
       - name: Merge coverage reports
+        if: matrix.mode == 'coverage'
         # Every test project now collects coverage (coverlet.collector is shared via
         # tests/Directory.Build.props), so dotnet test emits one cobertura file per test
         # project. Merge them into a single report so the summary de-duplicates packages
@@ -191,10 +201,24 @@ jobs:
         run: reportgenerator -reports:"tests/**/coverage.cobertura.xml" -targetdir:coveragereport -reporttypes:"Cobertura;Html"
 
       - name: Save
+        if: matrix.mode == 'coverage'
         uses: actions/upload-artifact@v7
         with:
           name: Coverage
           path: coveragereport
+
+  # Preserve the required "build" check while running coverage and validation on
+  # separate runners. A failed or cancelled matrix leg must never pass this gate.
+  build:
+    if: always()
+    needs: test
+    permissions: {}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require every test job to succeed
+        env:
+          TEST_RESULT: ${{ needs.test.result }}
+        run: test "$TEST_RESULT" = success
 
   upload-coverage:
     needs: build

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [ main ]
 
+# A newer PR revision supersedes its previous checks. Keep main runs independent.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build:
     permissions:
@@ -22,7 +27,10 @@ jobs:
       - name: Free disk space
         run: |
           df -h /
-          sudo rm -rf /usr/local/lib/android /opt/ghc /usr/local/.ghcup /opt/hostedtoolcache/CodeQL
+          # Independent directory trees can be removed concurrently; wait for all
+          # removals before checkout so the same disk headroom is still reclaimed.
+          printf '%s\0' /usr/local/lib/android /opt/ghc /usr/local/.ghcup /opt/hostedtoolcache/CodeQL \
+            | xargs -0 -n 1 -P 4 sudo rm -rf
           sudo docker image prune --all --force || true
           df -h /
 
@@ -40,6 +48,17 @@ jobs:
       - name: Resolve .NET SDK version
         id: dotnet-sdk
         run: echo "version=$(dotnet --version)" >> "$GITHUB_OUTPUT"
+
+      # Cache packages separately from obj: source-only changes can reuse the
+      # same packages, and restore still runs to reconcile the dependency graph.
+      - name: Restore NuGet package cache
+        id: nuget-cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.nuget/packages
+          key: nuget-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.dotnet-sdk.outputs.version }}-${{ hashFiles('global.json', '**/*.csproj', '**/*.props', '**/*.targets', '**/NuGet.Config', '**/nuget.config', '**/packages.lock.json') }}
+          restore-keys: |
+            nuget-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.dotnet-sdk.outputs.version }}-
 
       - name: Restore .NET build cache
         id: build-cache
@@ -104,6 +123,15 @@ jobs:
 
       - name: Restore dependencies
         run: dotnet restore Beutl.slnx
+
+      # Save immediately after restore so a later test failure does not discard
+      # downloaded dependencies and slow down the next attempt.
+      - name: Save NuGet package cache
+        if: steps.nuget-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.nuget/packages
+          key: ${{ steps.nuget-cache.outputs.cache-primary-key }}
 
       - name: Build
         run: dotnet build Beutl.slnx --no-restore

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -12,12 +12,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  test:
-    name: test (${{ matrix.mode }})
-    strategy:
-      fail-fast: false
-      matrix:
-        mode: [coverage, validation]
+  build:
     permissions:
       contents: read
 
@@ -53,17 +48,6 @@ jobs:
       - name: Resolve .NET SDK version
         id: dotnet-sdk
         run: echo "version=$(dotnet --version)" >> "$GITHUB_OUTPUT"
-
-      # Cache packages separately from obj: source-only changes can reuse the
-      # same packages, and restore still runs to reconcile the dependency graph.
-      - name: Restore NuGet package cache
-        id: nuget-cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.nuget/packages
-          key: nuget-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.dotnet-sdk.outputs.version }}-${{ hashFiles('global.json', '**/*.csproj', '**/*.props', '**/*.targets', '**/NuGet.Config', '**/nuget.config', '**/packages.lock.json') }}
-          restore-keys: |
-            nuget-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.dotnet-sdk.outputs.version }}-
 
       - name: Restore .NET build cache
         id: build-cache
@@ -124,20 +108,10 @@ jobs:
             done < <(git diff --name-only -z --diff-filter=ACMRTUXB "$CACHED_SHA" HEAD --)
           fi
 
-      - if: matrix.mode == 'coverage'
-        run: dotnet tool install -g dotnet-reportgenerator-globaltool
+      - run: dotnet tool install -g dotnet-reportgenerator-globaltool
 
       - name: Restore dependencies
         run: dotnet restore Beutl.slnx
-
-      # Save immediately after restore so a later test failure does not discard
-      # downloaded dependencies and slow down the next attempt.
-      - name: Save NuGet package cache
-        if: steps.nuget-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.nuget/packages
-          key: ${{ steps.nuget-cache.outputs.cache-primary-key }}
 
       - name: Build
         run: dotnet build Beutl.slnx --no-restore
@@ -151,7 +125,6 @@ jobs:
           key: dotnet-obj-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.dotnet-sdk.outputs.version }}-${{ hashFiles('global.json') }}-${{ github.sha }}
 
       - name: Test
-        if: matrix.mode == 'coverage'
         run: dotnet test Beutl.slnx --no-build --verbosity normal -f net10.0 --collect:"XPlat Code Coverage" --settings coverlet.runsettings
         env:
           # GPU golden tests must fail loudly (not Assert.Ignore) when the bundled
@@ -161,13 +134,12 @@ jobs:
       # A validation error names API misuse the driver is not required to diagnose - a render pass instance
       # begun inside another, a handle submitted to a device that never created it - so a suite that runs
       # green while reporting one has already entered undefined behaviour. The layer stays off for the run
-      # coverage run because it adds overhead; the validation matrix job enables it for the GPU-backed
-      # projects independently of coverage. VulkanTestEnvironment/GpuTestEnvironment compare the validation
+      # above because it costs time on all 7,000 tests and is only meaningful for the GPU-backed ones; this
+      # step turns it on for exactly those. VulkanTestEnvironment/GpuTestEnvironment compare the validation
       # log around every render-thread invocation, so an error fails the test that reported it, and
       # VulkanValidationGateTests fails if the layer was requested but did not load - a gate that cannot
       # observe anything must not pass quietly.
       - name: Install Vulkan validation layers
-        if: matrix.mode == 'validation'
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends vulkan-validationlayers
@@ -182,7 +154,6 @@ jobs:
       # that never reach the render thread only cost their own runtime, and the ones that do are checked.
       # KnownVulkanSkiaLayoutInterop is the one held-back category (#2263).
       - name: GPU tests under Vulkan validation
-        if: matrix.mode == 'validation'
         run: |
           dotnet test tests/Beutl.UnitTests/Beutl.UnitTests.csproj --no-build -f net10.0 \
             --filter "TestCategory!=KnownVulkanSkiaLayoutInterop"
@@ -193,7 +164,6 @@ jobs:
           BEUTL_VULKAN_VALIDATION: "1"
 
       - name: Merge coverage reports
-        if: matrix.mode == 'coverage'
         # Every test project now collects coverage (coverlet.collector is shared via
         # tests/Directory.Build.props), so dotnet test emits one cobertura file per test
         # project. Merge them into a single report so the summary de-duplicates packages
@@ -201,24 +171,10 @@ jobs:
         run: reportgenerator -reports:"tests/**/coverage.cobertura.xml" -targetdir:coveragereport -reporttypes:"Cobertura;Html"
 
       - name: Save
-        if: matrix.mode == 'coverage'
         uses: actions/upload-artifact@v7
         with:
           name: Coverage
           path: coveragereport
-
-  # Preserve the required "build" check while running coverage and validation on
-  # separate runners. A failed or cancelled matrix leg must never pass this gate.
-  build:
-    if: always()
-    needs: test
-    permissions: {}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Require every test job to succeed
-        env:
-          TEST_RESULT: ${{ needs.test.result }}
-        run: test "$TEST_RESULT" = success
 
   upload-coverage:
     needs: build

--- a/tests/Beutl.UnitTests/Extensions/FFmpeg/FFmpegInstallNotifierTests.cs
+++ b/tests/Beutl.UnitTests/Extensions/FFmpeg/FFmpegInstallNotifierTests.cs
@@ -224,50 +224,28 @@ public class FFmpegInstallNotifierTests
     {
         FFmpegInstallNotifier.MarkMissing();
         long since = FFmpegInstallNotifier.MissingSinceTicks;
-        const int callers = 32;
-        using var barrier = new Barrier(callers);
-        var tasks = new Task[callers];
-
-        for (int i = 0; i < callers; i++)
-        {
-            tasks[i] = Task.Run(() =>
-            {
-                barrier.SignalAndWait();
-                FFmpegInstallNotifier.NotifyMissing();
-            });
-        }
-
-        Task.WaitAll(tasks);
-        Assert.That(FFmpegInstallNotifier.MissingSinceTicks, Is.EqualTo(since));
+        RunConcurrentIterations(32, 1,
+            beforeIteration: () => { },
+            action: FFmpegInstallNotifier.NotifyMissing,
+            afterIteration: () => Assert.That(FFmpegInstallNotifier.MissingSinceTicks, Is.EqualTo(since)));
     }
 
     [Test]
     public void RecordMissingObserved_UnderConcurrency_OnlyOneFirstObservation()
     {
-        const int iterations = 25;
-        const int threads = 64;
-
-        for (int i = 0; i < iterations; i++)
-        {
-            FFmpegInstallNotifier.MarkInstalled();
-
-            int firstObservations = 0;
-            using var barrier = new Barrier(threads);
-            var tasks = new Task[threads];
-            for (int t = 0; t < threads; t++)
+        int firstObservations = 0;
+        RunConcurrentIterations(64, 25,
+            beforeIteration: () =>
             {
-                tasks[t] = Task.Run(() =>
-                {
-                    barrier.SignalAndWait();
-                    if (!FFmpegInstallNotifier.RecordMissingObserved())
-                        Interlocked.Increment(ref firstObservations);
-                });
-            }
-
-            Task.WaitAll(tasks);
-            Assert.That(firstObservations, Is.EqualTo(1),
-                $"iteration {i}: expected exactly one first observation");
-        }
+                FFmpegInstallNotifier.MarkInstalled();
+                firstObservations = 0;
+            },
+            action: () =>
+            {
+                if (!FFmpegInstallNotifier.RecordMissingObserved())
+                    Interlocked.Increment(ref firstObservations);
+            },
+            afterIteration: () => Assert.That(firstObservations, Is.EqualTo(1)));
     }
 
     [Test]
@@ -632,29 +610,51 @@ public class FFmpegInstallNotifierTests
     [Test]
     public void TryAcquireNotifySlot_UnderConcurrency_OnlyOneWinner()
     {
-        const int iterations = 25;
-        const int threads = 64;
-
-        for (int i = 0; i < iterations; i++)
-        {
-            FFmpegInstallNotifier.MarkInstalled();
-
-            long now = 1_000_000L + i; // any non-zero value works
-            int winners = 0;
-            using var barrier = new Barrier(threads);
-            var tasks = new Task[threads];
-            for (int t = 0; t < threads; t++)
+        long now = 1_000_000L;
+        int winners = 0;
+        RunConcurrentIterations(64, 25,
+            beforeIteration: () =>
             {
-                tasks[t] = Task.Run(() =>
-                {
-                    barrier.SignalAndWait();
-                    if (FFmpegInstallNotifier.TryAcquireNotifySlot(now))
-                        Interlocked.Increment(ref winners);
-                });
-            }
+                FFmpegInstallNotifier.MarkInstalled();
+                now++;
+                winners = 0;
+            },
+            action: () =>
+            {
+                if (FFmpegInstallNotifier.TryAcquireNotifySlot(now))
+                    Interlocked.Increment(ref winners);
+            },
+            afterIteration: () => Assert.That(winners, Is.EqualTo(1)));
+    }
 
-            Task.WaitAll(tasks);
-            Assert.That(winners, Is.EqualTo(1), $"iteration {i}: expected exactly one winner");
+    private static void RunConcurrentIterations(int participants, int iterations,
+        Action beforeIteration, Action action, Action afterIteration)
+    {
+        // Dedicated workers avoid ThreadPool starvation at the barrier. Reuse them
+        // across rounds instead of creating thousands of OS threads per test.
+        using var barrier = new Barrier(participants, phase =>
+        {
+            if (phase.CurrentPhaseNumber % 2 == 0)
+                beforeIteration();
+            else
+                afterIteration();
+        });
+        var tasks = new Task[participants];
+        for (int i = 0; i < participants; i++)
+        {
+            tasks[i] = Task.Factory.StartNew(() =>
+            {
+                for (int round = 0; round < iterations; round++)
+                {
+                    if (!barrier.SignalAndWait(TimeSpan.FromSeconds(30)))
+                        throw new TimeoutException("Concurrent test workers did not reach the start barrier.");
+                    action();
+                    if (!barrier.SignalAndWait(TimeSpan.FromSeconds(30)))
+                        throw new TimeoutException("Concurrent test workers did not reach the end barrier.");
+                }
+            }, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default);
         }
+
+        Task.WaitAll(tasks);
     }
 }


### PR DESCRIPTION
## Description
Blocking Barrier participants in the FFmpeg notifier race tests exhausted the ThreadPool and spent tens of seconds waiting for worker injection. Reuse dedicated workers across synchronized rounds while preserving all contenders, iterations, and assertions. Bound barrier waits so failures do not leave a test hanging indefinitely.

The workflow cancels superseded PR checks and removes independent unused tooling directories concurrently. It retains the original single `build` job, existing obj cache, full solution build, coverage collection, Vulkan validation filters, and separate Codecov upload.

The matrix and additional NuGet cache were removed after hosted measurements showed queueing and transfer overhead. There is no additional aggregate job or matrix cache writer.

## Measurements
- Original 24-test notifier fixture: 56.792 seconds, all passed.
- Final fixture: 1.164, 3.555, 4.199, and 3.657 seconds; all 24 passed each time.
- Final fixture with coverage collection: 24/24 passed in 24.205 seconds.
- Hosted CI on c7e4ba7: the three optimized race cases took approximately 42 ms combined. Cleanup varied from 27 to 86 seconds across runners; a cleanup speedup is not established.

These fixture measurements do not claim a measured whole-workflow speedup for the final single-job configuration.

## Affected areas
- [x] Build / CI / test infrastructure only

## Breaking changes
None.

## Validation
- Local targeted build, notifier tests, format verification, and independent review passed for the retained test changes.
- Review fix e2d8df8ff changes only the workflow. actionlint, shell syntax, git diff --check, and GPL/MIT diff check passed.
- Structural comparison confirms all original build-job steps except cleanup, and the entire upload-coverage job, match base 572e130 exactly. Original check names and test scope are preserved.
- Previous-head CI c7e4ba7 passed coverage, Vulkan validation, format, build gate, and Codecov upload. Its separate Codecov project status failed at 58.17% versus 58.18% on base (-21 covered production lines in untouched files); no threshold was relaxed.
- Final-head CI is pending. All three existing inline review threads were addressed and resolved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved continuous integration run management by canceling redundant pull request runs.
  - Accelerated build-environment cleanup through parallel disk-space reclamation.

- **Tests**
  - Strengthened concurrency test coverage and consistency through reusable multi-round execution checks.
  - Added timeout protection to help identify stalled concurrent test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->