### PR TITLE
fix: prevent crashes from zero-length resize requests

### DIFF
--- a/src/Beutl.Editor.Components/TimelineTab/ViewModels/ElementViewModel.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/ViewModels/ElementViewModel.cs
@@ -621,7 +621,7 @@ public sealed class ElementViewModel : IDisposable, IContextCommandHandler
         int rate = Scene.FindHierarchicalParent<Project>() is { } proj ? proj.GetFrameRate() : 30;
         TimeSpan roundedStart = BorderMargin.Value.Left.PixelToTimeSpan(scale).RoundToRate(rate);
         TimeSpan roundedLength = Width.Value.PixelToTimeSpan(scale).RoundToRate(rate);
-        (TimeSpan start, TimeSpan length) = ripple
+        (TimeSpan start, TimeSpan length) = ripple || leftEdge
             ? ResolveRippleResizeBounds(leftEdge, roundedStart, roundedLength, Model.Start, Model.Range.End)
             : (roundedStart, roundedLength);
         int zindex = Timeline.ToLayerNumber(Margin.Value);

--- a/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml.cs
@@ -830,7 +830,7 @@ public sealed partial class ElementView : UserControl
                             ElementResizeContext ctx = _resizeContexts[i];
                             TimeSpan roundedStart = ctx.ViewModel.BorderMargin.Value.Left.PixelToTimeSpan(scale).RoundToRate(rate);
                             TimeSpan roundedLength = ctx.ViewModel.Width.Value.PixelToTimeSpan(scale).RoundToRate(rate);
-                            (TimeSpan newStart, TimeSpan newLength) = ripple
+                            (TimeSpan newStart, TimeSpan newLength) = ripple || leftEdge
                                 ? ElementViewModel.ResolveRippleResizeBounds(
                                     leftEdge, roundedStart, roundedLength, ctx.RecordedStartTime, ctx.RecordedEndTime)
                                 : (roundedStart, roundedLength);

--- a/src/Beutl.Editor/Services/ElementResizeService.cs
+++ b/src/Beutl.Editor/Services/ElementResizeService.cs
@@ -28,7 +28,8 @@ public sealed class ElementResizeService : IElementResizeService
         // Sub-frame original durations and pixel rounding can submit zero length from async UI handlers.
         int rate = SceneTimeRangeService.GetFrameRate(scene);
         // Invalid persisted rates use the default; sub-tick frames still require a positive duration.
-        TimeSpan minLength = TimeSpan.FromTicks(Math.Max(1, TimeSpan.TicksPerSecond / (rate > 0 ? rate : 30)));
+        if (rate <= 0) rate = 30;
+        TimeSpan minLength = TimeSpan.FromTicks((TimeSpan.TicksPerSecond + (long)rate - 1) / rate);
         requests = NormalizeRequests(requests, ripple, minLength);
 
         bool autoAdjustSceneDuration = ripple && GlobalConfiguration.Instance.EditorConfig.AutoAdjustSceneDuration;
@@ -126,8 +127,8 @@ public sealed class ElementResizeService : IElementResizeService
             {
                 // A changed start with the original end identifies a fixed-right-edge resize.
                 TimeSpan end = req.Element.Range.End;
-                if (req.NewLength >= TimeSpan.Zero && req.NewStart != req.Element.Start
-                    && req.NewStart == end - req.NewLength)
+                if (req.NewStart >= TimeSpan.Zero && req.NewStart != req.Element.Start
+                    && req.NewLength == end - req.NewStart)
                 {
                     start = end > minLength ? end - minLength : TimeSpan.Zero;
                 }

--- a/src/Beutl.Editor/Services/ElementResizeService.cs
+++ b/src/Beutl.Editor/Services/ElementResizeService.cs
@@ -25,6 +25,9 @@ public sealed class ElementResizeService : IElementResizeService
         requests = requests.Where(r => !scene.IsElementLocked(r.Element)).ToArray();
         if (requests.Count == 0) return;
 
+        // Sub-frame original durations and pixel rounding can submit zero length from async UI handlers.
+        requests = NormalizeRequests(scene, requests);
+
         bool autoAdjustSceneDuration = ripple && GlobalConfiguration.Instance.EditorConfig.AutoAdjustSceneDuration;
         var oldBounds = ripple ? new Dictionary<Element, (int ZIndex, TimeSpan Start, TimeSpan End)>(requests.Count) : null;
         var clamped = ripple ? new Dictionary<Element, (TimeSpan Start, TimeSpan Length)>(requests.Count) : null;
@@ -33,7 +36,6 @@ public sealed class ElementResizeService : IElementResizeService
             var resizedSet = new HashSet<Element>(requests.Select(r => r.Element));
             foreach (ElementResizeRequest req in requests)
             {
-                ValidateRippleRequest(req);
                 // Clamp computed against pre-mutation state so the write loop applies a floor-safe start.
                 (TimeSpan start, TimeSpan length) = ClampRippleStart(scene, req, resizedSet);
                 length = ClampRippleEnd(scene, req, start, length, resizedSet);
@@ -102,19 +104,22 @@ public sealed class ElementResizeService : IElementResizeService
         scene.Duration = sceneEnd - scene.Start;
     }
 
-    private static void ValidateRippleRequest(ElementResizeRequest req)
+    private static ElementResizeRequest[] NormalizeRequests(Scene scene, IReadOnlyList<ElementResizeRequest> requests)
     {
-        ArgumentNullException.ThrowIfNull(req.Element);
-
-        if (req.NewStart < TimeSpan.Zero)
+        int rate = SceneTimeRangeService.GetFrameRate(scene);
+        // Invalid persisted rates use the default; sub-tick frames still require a positive duration.
+        TimeSpan minLength = TimeSpan.FromTicks(Math.Max(1, TimeSpan.TicksPerSecond / (rate > 0 ? rate : 30)));
+        var normalized = new ElementResizeRequest[requests.Count];
+        for (int i = 0; i < requests.Count; i++)
         {
-            throw new ArgumentOutOfRangeException(nameof(ElementResizeRequest.NewStart));
+            ElementResizeRequest req = requests[i];
+            ArgumentNullException.ThrowIfNull(req.Element);
+            TimeSpan start = req.NewStart < TimeSpan.Zero ? TimeSpan.Zero : req.NewStart;
+            TimeSpan length = req.NewLength < minLength ? minLength : req.NewLength;
+            normalized[i] = new ElementResizeRequest(req.Element, start, length, req.ZIndex);
         }
 
-        if (req.NewLength <= TimeSpan.Zero)
-        {
-            throw new ArgumentOutOfRangeException(nameof(ElementResizeRequest.NewLength));
-        }
+        return normalized;
     }
 
     // Limits a same-layer left-edge grow so the rigid ripple shift cannot push any upstream element

--- a/src/Beutl.Editor/Services/ElementResizeService.cs
+++ b/src/Beutl.Editor/Services/ElementResizeService.cs
@@ -26,7 +26,7 @@ public sealed class ElementResizeService : IElementResizeService
         if (requests.Count == 0) return;
 
         // Sub-frame original durations and pixel rounding can submit zero length from async UI handlers.
-        requests = NormalizeRequests(scene, requests);
+        requests = NormalizeRequests(scene, requests, ripple);
 
         bool autoAdjustSceneDuration = ripple && GlobalConfiguration.Instance.EditorConfig.AutoAdjustSceneDuration;
         var oldBounds = ripple ? new Dictionary<Element, (int ZIndex, TimeSpan Start, TimeSpan End)>(requests.Count) : null;
@@ -104,7 +104,7 @@ public sealed class ElementResizeService : IElementResizeService
         scene.Duration = sceneEnd - scene.Start;
     }
 
