### PR TITLE
fix(tests): migrate context fixtures to async element addition

### DIFF
--- a/tests/Beutl.HeadlessUITests/ContextCommandDispatchTests.cs
+++ b/tests/Beutl.HeadlessUITests/ContextCommandDispatchTests.cs
@@ -132,11 +132,12 @@ public class ContextCommandDispatchTests
             HeadlessTestHelpers.Settle();
             var editor = (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
             var adder = (IElementAdder)editor.GetService(typeof(IElementAdder))!;
-            adder.AddElement(new ElementDescription(
+            await adder.AddAsync([new ElementDescription(
                 Start: TimeSpan.Zero,
                 Length: TimeSpan.FromSeconds(1),
                 Layer: 0,
-                EngineObjectFactory: () => new RectShape()));
+                Source: new ElementSource.EngineObject(() => new RectShape()))],
+                CancellationToken.None);
             HeadlessTestHelpers.Settle();
             TimelineTabViewModel timeline = editor.FindToolTab<TimelineTabViewModel>()!;
             ElementViewModel target = timeline.Elements.Single();
@@ -182,11 +183,12 @@ public class ContextCommandDispatchTests
             HeadlessTestHelpers.Settle();
             var editor = (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
             var adder = (IElementAdder)editor.GetService(typeof(IElementAdder))!;
-            adder.AddElement(new ElementDescription(
+            await adder.AddAsync([new ElementDescription(
                 Start: TimeSpan.Zero,
                 Length: TimeSpan.FromSeconds(1),
                 Layer: 0,
-                EngineObjectFactory: () => new RectShape()));
+                Source: new ElementSource.EngineObject(() => new RectShape()))],
+                CancellationToken.None);
             HeadlessTestHelpers.Settle();
             TimelineTabViewModel timeline = editor.FindToolTab<TimelineTabViewModel>()!;
             ElementViewModel target = timeline.Elements.Single();


### PR DESCRIPTION
## Description

Update both ContextCommandDispatchTests setups to await IElementAdder.AddAsync with ElementSource.EngineObject. The removed AddElement method and EngineObjectFactory parameter cause CS1061 and CS1739 on main after #2305. Test assertions are unchanged.

## Affected areas

- Beutl.HeadlessUITests context command fixtures.

## Breaking changes

None.

## Test plan

- Confirmed compiler errors in https://github.com/b-editor/beutl/actions/runs/34248831417/job/102137708831.
- Matched existing AddAsync usage in neighboring headless tests.
- git diff --check passed. Local builds/tests skipped as requested; CI provides validation.

## Fixed issues / References

Closes #2342. Independent PR directly against main.
