### PR TITLE
fix(tests): avoid shadowed census alias variable

### DIFF
--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Recording/RenderPipelineMigrationCensusTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Recording/RenderPipelineMigrationCensusTests.cs
@@ -2451,11 +2451,11 @@ public sealed class RenderPipelineMigrationCensusTests
             if (aliasQualified is not null
                 && aliasQualified.Alias.Identifier.ValueText != "global")
             {
-                string aliasName = aliasQualified.Alias.Identifier.ValueText;
-                string prefix = aliasName + ".";
+                string externAliasName = aliasQualified.Alias.Identifier.ValueText;
+                string prefix = externAliasName + ".";
                 return writtenType.StartsWith(prefix, StringComparison.Ordinal)
                        && writtenType[prefix.Length..] == qualifiedTypeName
-                       && ExternAliasTargetsEngine(aliasName, document);
+                       && ExternAliasTargetsEngine(externAliasName, document);
             }
 
             if (IsGloballyQualified(type))


### PR DESCRIPTION
## Description

Rename the extern-alias local in RenderPipelineMigrationCensusTests to avoid CS0136: `aliasName` is also declared in the enclosing scope. This unblocks main's unit-test compilation without changing behavior.

## Affected areas

- Beutl.UnitTests renderer API census.

## Breaking changes

None.

## Test plan

- CI error confirmed: https://github.com/b-editor/beutl/actions/runs/34246729512/job/102130515090.
- `git diff --check` passed. Existing test logic is unchanged.
- Local builds and tests skipped as requested; CI provides validation.

## Fixed issues / References

Closes #2340. Based directly on main.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Clarified internal naming in a rendering-related test without changing functionality or user-visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->