-    private static ElementResizeRequest[] NormalizeRequests(Scene scene, IReadOnlyList<ElementResizeRequest> requests)
+    private static ElementResizeRequest[] NormalizeRequests(Scene scene, IReadOnlyList<ElementResizeRequest> requests, bool ripple)
     {
         int rate = SceneTimeRangeService.GetFrameRate(scene);
         // Invalid persisted rates use the default; sub-tick frames still require a positive duration.
@@ -115,7 +115,14 @@ public sealed class ElementResizeService : IElementResizeService
             ElementResizeRequest req = requests[i];
             ArgumentNullException.ThrowIfNull(req.Element);
             TimeSpan start = req.NewStart < TimeSpan.Zero ? TimeSpan.Zero : req.NewStart;
-            TimeSpan length = req.NewLength < minLength ? minLength : req.NewLength;
+            TimeSpan length = req.NewLength;
+            if (ripple && req.NewStart < TimeSpan.Zero && length > TimeSpan.Zero)
+            {
+                // Preserve the requested end so clamping a left-edge drag does not ripple followers.
+                length += req.NewStart;
+            }
+
+            if (length < minLength) length = minLength;
             normalized[i] = new ElementResizeRequest(req.Element, start, length, req.ZIndex);
         }
 

--- a/src/Beutl.Editor/Services/ElementResizeService.cs
+++ b/src/Beutl.Editor/Services/ElementResizeService.cs
@@ -26,7 +26,10 @@ public sealed class ElementResizeService : IElementResizeService
         if (requests.Count == 0) return;
 
         // Sub-frame original durations and pixel rounding can submit zero length from async UI handlers.
-        requests = NormalizeRequests(scene, requests, ripple);
+        int rate = SceneTimeRangeService.GetFrameRate(scene);
+        // Invalid persisted rates use the default; sub-tick frames still require a positive duration.
+        TimeSpan minLength = TimeSpan.FromTicks(Math.Max(1, TimeSpan.TicksPerSecond / (rate > 0 ? rate : 30)));
+        requests = NormalizeRequests(requests, ripple, minLength);
 
         bool autoAdjustSceneDuration = ripple && GlobalConfiguration.Instance.EditorConfig.AutoAdjustSceneDuration;
         var oldBounds = ripple ? new Dictionary<Element, (int ZIndex, TimeSpan Start, TimeSpan End)>(requests.Count) : null;
@@ -37,7 +40,7 @@ public sealed class ElementResizeService : IElementResizeService
             foreach (ElementResizeRequest req in requests)
             {
                 // Clamp computed against pre-mutation state so the write loop applies a floor-safe start.
-                (TimeSpan start, TimeSpan length) = ClampRippleStart(scene, req, resizedSet);
+                (TimeSpan start, TimeSpan length) = ClampRippleStart(scene, req, resizedSet, minLength);
                 length = ClampRippleEnd(scene, req, start, length, resizedSet);
                 clamped![req.Element] = (start, length);
                 oldBounds![req.Element] = (req.Element.ZIndex, req.Element.Start, req.Element.Range.End);
@@ -104,11 +107,8 @@ public sealed class ElementResizeService : IElementResizeService
         scene.Duration = sceneEnd - scene.Start;
     }
 
-    private static ElementResizeRequest[] NormalizeRequests(Scene scene, IReadOnlyList<ElementResizeRequest> requests, bool ripple)
+    private static ElementResizeRequest[] NormalizeRequests(IReadOnlyList<ElementResizeRequest> requests, bool ripple, TimeSpan minLength)
     {
-        int rate = SceneTimeRangeService.GetFrameRate(scene);
-        // Invalid persisted rates use the default; sub-tick frames still require a positive duration.
-        TimeSpan minLength = TimeSpan.FromTicks(Math.Max(1, TimeSpan.TicksPerSecond / (rate > 0 ? rate : 30)));
         var normalized = new ElementResizeRequest[requests.Count];
         for (int i = 0; i < requests.Count; i++)
         {
@@ -122,7 +122,18 @@ public sealed class ElementResizeService : IElementResizeService
                 length += req.NewStart;
             }
 
-            if (length < minLength) length = minLength;
+            if (length < minLength)
+            {
+                // A changed start with the original end identifies a fixed-right-edge resize.
+                TimeSpan end = req.Element.Range.End;
+                if (req.NewLength >= TimeSpan.Zero && req.NewStart != req.Element.Start
+                    && req.NewStart == end - req.NewLength)
+                {
+                    start = end > minLength ? end - minLength : TimeSpan.Zero;
+                }
+
+                length = minLength;
+            }
             normalized[i] = new ElementResizeRequest(req.Element, start, length, req.ZIndex);
         }
 
@@ -134,7 +145,7 @@ public sealed class ElementResizeService : IElementResizeService
     // callers run on an async-void pointer path, and frame rounding at submission can dip below the
     // preview floor.
     private static (TimeSpan Start, TimeSpan Length) ClampRippleStart(
-        Scene scene, ElementResizeRequest req, IReadOnlyCollection<Element> resized)
+        Scene scene, ElementResizeRequest req, IReadOnlyCollection<Element> resized, TimeSpan minLength)
     {
         if (req.ZIndex != req.Element.ZIndex) return (req.NewStart, req.NewLength);
 
@@ -175,14 +186,8 @@ public sealed class ElementResizeService : IElementResizeService
 
         TimeSpan clampedStart = req.Element.Start - maxGrow;
         TimeSpan clampedLength = req.NewStart + req.NewLength - clampedStart;
-        if (clampedLength <= TimeSpan.Zero)
-        {
-            // Requested end sits before the clamp point: keeping upstream in bounds and the end while
-            // staying positive is impossible. A left-edge resize keeps the end, so the UI never reaches this.
-            throw new ArgumentOutOfRangeException(
-                nameof(ElementResizeRequest.NewLength),
-                "Ripple left-shift cannot preserve the requested end with a positive length.");
-        }
+        // If the requested end is too close to or before the barrier, keep a positive minimum.
+        if (clampedLength < minLength) clampedLength = minLength;
 
         return (clampedStart, clampedLength);
     }

--- a/src/Beutl.Editor/Services/SlippableMedia.cs
+++ b/src/Beutl.Editor/Services/SlippableMedia.cs
@@ -1,4 +1,5 @@
 ﻿using Beutl.Audio;
+using Beutl.Composition;
 using Beutl.Engine;
 using Beutl.Graphics;
 using Beutl.ProjectSystem;
@@ -92,11 +93,9 @@ internal static class SlippableMedia
 
     private static Target CreateVideoTarget(SourceVideo video)
     {
-        // SourceVideo.TryGetOriginalDuration returns the duration remaining from the current
-        // offset, so the absolute source length is current + remaining.
-        TimeSpan? total = video.TryGetOriginalDuration(out TimeSpan remaining)
-            ? video.OffsetPosition.CurrentValue + remaining
-            : null;
+        // An exhausted source still has a known total even when TryGetOriginalDuration returns false.
+        using var resource = video.ToResource(CompositionContext.Default);
+        TimeSpan? total = video.CalculateOriginalTime((SourceVideo.Resource)resource);
         return new Target(video.OffsetPosition, total);
     }
 

