### PR TITLE
fix(core): remove stale path comparison API references

### DIFF
--- a/src/Beutl.Core/Serialization/FilePathBoundary.cs
+++ b/src/Beutl.Core/Serialization/FilePathBoundary.cs
@@ -2,7 +2,9 @@
 
 internal static class PathBoundary
 {
-    private static readonly StringComparison s_comparison = FilePathComparison.Comparison;
+    private static readonly StringComparison s_comparison = OperatingSystem.IsLinux()
+        ? StringComparison.Ordinal
+        : StringComparison.OrdinalIgnoreCase;
 
     public static StringComparison Comparison => s_comparison;
 

--- a/tests/Beutl.UnitTests/Core/FilePathBoundaryTests.cs
+++ b/tests/Beutl.UnitTests/Core/FilePathBoundaryTests.cs
@@ -16,7 +16,9 @@ public sealed class PathBoundaryTests
         Assert.That(
             PathBoundary.IsPathInsideRoot(root, differentlyCasedPath),
             Is.EqualTo(!OperatingSystem.IsLinux()));
-        Assert.That(PathBoundary.Comparison, Is.EqualTo(FilePathComparison.Comparison));
+        Assert.That(PathBoundary.Comparison, Is.EqualTo(OperatingSystem.IsLinux()
+            ? StringComparison.Ordinal
+            : StringComparison.OrdinalIgnoreCase));
         Assert.That(PathBoundary.Comparer.Equals(root, root.ToUpperInvariant()),
             Is.EqualTo(!OperatingSystem.IsLinux()));
     }


### PR DESCRIPTION
## Description

Main fails with CS0117 because PathBoundary and its test still reference `FilePathComparison.Comparison`, removed by #2316. Define the existing platform comparison directly inside PathBoundary and update the test expectation. This preserves its existing behavior without restoring the removed public API.

## Affected areas

- Beutl.Core serialization and its unit test.

## Breaking changes

None.

## Test plan

- CI failure confirmed in https://github.com/b-editor/beutl/actions/runs/34244714765/job/102123626210.
- Updated the existing platform-case-semantics NUnit test.
- `git diff --check` passed; source search found no remaining references to the removed API in src/tests.
- Local builds and tests skipped as requested; validation is delegated to CI.

## Fixed issues / References

Closes #2338.

Unblocks the shared main compilation failure reported on #2317. This PR is based directly on main.