--- a/src/Beutl.Engine/Graphics/SourceVideo.cs
+++ b/src/Beutl.Engine/Graphics/SourceVideo.cs
@@ -39,7 +39,7 @@ public partial class SourceVideo : Drawable, IOriginalDurationProvider, ISplitta
     {
         using var resource = ToResource(CompositionContext.Default);
         var ts = CalculateOriginalTime((Resource)resource);
-        if (ts.HasValue)
+        if (ts.HasValue && ts.Value - OffsetPosition.CurrentValue > TimeSpan.Zero)
         {
             timeSpan = ts.Value - OffsetPosition.CurrentValue;
             return true;

--- a/tests/Beutl.HeadlessUITests/SubFrameResizeClampTests.cs
+++ b/tests/Beutl.HeadlessUITests/SubFrameResizeClampTests.cs
@@ -30,7 +30,7 @@ public class SubFrameResizeClampTests
     // 10 ms: positive, but 0.3 frames at the 30 fps project rate, so FloorToRate(30) == 0.
     private static readonly TimeSpan SubFrameAudioDuration = TimeSpan.FromMilliseconds(10);
 
-    private static readonly TimeSpan OneFrameAt30 = TimeSpan.FromSeconds(1d / 30);
+    private static readonly TimeSpan OneFrameAt30 = TimeSpan.FromTicks(333334);
 
     [OneTimeTearDown]
     public void OneTimeTearDown()
@@ -180,6 +180,34 @@ public class SubFrameResizeClampTests
             Assert.That(element.Length, Is.EqualTo(OneFrameAt30),
                 "the zero-frame width is floored to one frame at the project rate");
         });
+    }
+
+    [AvaloniaTest]
+    [TestCase(false, 2.01)]
+    [TestCase(false, 2.02)]
+    [TestCase(true, 2.01)]
+    [TestCase(true, 2.02)]
+    public async Task SubmitLeftEdge_OffFrameEnd_PreservesEnd(bool ripple, double endSeconds)
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditorForNewScene($"left-edge-{ripple}-{endSeconds}");
+        var adder = (IElementAdder)editor.GetService(typeof(IElementAdder))!;
+        TimeSpan end = TimeSpan.FromSeconds(endSeconds);
+        ElementAddResult added = await adder.AddAsync([new ElementDescription(
+            Start: TimeSpan.Zero, Length: end, Layer: 0,
+            Source: new ElementSource.EngineObject(() => new Beutl.Graphics.Shapes.RectShape()))], CancellationToken.None);
+        Assert.That(added.IsSuccess, Is.True);
+        HeadlessTestHelpers.Settle();
+        Element element = editor.Scene.Children.Single();
+        var timeline = editor.FindToolTab<TimelineTabViewModel>()!;
+        var viewModel = timeline.GetViewModelFor(element)!;
+        viewModel.BorderMargin.Value = new Thickness(end.TimeToPixel(timeline.Options.Value.Scale), 0, 0, 0);
+        viewModel.Width.Value = 0;
+
+        await viewModel.SubmitViewModelChanges(ripple, leftEdge: true);
+
+        Assert.That(element.Range.End, Is.EqualTo(end));
+        Assert.That(element.Length, Is.GreaterThanOrEqualTo(OneFrameAt30));
     }
 
     private static Exception Unwrap(Exception ex)

--- a/tests/Beutl.HeadlessUITests/SubFrameResizeClampTests.cs
+++ b/tests/Beutl.HeadlessUITests/SubFrameResizeClampTests.cs
@@ -1,0 +1,260 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using Avalonia;
+using Avalonia.Headless.NUnit;
+using Beutl.Audio;
+using Beutl.Editor.Components.Helpers;
+using Beutl.Editor.Components.TimelineTab.ViewModels;
+using Beutl.Editor.Models;
+using Beutl.Editor.Services;
+using Beutl.Media;
+using Beutl.Media.Decoding;
+using Beutl.Media.Music;
+using Beutl.Media.Music.Samples;
+using Beutl.Media.Source;
+using Beutl.ProjectSystem;
+using Beutl.Testing.Headless;
+using Beutl.ViewModels;
+
+namespace Beutl.HeadlessUITests;
+
+// Regression for the telemetry ArgumentOutOfRangeException('length') crash: sub-frame original
+// durations and zero-pixel resizes used to reach Scene.MoveChild and escape the async-void handler.
+// The service now floors every request to one frame.
+[TestFixture]
+public class SubFrameResizeClampTests
+{
+    private static readonly object s_registerLock = new();
+    private static bool s_registered;
+    private static string? s_tempDir;
+
+    // 10 ms: positive, but 0.3 frames at the 30 fps project rate, so FloorToRate(30) == 0.
+    private static readonly TimeSpan SubFrameAudioDuration = TimeSpan.FromMilliseconds(10);
+
+    private static readonly TimeSpan OneFrameAt30 = TimeSpan.FromSeconds(1d / 30);
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        try
+        {
+            if (s_tempDir != null && Directory.Exists(s_tempDir))
+                Directory.Delete(s_tempDir, recursive: true);
+        }
+        catch (Exception)
+        {
+            // Best-effort cleanup of the temp fixture; a leftover directory must not fail the run.
+        }
+    }
+
+    private static string NewWorkspace(string name)
+    {
+        string location = Path.Combine(BeutlHomeIsolation.CurrentHome!, name);
+        Directory.CreateDirectory(location);
+        return location;
+    }
+
+    private static async Task<EditViewModel> OpenEditorForNewScene(string name)
+    {
+        Project project = (await TestShell.Project.CreateProject(
+            640, 480, 30, 44100, name, NewWorkspace(name)))!;
+        HeadlessTestHelpers.Settle();
+        Scene scene = project.Items.OfType<Scene>().First();
+
+        TestShell.Editor.ActivateTabItem(scene);
+        HeadlessTestHelpers.Settle();
+        return (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
+    }
+
+    // Primary telemetry stack (4 of 5 sessions):
+    // ElementViewModel.OnChangeToOriginalDuration -> ElementResizeService.Resize -> Scene.MoveChild.
+    [AvaloniaTest]
+    public async Task ChangeToOriginalDuration_SubFrameMedia_ClampsToOneFrameWithoutCrashing()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditorForNewScene("original-duration-subframe");
+        RegisterSubFrameDecoder();
+
+        string path = CreateSubFrameAudioFile();
+        var soundSource = new SoundSource();
+        soundSource.ReadFrom(new Uri(path));
+
+        var adder = (IElementAdder)editor.GetService(typeof(IElementAdder))!;
+        ElementAddResult added = await adder.AddAsync([new ElementDescription(
+            Start: TimeSpan.Zero,
+            Length: TimeSpan.FromSeconds(1),
+            Layer: 0,
+            Source: new ElementSource.EngineObject(() => new SourceSound
+            {
+                Source = { CurrentValue = soundSource },
+            }))], CancellationToken.None);
+        Assert.That(added.IsSuccess, Is.True);
+        HeadlessTestHelpers.Settle();
+
+        Element element = editor.Scene.Children.Single();
+        var timeline = editor.FindToolTab<TimelineTabViewModel>();
+        Assert.That(timeline, Is.Not.Null, "The editor must open with a timeline tool tab.");
+        var viewModel = timeline!.GetViewModelFor(element);
+        Assert.That(viewModel, Is.Not.Null, "The timeline must create an ElementViewModel for the clip.");
+
+        // Preconditions that used to make the crash deterministic:
+        // the original duration resolves, is positive, but floors to zero frames.
+        Assert.That(viewModel!.HasOriginalDuration(), Is.True);
+        Assert.That(element.TryGetOriginalDuration(out TimeSpan original), Is.True);
+        Assert.That(original, Is.EqualTo(SubFrameAudioDuration));
+        Assert.That(original.FloorToRate(30), Is.EqualTo(TimeSpan.Zero),
+            "The scenario requires an original duration shorter than one project frame.");
+        Assert.That(timeline.IsRippleEnabled.Value, Is.False,
+            "The telemetry crash is the non-ripple path.");
+
+        viewModel.ChangeToOriginalDuration.Execute();
+
+        Exception? surfaced = null;
+        try
+        {
+            HeadlessTestHelpers.Settle(4);
+        }
+        catch (Exception ex)
+        {
+            surfaced = Unwrap(ex);
+        }
+
+        Assert.That(surfaced, Is.Null,
+            $"The resize must be clamped at the service boundary instead of escaping to the dispatcher, but got: {surfaced}");
+        Assert.Multiple(() =>
+        {
+            Assert.That(element.Start, Is.EqualTo(TimeSpan.Zero));
+            Assert.That(element.Length, Is.EqualTo(OneFrameAt30),
+                "the sub-frame original duration is floored to one frame at the project rate");
+        });
+    }
+
+    // Second telemetry stack (preview.6, OnBorderPointerReleased -> Resize -> MoveChild): the
+    // pointer-release resize submits Width/BorderMargin pixels rounded to frames, and a clip whose
+    // visual width rounds to zero frames used to reach Scene.MoveChild with length == 0 through
+    // SubmitViewModelChanges.
+    [AvaloniaTest]
+    public async Task SubmitViewModelChanges_ZeroPixelWidth_ClampsToOneFrameWithoutCrashing()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditorForNewScene("resize-zero-width");
+
+        var adder = (IElementAdder)editor.GetService(typeof(IElementAdder))!;
+        ElementAddResult added = await adder.AddAsync([new ElementDescription(
+            Start: TimeSpan.FromSeconds(1),
+            Length: TimeSpan.FromSeconds(2),
+            Layer: 0,
+            Source: new ElementSource.EngineObject(() => new Beutl.Graphics.Shapes.RectShape()))], CancellationToken.None);
+        Assert.That(added.IsSuccess, Is.True);
+        HeadlessTestHelpers.Settle();
+
+        Element element = editor.Scene.Children.Single();
+        var timeline = editor.FindToolTab<TimelineTabViewModel>();
+        Assert.That(timeline, Is.Not.Null, "The editor must open with a timeline tool tab.");
+        var viewModel = timeline!.GetViewModelFor(element);
+        Assert.That(viewModel, Is.Not.Null, "The timeline must create an ElementViewModel for the clip.");
+        Assert.That(timeline.IsRippleEnabled.Value, Is.False,
+            "The telemetry crash is the non-ripple path.");
+
+        // The drag visual collapsed the clip to zero width; keep the left edge pinned at the
+        // element's start so the submission only degenerates the length.
+        float scale = timeline.Options.Value.Scale;
+        viewModel!.BorderMargin.Value = new Thickness(element.Start.TimeToPixel(scale), 0, 0, 0);
+        viewModel.Width.Value = 0;
+
+        Exception? surfaced = null;
+        try
+        {
+            await viewModel.SubmitViewModelChanges();
+            HeadlessTestHelpers.Settle(4);
+        }
+        catch (Exception ex)
+        {
+            surfaced = Unwrap(ex);
+        }
+
+        Assert.That(surfaced, Is.Null,
+            $"A zero-length resize submission must be floored at the service boundary, but got: {surfaced}");
+        Assert.Multiple(() =>
+        {
+            Assert.That(element.Start, Is.EqualTo(TimeSpan.FromSeconds(1)));
+            Assert.That(element.Length, Is.EqualTo(OneFrameAt30),
+                "the zero-frame width is floored to one frame at the project rate");
+        });
+    }
+
+    private static Exception Unwrap(Exception ex)
+    {
+        while (ex is System.Reflection.TargetInvocationException or AggregateException
+               && ex.InnerException is { } inner)
+        {
+            ex = inner;
+        }
+
+        return ex;
+    }
+
+    private static void RegisterSubFrameDecoder()
+    {
+        lock (s_registerLock)
+        {
+            if (s_registered) return;
+            DecoderRegistry.Register(new SubFrameDecoderInfo());
+            s_registered = true;
+        }
+    }
+
+    private static string CreateSubFrameAudioFile()
+    {
+        s_tempDir ??= Path.Combine(Path.GetTempPath(), $"beutl-subframe-tests-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(s_tempDir);
+        string path = Path.Combine(s_tempDir, $"subframe-{Guid.NewGuid():N}.subaudio");
+        File.WriteAllBytes(path, []);
+        return path;
+    }
+
+    private sealed class SubFrameDecoderInfo : IDecoderInfo
+    {
+        public string Name => "SubFrame Test Decoder";
+
+        public MediaReader? Open(string file, MediaOptions options)
+        {
+            return Path.GetExtension(file) == ".subaudio" ? new SubFrameReader() : null;
+        }
+
+        public IEnumerable<string> VideoExtensions() => [];
+
+        public IEnumerable<string> AudioExtensions() => [".subaudio"];
+    }
+
+    private sealed class SubFrameReader : MediaReader
+    {
+        private readonly AudioStreamInfo _audioInfo = new(
+            "test",
+            new Rational(SubFrameAudioDuration.Milliseconds, 1000),
+            44100,
+            2);
+
+        public override VideoStreamInfo VideoInfo => throw new Exception("The stream does not exist.");
+
+        public override AudioStreamInfo AudioInfo => _audioInfo;
+
+        public override bool HasVideo => false;
+
+        public override bool HasAudio => true;
+
+        public override bool ReadVideo(int frame, [NotNullWhen(true)] out Ref<Bitmap>? image)
+        {
+            image = null;
+            return false;
+        }
+
+        public override bool ReadAudio(int start, int length, [NotNullWhen(true)] out Ref<IPcm>? sound)
+        {
+            // Report end-of-stream with an empty buffer instead of a decode failure (false signals
+            // an unrecoverable error): HasAudio stays truthful while sample consumers see silence,
+            // matching SampleProviderReader's empty-result pattern.
+            sound = Ref<IPcm>.Create(new Pcm<Stereo32BitFloat>(_audioInfo.SampleRate, 0));
+            return true;
+        }
+    }
+}

--- a/tests/Beutl.UnitTests/Editor/Services/ElementResizeServiceTests.cs
+++ b/tests/Beutl.UnitTests/Editor/Services/ElementResizeServiceTests.cs
@@ -243,6 +243,47 @@ public class ElementResizeServiceTests
         Assert.That(follower.Start, Is.EqualTo(fixedEnd));
     }
 
+    [TestCase(false, 0)]
+    [TestCase(false, 10)]
+    [TestCase(true, 0)]
+    [TestCase(true, 10)]
+    public void Resize_LeftEdgeBelowMinimum_PreservesRightEdge(bool ripple, int milliseconds)
+    {
+        Element element = AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));
+        Element follower = AddElement(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2));
+        TimeSpan end = element.Range.End;
+        TimeSpan length = TimeSpan.FromMilliseconds(milliseconds);
+
+        _service.Resize(_scene, [new ElementResizeRequest(element, end - length, length, 0)], ripple);
+
+        Assert.That(element.Length, Is.EqualTo(TimeSpan.FromSeconds(1d / 30)));
+        Assert.That(element.Range.End, Is.EqualTo(end));
+        Assert.That(follower.Start, Is.EqualTo(end));
+        _history.Undo();
+        Assert.That(element.Start, Is.EqualTo(TimeSpan.FromSeconds(1)));
+        Assert.That(element.Length, Is.EqualTo(TimeSpan.FromSeconds(2)));
+    }
+
+    [TestCase(-2, 1)]
+    [TestCase(0, 0.51)]
+    public void Resize_RippleLockedBarrier_RetainsMinimumLength(double start, double length)
+    {
+        Element barrier = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(0.5));
+        barrier.IsLocked = true;
+        Element element = AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));
+
+        _service.Resize(_scene,
+            [new ElementResizeRequest(element, TimeSpan.FromSeconds(start), TimeSpan.FromSeconds(length), 0)], ripple: true);
+
+        Assert.That(element.Start, Is.EqualTo(barrier.Range.End));
+        Assert.That(element.Length, Is.EqualTo(TimeSpan.FromSeconds(1d / 30)));
+        Assert.That(barrier.Start, Is.EqualTo(TimeSpan.Zero));
+        Assert.That(barrier.Length, Is.EqualTo(TimeSpan.FromSeconds(0.5)));
+        _history.Undo();
+        Assert.That(element.Start, Is.EqualTo(TimeSpan.FromSeconds(1)));
+        Assert.That(element.Length, Is.EqualTo(TimeSpan.FromSeconds(2)));
+    }
+
     [TestCase(-2, 1)]
     [TestCase(-2, -1)]
     public void Resize_RippleRequestedEndBeforeOrigin_UsesMinimumLength(int start, int length)

--- a/tests/Beutl.UnitTests/Editor/Services/ElementResizeServiceTests.cs
+++ b/tests/Beutl.UnitTests/Editor/Services/ElementResizeServiceTests.cs
@@ -135,7 +135,7 @@ public class ElementResizeServiceTests
         Assert.Multiple(() =>
         {
             Assert.That(element.Start, Is.EqualTo(TimeSpan.FromSeconds(1)));
-            Assert.That(element.Length, Is.EqualTo(TimeSpan.FromSeconds(1d / 30)),
+            Assert.That(element.Length, Is.EqualTo(TimeSpan.FromTicks(333334)),
                 "the service floors the length to one frame at the scene rate");
             Assert.That(_history.UndoCount, Is.EqualTo(before + 1));
         });
@@ -165,10 +165,24 @@ public class ElementResizeServiceTests
                 [new ElementResizeRequest(null!, TimeSpan.Zero, TimeSpan.FromSeconds(1), 0)]));
     }
 
-    [TestCase("0", 333333)]
-    [TestCase("-1", 333333)]
-    [TestCase("invalid", 333333)]
-    [TestCase("60", 166666)]
+    [TestCase(24)]
+    [TestCase(30)]
+    [TestCase(60)]
+    public void Resize_MinimumLength_DoesNotFloorToZeroFrames(int rate)
+    {
+        var project = new Project();
+        project.Variables[ProjectVariableKeys.FrameRate] = rate.ToString();
+        project.Items.Add(_scene);
+        Element element = AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));
+        _service.Resize(_scene, [new ElementResizeRequest(element, element.Start, TimeSpan.Zero, 0)]);
+
+        Assert.That(element.Length.FloorToRate(rate), Is.GreaterThan(TimeSpan.Zero));
+    }
+
+    [TestCase("0", 333334)]
+    [TestCase("-1", 333334)]
+    [TestCase("invalid", 333334)]
+    [TestCase("60", 166667)]
     [TestCase("2147483647", 1)]
     public void Resize_FrameRate_AlwaysProducesPositiveLength(string rate, long expectedTicks)
     {
@@ -195,7 +209,7 @@ public class ElementResizeServiceTests
             [new ElementResizeRequest(element, element.Start, TimeSpan.FromMilliseconds(milliseconds), 0)], ripple);
 
         Assert.That(element.Start, Is.EqualTo(TimeSpan.FromSeconds(1)), "Scene.Start is not the timeline origin.");
-        Assert.That(element.Length, Is.EqualTo(TimeSpan.FromSeconds(1d / 30)));
+        Assert.That(element.Length, Is.EqualTo(TimeSpan.FromTicks(333334)));
         _history.Undo();
         Assert.That(element.Length, Is.EqualTo(TimeSpan.FromSeconds(2)));
     }
@@ -256,7 +270,7 @@ public class ElementResizeServiceTests
 
         _service.Resize(_scene, [new ElementResizeRequest(element, end - length, length, 0)], ripple);
 
-        Assert.That(element.Length, Is.EqualTo(TimeSpan.FromSeconds(1d / 30)));
+        Assert.That(element.Length, Is.EqualTo(TimeSpan.FromTicks(333334)));
         Assert.That(element.Range.End, Is.EqualTo(end));
         Assert.That(follower.Start, Is.EqualTo(end));
         _history.Undo();
@@ -276,7 +290,7 @@ public class ElementResizeServiceTests
             [new ElementResizeRequest(element, TimeSpan.FromSeconds(start), TimeSpan.FromSeconds(length), 0)], ripple: true);
 
         Assert.That(element.Start, Is.EqualTo(barrier.Range.End));
-        Assert.That(element.Length, Is.EqualTo(TimeSpan.FromSeconds(1d / 30)));
+        Assert.That(element.Length, Is.EqualTo(TimeSpan.FromTicks(333334)));
         Assert.That(barrier.Start, Is.EqualTo(TimeSpan.Zero));
         Assert.That(barrier.Length, Is.EqualTo(TimeSpan.FromSeconds(0.5)));
         _history.Undo();
@@ -293,7 +307,7 @@ public class ElementResizeServiceTests
             [new ElementResizeRequest(element, TimeSpan.FromSeconds(start), TimeSpan.FromSeconds(length), 0)], ripple: true);
 
         Assert.That(element.Start, Is.EqualTo(TimeSpan.Zero));
-        Assert.That(element.Length, Is.EqualTo(TimeSpan.FromSeconds(1d / 30)));
+        Assert.That(element.Length, Is.EqualTo(TimeSpan.FromTicks(333334)));
     }
 
     [Test]
@@ -310,7 +324,7 @@ public class ElementResizeServiceTests
         Assert.Multiple(() =>
         {
             Assert.That(element.Start, Is.EqualTo(TimeSpan.FromSeconds(1)));
-            Assert.That(element.Length, Is.EqualTo(TimeSpan.FromSeconds(1d / 30)),
+            Assert.That(element.Length, Is.EqualTo(TimeSpan.FromTicks(333334)),
                 "the service floors the length to one frame at the scene rate");
             Assert.That(_history.UndoCount, Is.EqualTo(before + 1));
         });
@@ -336,7 +350,7 @@ public class ElementResizeServiceTests
             Assert.That(valid.Start, Is.EqualTo(TimeSpan.FromSeconds(1)));
             Assert.That(valid.Length, Is.EqualTo(TimeSpan.FromSeconds(5)));
             Assert.That(invalid.Start, Is.EqualTo(TimeSpan.FromSeconds(4)));
-            Assert.That(invalid.Length, Is.EqualTo(TimeSpan.FromSeconds(1d / 30)),
+            Assert.That(invalid.Length, Is.EqualTo(TimeSpan.FromTicks(333334)),
                 "the zero length is floored to one frame instead of rejecting the batch");
             Assert.That(_history.UndoCount, Is.EqualTo(before + 1));
         });

--- a/tests/Beutl.UnitTests/Editor/Services/ElementResizeServiceTests.cs
+++ b/tests/Beutl.UnitTests/Editor/Services/ElementResizeServiceTests.cs
@@ -120,31 +120,113 @@ public class ElementResizeServiceTests
     }
 
     [Test]
-    public void Resize_RippleOn_NegativeStart_ThrowsBeforeMutation()
+    public void Resize_NonRipple_ZeroLength_ClampsToOneFrameInsteadOfThrowing()
+    {
+        // Telemetry regression: "change to original duration" floored a sub-frame original
+        // duration to zero and the non-ripple branch handed it to Scene.MoveChild, whose
+        // ArgumentOutOfRangeException escaped the async-void UI handler and crashed the app.
+        Element element = AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));
+        int before = _history.UndoCount;
+
+        Assert.DoesNotThrow(() =>
+            _service.Resize(_scene,
+                [new ElementResizeRequest(element, TimeSpan.FromSeconds(1), TimeSpan.Zero, 0)]));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(element.Start, Is.EqualTo(TimeSpan.FromSeconds(1)));
+            Assert.That(element.Length, Is.EqualTo(TimeSpan.FromSeconds(1d / 30)),
+                "the service floors the length to one frame at the scene rate");
+            Assert.That(_history.UndoCount, Is.EqualTo(before + 1));
+        });
+    }
+
+    [Test]
+    public void Resize_NonRipple_NegativeStart_ClampsToZeroInsteadOfThrowing()
+    {
+        Element element = AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));
+
+        Assert.DoesNotThrow(() =>
+            _service.Resize(_scene,
+                [new ElementResizeRequest(element, TimeSpan.FromSeconds(-2), TimeSpan.FromSeconds(1), 0)]));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(element.Start, Is.EqualTo(TimeSpan.Zero));
+            Assert.That(element.Length, Is.EqualTo(TimeSpan.FromSeconds(1)));
+        });
+    }
+
+    [Test]
+    public void Resize_NullElementInRequest_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            _service.Resize(_scene,
+                [new ElementResizeRequest(null!, TimeSpan.Zero, TimeSpan.FromSeconds(1), 0)]));
+    }
+
+    [TestCase("0", 333333)]
+    [TestCase("-1", 333333)]
+    [TestCase("invalid", 333333)]
+    [TestCase("60", 166666)]
+    [TestCase("2147483647", 1)]
+    public void Resize_FrameRate_AlwaysProducesPositiveLength(string rate, long expectedTicks)
+    {
+        var project = new Project();
+        project.Variables[ProjectVariableKeys.FrameRate] = rate;
+        project.Items.Add(_scene);
+        Element element = AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));
+
+        _service.Resize(_scene, [new ElementResizeRequest(element, element.Start, TimeSpan.Zero, 0)]);
+
+        Assert.That(element.Length.Ticks, Is.EqualTo(expectedTicks));
+    }
+
+    [TestCase(false, -1)]
+    [TestCase(false, 10)]
+    [TestCase(true, -1)]
+    [TestCase(true, 10)]
+    public void Resize_ShortLength_ClampsAndCanBeUndone(bool ripple, int milliseconds)
+    {
+        _scene.Start = TimeSpan.FromSeconds(5);
+        Element element = AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));
+
+        _service.Resize(_scene,
+            [new ElementResizeRequest(element, element.Start, TimeSpan.FromMilliseconds(milliseconds), 0)], ripple);
+
+        Assert.That(element.Start, Is.EqualTo(TimeSpan.FromSeconds(1)), "Scene.Start is not the timeline origin.");
+        Assert.That(element.Length, Is.EqualTo(TimeSpan.FromSeconds(1d / 30)));
+        _history.Undo();
+        Assert.That(element.Length, Is.EqualTo(TimeSpan.FromSeconds(2)));
+    }
+
+    [Test]
+    public void Resize_RippleOn_NegativeStart_ClampsToZeroAndApplies()
     {
         Element element = AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));
         int before = _history.UndoCount;
 
-        Assert.Throws<ArgumentOutOfRangeException>(() =>
+        Assert.DoesNotThrow(() =>
             _service.Resize(_scene,
                 [new ElementResizeRequest(element, TimeSpan.FromSeconds(-1), TimeSpan.FromSeconds(2), 0)],
                 ripple: true));
 
         Assert.Multiple(() =>
         {
-            Assert.That(element.Start, Is.EqualTo(TimeSpan.FromSeconds(1)));
+            Assert.That(element.Start, Is.EqualTo(TimeSpan.Zero),
+                "the service floors the start to the timeline start");
             Assert.That(element.Length, Is.EqualTo(TimeSpan.FromSeconds(2)));
-            Assert.That(_history.UndoCount, Is.EqualTo(before));
+            Assert.That(_history.UndoCount, Is.EqualTo(before + 1));
         });
     }
 
     [Test]
-    public void Resize_RippleOn_ZeroLength_ThrowsBeforeMutation()
+    public void Resize_RippleOn_ZeroLength_ClampsToOneFrameAndApplies()
     {
         Element element = AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));
         int before = _history.UndoCount;
 
-        Assert.Throws<ArgumentOutOfRangeException>(() =>
+        Assert.DoesNotThrow(() =>
             _service.Resize(_scene,
                 [new ElementResizeRequest(element, TimeSpan.FromSeconds(1), TimeSpan.Zero, 0)],
                 ripple: true));
@@ -152,19 +234,20 @@ public class ElementResizeServiceTests
         Assert.Multiple(() =>
         {
             Assert.That(element.Start, Is.EqualTo(TimeSpan.FromSeconds(1)));
-            Assert.That(element.Length, Is.EqualTo(TimeSpan.FromSeconds(2)));
-            Assert.That(_history.UndoCount, Is.EqualTo(before));
+            Assert.That(element.Length, Is.EqualTo(TimeSpan.FromSeconds(1d / 30)),
+                "the service floors the length to one frame at the scene rate");
+            Assert.That(_history.UndoCount, Is.EqualTo(before + 1));
         });
     }
 
     [Test]
-    public void Resize_RippleOn_InvalidSecondRequest_ThrowsBeforeAnyMutation()
+    public void Resize_RippleOn_ZeroLengthSecondRequest_ClampsAndAppliesBoth()
     {
         Element valid = AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2), zIndex: 0);
         Element invalid = AddElement(TimeSpan.FromSeconds(4), TimeSpan.FromSeconds(2), zIndex: 1);
         int before = _history.UndoCount;
 
-        Assert.Throws<ArgumentOutOfRangeException>(() =>
+        Assert.DoesNotThrow(() =>
             _service.Resize(_scene,
             [
                 new ElementResizeRequest(valid, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(5), 0),
@@ -175,10 +258,11 @@ public class ElementResizeServiceTests
         Assert.Multiple(() =>
         {
             Assert.That(valid.Start, Is.EqualTo(TimeSpan.FromSeconds(1)));
-            Assert.That(valid.Length, Is.EqualTo(TimeSpan.FromSeconds(2)));
+            Assert.That(valid.Length, Is.EqualTo(TimeSpan.FromSeconds(5)));
             Assert.That(invalid.Start, Is.EqualTo(TimeSpan.FromSeconds(4)));
-            Assert.That(invalid.Length, Is.EqualTo(TimeSpan.FromSeconds(2)));
-            Assert.That(_history.UndoCount, Is.EqualTo(before));
+            Assert.That(invalid.Length, Is.EqualTo(TimeSpan.FromSeconds(1d / 30)),
+                "the zero length is floored to one frame instead of rejecting the batch");
+            Assert.That(_history.UndoCount, Is.EqualTo(before + 1));
         });
     }
 

--- a/tests/Beutl.UnitTests/Editor/Services/ElementResizeServiceTests.cs
+++ b/tests/Beutl.UnitTests/Editor/Services/ElementResizeServiceTests.cs
@@ -208,7 +208,7 @@ public class ElementResizeServiceTests
 
         Assert.DoesNotThrow(() =>
             _service.Resize(_scene,
-                [new ElementResizeRequest(element, TimeSpan.FromSeconds(-1), TimeSpan.FromSeconds(2), 0)],
+                [new ElementResizeRequest(element, TimeSpan.FromSeconds(-1), TimeSpan.FromSeconds(3), 0)],
                 ripple: true));
 
         Assert.Multiple(() =>
@@ -218,6 +218,41 @@ public class ElementResizeServiceTests
             Assert.That(element.Length, Is.EqualTo(TimeSpan.FromSeconds(2)));
             Assert.That(_history.UndoCount, Is.EqualTo(before + 1));
         });
+    }
+
+    [Test]
+    public void Resize_RippleLeftEdgeCrossesOrigin_PreservesRightEdgeAndFollowers()
+    {
+        Element element = AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));
+        Element follower = AddElement(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(2));
+        TimeSpan requestedStart = TimeSpan.FromSeconds(-1);
+        TimeSpan fixedEnd = element.Range.End;
+
+        _service.Resize(_scene,
+            [new ElementResizeRequest(element, requestedStart, fixedEnd - requestedStart, 0)], ripple: true);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(element.Start, Is.EqualTo(TimeSpan.Zero));
+            Assert.That(element.Range.End, Is.EqualTo(fixedEnd));
+            Assert.That(follower.Start, Is.EqualTo(fixedEnd));
+        });
+        _history.Undo();
+        Assert.That(element.Start, Is.EqualTo(TimeSpan.FromSeconds(1)));
+        Assert.That(element.Length, Is.EqualTo(TimeSpan.FromSeconds(2)));
+        Assert.That(follower.Start, Is.EqualTo(fixedEnd));
+    }
+
+    [TestCase(-2, 1)]
+    [TestCase(-2, -1)]
+    public void Resize_RippleRequestedEndBeforeOrigin_UsesMinimumLength(int start, int length)
+    {
+        Element element = AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));
+        _service.Resize(_scene,
+            [new ElementResizeRequest(element, TimeSpan.FromSeconds(start), TimeSpan.FromSeconds(length), 0)], ripple: true);
+
+        Assert.That(element.Start, Is.EqualTo(TimeSpan.Zero));
+        Assert.That(element.Length, Is.EqualTo(TimeSpan.FromSeconds(1d / 30)));
     }
 
     [Test]

--- a/tests/Beutl.UnitTests/Editor/Services/ElementSlipServiceTests.cs
+++ b/tests/Beutl.UnitTests/Editor/Services/ElementSlipServiceTests.cs
@@ -187,6 +187,35 @@ public class ElementSlipServiceTests
         });
     }
 
+    [TestCase(2, 1, false)]
+    [TestCase(3, 1, false)]
+    [TestCase(2, -1, true)]
+    [TestCase(3, -1, true)]
+    public void Slip_ExhaustedVideo_PreservesKnownSourceBounds(int offset, int delta, bool expectedApplied)
+    {
+        Element element = AddElement(TimeSpan.Zero, TimeSpan.FromSeconds(1));
+        var source = new VideoSource();
+        source.ReadFrom(new Uri(TestMediaHelper.CreateTestVideoFile(100, 100, new Rational(30, 1), 60)));
+        var video = new SourceVideo
+        {
+            Source = { CurrentValue = source },
+            OffsetPosition = { CurrentValue = TimeSpan.FromSeconds(offset) }
+        };
+        element.Objects.Add(video);
+        int before = _history.UndoCount;
+        Assert.That(video.TryGetOriginalDuration(out _), Is.False);
+
+        bool applied = _service.Slip(_scene, [element], TimeSpan.FromSeconds(delta));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(applied, Is.EqualTo(expectedApplied));
+            Assert.That(video.OffsetPosition.CurrentValue,
+                Is.EqualTo(TimeSpan.FromSeconds(expectedApplied ? offset + delta : offset)));
+            Assert.That(_history.UndoCount, Is.EqualTo(before + (expectedApplied ? 1 : 0)));
+        });
+    }
+
     [Test]
     public void Slip_SourceSound_ShiftsOffsetPositionAndCommits()
     {

--- a/tests/Beutl.UnitTests/Editor/Services/RippleEditTests.cs
+++ b/tests/Beutl.UnitTests/Editor/Services/RippleEditTests.cs
@@ -301,23 +301,31 @@ public class RippleEditTests
     }
 
     [Test]
-    public void Resize_RippleOn_ThrowsWhenClampWouldMakeLengthNonPositive()
+    public void Resize_RippleOn_FloorsLengthWhenRequestedEndPrecedesClampedStart()
     {
         var resize = new ElementResizeService(_history);
         Element upstream = AddElement(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(3), zIndex: 0);
         Element target = AddElement(TimeSpan.FromSeconds(4), TimeSpan.FromSeconds(4), zIndex: 0);
 
-        // Incoherent request (end 0.5s sits before the clamped start 3s): keeping upstream >= 0
-        // and the requested end cannot yield a positive length. Not reachable from the UI (end fixed).
-        Assert.Throws<ArgumentOutOfRangeException>(() => resize.Resize(_scene,
+        int before = _history.UndoCount;
+        // The requested end (0.5s) precedes the clamped start (3s), so preserve the upstream
+        // boundary and use the positive minimum instead of preserving that end or throwing.
+        resize.Resize(_scene,
             [new ElementResizeRequest(target, TimeSpan.Zero, TimeSpan.FromSeconds(0.5), 0)],
-            ripple: true));
+            ripple: true);
 
         Assert.Multiple(() =>
         {
-            Assert.That(target.Start, Is.EqualTo(TimeSpan.FromSeconds(4)), "rejected before any mutation");
-            Assert.That(upstream.Start, Is.EqualTo(TimeSpan.FromSeconds(1)), "upstream untouched");
+            Assert.That(target.Start, Is.EqualTo(TimeSpan.FromSeconds(3)));
+            Assert.That(target.Length, Is.EqualTo(TimeSpan.FromSeconds(1d / 30)));
+            Assert.That(upstream.Start, Is.EqualTo(TimeSpan.Zero));
+            Assert.That(upstream.Length, Is.EqualTo(TimeSpan.FromSeconds(3)));
+            Assert.That(_history.UndoCount, Is.EqualTo(before + 1));
         });
+        _history.Undo();
+        Assert.That(target.Start, Is.EqualTo(TimeSpan.FromSeconds(4)));
+        Assert.That(target.Length, Is.EqualTo(TimeSpan.FromSeconds(4)));
+        Assert.That(upstream.Start, Is.EqualTo(TimeSpan.FromSeconds(1)));
     }
 
     [Test]

--- a/tests/Beutl.UnitTests/Editor/Services/RippleEditTests.cs
+++ b/tests/Beutl.UnitTests/Editor/Services/RippleEditTests.cs
@@ -317,7 +317,7 @@ public class RippleEditTests
         Assert.Multiple(() =>
         {
             Assert.That(target.Start, Is.EqualTo(TimeSpan.FromSeconds(3)));
-            Assert.That(target.Length, Is.EqualTo(TimeSpan.FromSeconds(1d / 30)));
+            Assert.That(target.Length, Is.EqualTo(TimeSpan.FromTicks(333334)));
             Assert.That(upstream.Start, Is.EqualTo(TimeSpan.Zero));
             Assert.That(upstream.Length, Is.EqualTo(TimeSpan.FromSeconds(3)));
             Assert.That(_history.UndoCount, Is.EqualTo(before + 1));

--- a/tests/Beutl.UnitTests/Engine/Graphics/SourceVideoOriginalDurationTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/SourceVideoOriginalDurationTests.cs
@@ -1,0 +1,62 @@
+﻿using Beutl.Composition;
+using Beutl.Graphics;
+using Beutl.Media;
+using Beutl.Media.Source;
+using Beutl.UnitTests.Engine.Graphics.Rendering;
+
+namespace Beutl.UnitTests.Engine.Graphics;
+
+// Telemetry regression: SourceVideo.TryGetOriginalDuration used to return true with a
+// non-positive duration when OffsetPosition had reached or passed the media end, and "change to
+// original duration" then fed that value into the resize pipeline, crashing Scene.MoveChild with
+// ArgumentOutOfRangeException('length'). The provider contract is a positive duration or false,
+// matching the SourceSound guard.
+[TestFixture]
+public class SourceVideoOriginalDurationTests
+{
+    private static readonly TimeSpan MediaDuration = TimeSpan.FromSeconds(2);
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp() => TestMediaHelper.RegisterTestDecoder();
+
+    private static SourceVideo CreateSourceVideo()
+    {
+        // 60 frames at 30 fps: a two-second test video decoded by the registered test decoder.
+        string path = TestMediaHelper.CreateTestVideoFile(80, 80, new Rational(30, 1), 60);
+        var source = new VideoSource();
+        source.ReadFrom(new Uri(path));
+        var video = new SourceVideo();
+        video.Source.CurrentValue = source;
+        return video;
+    }
+
+    [Test]
+    public void TryGetOriginalDuration_OffsetInsideMedia_ReturnsRemainingDuration()
+    {
+        SourceVideo video = CreateSourceVideo();
+        video.OffsetPosition.CurrentValue = TimeSpan.FromSeconds(0.5);
+
+        Assert.That(video.TryGetOriginalDuration(out TimeSpan duration), Is.True);
+        Assert.That(duration, Is.EqualTo(MediaDuration - TimeSpan.FromSeconds(0.5)));
+    }
+
+    [Test]
+    public void TryGetOriginalDuration_OffsetAtMediaEnd_ReturnsFalse()
+    {
+        SourceVideo video = CreateSourceVideo();
+        video.OffsetPosition.CurrentValue = MediaDuration;
+
+        Assert.That(video.TryGetOriginalDuration(out TimeSpan duration), Is.False);
+        Assert.That(duration, Is.EqualTo(TimeSpan.Zero));
+    }
+
+    [Test]
+    public void TryGetOriginalDuration_OffsetPastMediaEnd_ReturnsFalse()
+    {
+        SourceVideo video = CreateSourceVideo();
+        video.OffsetPosition.CurrentValue = MediaDuration + TimeSpan.FromSeconds(1);
+
+        Assert.That(video.TryGetOriginalDuration(out TimeSpan duration), Is.False);
+        Assert.That(duration, Is.EqualTo(TimeSpan.Zero));
+    }
+}


### PR DESCRIPTION
## Description

A minimal alternative to #2264, limited to the original resize-length crash and its direct regression.

- Normalize resize requests at the editor service boundary: clamp start to the timeline origin and length to at least one frame (or one tick for sub-tick frame durations). Frame durations round up to whole ticks. Invalid persisted frame rates use the default locally.
- Preserve the requested right edge when clamping a ripple left-edge drag at the timeline origin, without shifting downstream clips.
- Keep the right edge fixed when flooring left-edge resize lengths, and enforce the positive minimum after upstream barrier clamping.
- Return no original video duration when the remaining duration is non-positive.
- Preserve the known video total in slip/trim bounds even when the remaining duration is exhausted.
- Keep existing public APIs and time-mapping behavior; no Roll/Slide redesign or generalized time-mapping expansion.

Diff: 10 files, +627 / -49, predominantly regression tests.

## Affected areas

- [x] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [x] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [ ] Build / CI / docs only

## Breaking changes

None to public signatures. Invalid resize requests are clamped instead of throwing; exhausted videos report no original duration while retaining their known slip bounds.

## Test plan

- Reproduced both original UI paths on the base code: a 10 ms original duration at 30 fps and a zero-pixel resize both reached `Scene.MoveChild` with `ArgumentOutOfRangeException (length)`.
- `SubFrameResizeClampTests` and `ContextCommandDispatchTests`: 14/14 pass, including the original crashes and off-frame left-edge submissions with/without ripple.
- Related E2E fixtures (`ElementEditingPipelineTests`, `UndoRedoTests`): 9/9 pass.
- All `Beutl.UnitTests.Editor.Services` tests (including `RippleEditTests`) plus `SourceVideoOriginalDurationTests` and `TimelineResizePreviewTests` pass (565/565). The obsolete ripple-barrier throw expectation was updated to verify minimum-length clamping, upstream bounds, and undo.
- New exhausted-video slip cases: forward slip at/past the source end is rejected without a history entry; backward slip remains available. Both forward cases failed before the follow-up fix.
- `dotnet build Beutl.slnx --no-restore -m:1 -nr:false`: passed, 0 errors / 8 warnings.
- Changed-file `dotnet format Beutl.slnx --no-restore --verify-no-changes --include ...`: passed.
- Full test suite and CI results remain to be checked; no manual GUI session was used.

## Fixed issues / References

- Related: #2264. This PR intentionally excludes its expanded time-mapping work; the existing PR is left unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resizing elements with negative starts, zero lengths, or durations shorter than one frame now clamps safely instead of causing errors.
  * Ripple edits preserve timeline boundaries, maintain a positive minimum length, and remain undoable.
  * Zero-width resizes now safely produce a one-frame element.
  * Video slipping preserves known source boundaries when playback has reached the end.
  * Source duration reporting correctly handles offsets at or beyond the media’s end.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



