### PR TITLE
refactor!: migrate controls and dialogs to Avalonia 12 APIs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,3 +121,7 @@ Extension authors should also read the
 before implementing custom drawables, filter effects, brushes, or shaders, and
 the [tool-tab extension guide](docs/extension-authoring/tool-tabs.md) before
 adding a dockable editor tool.
+
+Extensions built for Avalonia 11 must follow the
+[Avalonia 12 migration guide](docs/extension-authoring/avalonia-12-migration.md)
+before targeting the upgraded host.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,6 +7,8 @@
     <Optimize>true</Optimize>
     <RootDirectory>$(MSBuildThisFileDirectory)</RootDirectory>
     <ImplicitUsings>enable</ImplicitUsings>
+    <!-- Preserve reflection bindings for dynamic editor models; projects can opt into compiled bindings. -->
+    <AvaloniaUseCompiledBindingsByDefault>false</AvaloniaUseCompiledBindingsByDefault>
     <NoWarn>$(NoWarn);NU1507</NoWarn>
     <NBGV_ThisAssemblyIncludesPackageVersion>true</NBGV_ThisAssemblyIncludesPackageVersion>
     <EnableWindowsTargeting>true</EnableWindowsTargeting>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -71,7 +71,6 @@
     <PackageVersion Include="NUnit" Version="4.6.1" />
     <PackageVersion Include="NUnit3TestAdapter" Version="6.3.0" />
     <PackageVersion Include="OpenTelemetry" Version="1.18.0" />
-    <PackageVersion Include="PanelExtension" Version="1.0.0" />
     <PackageVersion Include="ReactiveProperty" Version="9.9.0" />
     <PackageVersion Include="Dock.Avalonia" Version="12.1.0.6" />
     <PackageVersion Include="Dock.Model.Inpc" Version="12.1.0.6" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,16 +4,17 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Aigamo.ResXGenerator" Version="4.4.0" />
-    <PackageVersion Include="AsyncImageLoader.Avalonia" Version="3.7.0" />
-    <PackageVersion Include="Avalonia" Version="11.3.17" />
-    <PackageVersion Include="Avalonia.Controls.ItemsRepeater" Version="11.1.5" />
-    <PackageVersion Include="PanAndZoom" Version="11.3.9.1" />
-    <PackageVersion Include="Avalonia.Desktop" Version="11.3.17" />
-    <PackageVersion Include="Avalonia.Diagnostics" Version="11.3.17" />
-    <PackageVersion Include="Avalonia.Headless" Version="11.3.17" />
-    <PackageVersion Include="Avalonia.Headless.NUnit" Version="11.3.17" />
-    <PackageVersion Include="Avalonia.Skia" Version="11.3.17" />
-    <PackageVersion Include="ReactiveUI.Avalonia" Version="11.4.13" />
+    <PackageVersion Include="AsyncImageLoader.Avalonia" Version="3.8.0" />
+    <PackageVersion Include="Avalonia" Version="12.1.2" />
+    <PackageVersion Include="Avalonia.Controls.ItemsRepeater" Version="12.0.0" />
+    <PackageVersion Include="PanAndZoom" Version="12.1.1" />
+    <PackageVersion Include="Avalonia.Desktop" Version="12.1.2" />
+    <PackageVersion Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.3" />
+    <PackageVersion Include="Avalonia.Headless" Version="12.1.2" />
+    <PackageVersion Include="Avalonia.Headless.NUnit" Version="12.1.2" />
+    <PackageVersion Include="Avalonia.Skia" Version="12.1.2" />
+    <!-- Keep the System.Reactive scheduler used by ReactiveProperty (12.1 uses ReactiveUI.Primitives). -->
+    <PackageVersion Include="ReactiveUI.Avalonia" Version="12.0.3" />
     <PackageVersion Include="Silk.NET.MoltenVK.Native" Version="2.23.0" />
     <PackageVersion Include="Silk.NET.OpenAL" Version="2.23.0" />
     <PackageVersion Include="Silk.NET.OpenAL.Soft.Native" Version="1.23.1" />
@@ -25,10 +26,11 @@
     <PackageVersion Include="Silk.NET.Shaderc" Version="2.23.0" />
     <PackageVersion Include="Silk.NET.Shaderc.Native" Version="2.23.0" />
     <PackageVersion Include="Silk.NET.Assimp" Version="2.23.0" />
-    <PackageVersion Include="Svg.Controls.Skia.Avalonia" Version="11.3.9.5" />
-    <PackageVersion Include="Avalonia.Themes.Fluent" Version="11.3.17" />
-    <PackageVersion Include="Xaml.Behaviors.Avalonia" Version="11.3.9.6" />
-    <PackageVersion Include="Xaml.Behaviors.Interactivity" Version="11.3.9.6" />
+    <!-- Use the Avalonia 12 release compatible with the engine's SkiaSharp 3.x. -->
+    <PackageVersion Include="Svg.Controls.Skia.Avalonia" Version="12.0.0.10" />
+    <PackageVersion Include="Avalonia.Themes.Fluent" Version="12.1.2" />
+    <PackageVersion Include="Xaml.Behaviors.Avalonia" Version="12.0.7" />
+    <PackageVersion Include="Xaml.Behaviors.Interactivity" Version="12.0.7" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.18.0" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
@@ -36,8 +38,8 @@
     <PackageVersion Include="DynamicData" Version="9.4.33" />
     <PackageVersion Include="FFmpeg.AutoGen.Bindings.DynamicallyLoaded" Version="8.1.0" />
     <PackageVersion Include="FFmpeg4Sharp" Version="7.0.1" />
-    <PackageVersion Include="FluentAvaloniaUI" Version="2.5.1" />
-    <PackageVersion Include="FluentIcons.Avalonia.Fluent" Version="2.0.330" />
+    <PackageVersion Include="FluentAvaloniaUI" Version="3.1.0" />
+    <PackageVersion Include="FluentIcons.Avalonia.Fluent" Version="2.1.339.1" />
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.9.0" />
     <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.3.333" />
     <PackageVersion Include="Moq" Version="4.20.72" />
@@ -71,9 +73,9 @@
     <PackageVersion Include="OpenTelemetry" Version="1.18.0" />
     <PackageVersion Include="PanelExtension" Version="1.0.0" />
     <PackageVersion Include="ReactiveProperty" Version="9.9.0" />
-    <PackageVersion Include="Dock.Avalonia" Version="11.3.12.1" />
-    <PackageVersion Include="Dock.Model.Inpc" Version="11.3.12.1" />
-    <PackageVersion Include="Dock.Avalonia.Themes.Fluent" Version="11.3.12.1" />
+    <PackageVersion Include="Dock.Avalonia" Version="12.1.0.6" />
+    <PackageVersion Include="Dock.Model.Inpc" Version="12.1.0.6" />
+    <PackageVersion Include="Dock.Avalonia.Themes.Fluent" Version="12.1.0.6" />
     <PackageVersion Include="Refit" Version="15.2.0" />
     <PackageVersion Include="Roslynator.Analyzers" Version="5.0.0" />
     <PackageVersion Include="Serilog.Extensions.Logging" Version="10.0.0" />

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1205,11 +1205,14 @@ Third party licenses may be applicable. These have been disclosed in THIRD_PARTY
 ## PanelExtension
 https://github.com/yuto-trd/PanelExtension
 
-HorizontalGridLayout source is included in Beutl.Controls.
+HorizontalGridLayout source is included in Beutl.Controls, adapted from
+[commit cb809602b4cbae93c00b0527dd6ede2d21a4c514](https://github.com/yuto-trd/PanelExtension/tree/cb809602b4cbae93c00b0527dd6ede2d21a4c514).
+The upstream license's year placeholder is filled from the source's
+[2022 commit history](https://github.com/yuto-trd/PanelExtension/commit/4fb24e26fcbf161c7ce8830e861d2a514a0df271).
 
 MIT License
 
-Copyright (c) [year] Yuto Terada
+Copyright (c) 2022 Yuto Terada
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1205,9 +1205,11 @@ Third party licenses may be applicable. These have been disclosed in THIRD_PARTY
 ## PanelExtension
 https://github.com/yuto-trd/PanelExtension
 
+HorizontalGridLayout source is included in Beutl.Controls.
+
 MIT License
 
-Copyright (c) [year] [fullname]
+Copyright (c) [year] Yuto Terada
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/extension-authoring/avalonia-12-migration.md
+++ b/docs/extension-authoring/avalonia-12-migration.md
@@ -1,0 +1,65 @@
+# Migrating extensions to Avalonia 12
+
+The Avalonia 12 migration also upgrades FluentAvaloniaUI to 3.1.0. This is a
+breaking extension API change: binaries built against the Avalonia 11 /
+FluentAvalonia 2 SDK must be rebuilt before they can run in the upgraded host.
+
+## Icon contracts
+
+Both public extension methods now return
+`FluentAvalonia.UI.Controls.FAIconSource?`:
+
+- `EditorExtension.GetIcon()` (abstract)
+- `ToolWindowExtension.GetIcon()` (virtual)
+
+Their previous return type was `FluentAvalonia.UI.Controls.IconSource?`.
+The return type is part of the CLR method signature. An existing binary's
+override does not implement the new contract, even if the method name and
+namespace are unchanged. Loading exported types can fail and cause strict
+package discovery to reject the entire package. Do not rely on the tool
+window's default `null` icon as a compatibility fallback.
+
+Update the override and any concrete icon sources. For example, an override
+shared by either extension kind becomes:
+
+```csharp
+using FluentAvalonia.UI.Controls;
+
+public override FAIconSource? GetIcon()
+{
+    return new FAFontIconSource { Glyph = "★" };
+}
+```
+
+Other FluentAvalonia references in C# and XAML also need their new names,
+such as `SymbolIconSource` to `FASymbolIconSource`, `PathIconSource` to
+`FAPathIconSource`, and `Symbol` to `FASymbol`.
+
+## Rebuild and publish
+
+1. Target the `Beutl.Extensibility.Sdk` release that ships with the Avalonia 12
+   host. If the project overrides `BeutlPackagesVersion`, update that value to
+   the matching release too. Projects with explicit Beutl package references
+   must update those references together.
+2. Align direct UI dependencies with the host (`Avalonia` 12.1.2 and
+   `FluentAvaloniaUI` 3.1.0 for this migration), update C# and XAML references,
+   and rebuild the extension and its dependent assemblies. A C# alias alone
+   cannot repair an already compiled binary.
+3. Test the resulting package with the Avalonia 12 host: verify package
+   discovery, editor creation, tool window creation, and icon display.
+4. Publish a new extension package version and declare its supported Beutl
+   release range in the package dependencies/release metadata. Keep the older
+   package release for users on the Avalonia 11 host. Do not claim that a
+   single unchanged binary supports both hosts.
+
+There is no compatibility adapter for the old FluentAvalonia types. The
+supported migration path is a rebuilt extension package for the new host.
+The final Beutl release number is assigned by the release process; use that
+release's SDK version rather than the repository's development version.
+
+## PanelExtension
+
+The host no longer references the `PanelExtension` package. Its
+`HorizontalGridLayout` implementation is now `Beutl.Controls.HorizontalGridLayout`.
+Extensions using that layout must reference `Beutl.Controls` from the matching
+Beutl release and update their C# namespaces and XAML namespace mappings.

--- a/packages/ubuntu22.04_amd64/usr/share/doc/beutl/copyright
+++ b/packages/ubuntu22.04_amd64/usr/share/doc/beutl/copyright
@@ -1212,11 +1212,14 @@ Comment: Bundled third-party license notices follow. An additional copy is
  ## PanelExtension
  https://github.com/yuto-trd/PanelExtension
  .
- HorizontalGridLayout source is included in Beutl.Controls.
+ HorizontalGridLayout source is included in Beutl.Controls, adapted from
+ [commit cb809602b4cbae93c00b0527dd6ede2d21a4c514](https://github.com/yuto-trd/PanelExtension/tree/cb809602b4cbae93c00b0527dd6ede2d21a4c514).
+ The upstream license's year placeholder is filled from the source's
+ [2022 commit history](https://github.com/yuto-trd/PanelExtension/commit/4fb24e26fcbf161c7ce8830e861d2a514a0df271).
  .
  MIT License
  .
- Copyright (c) [year] Yuto Terada
+ Copyright (c) 2022 Yuto Terada
  .
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/packages/ubuntu22.04_amd64/usr/share/doc/beutl/copyright
+++ b/packages/ubuntu22.04_amd64/usr/share/doc/beutl/copyright
@@ -1212,9 +1212,11 @@ Comment: Bundled third-party license notices follow. An additional copy is
  ## PanelExtension
  https://github.com/yuto-trd/PanelExtension
  .
+ HorizontalGridLayout source is included in Beutl.Controls.
+ .
  MIT License
  .
- Copyright (c) [year] [fullname]
+ Copyright (c) [year] Yuto Terada
  .
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/samples/PackageSample/SampleEditorExtension.cs
+++ b/samples/PackageSample/SampleEditorExtension.cs
@@ -81,7 +81,7 @@ public class TextEditor : TextBox
 {
     public TextEditor()
     {
-        this[!TextProperty] = new Binding("Text.Value", BindingMode.TwoWay);
+        this[!TextProperty] = new ReflectionBinding("Text.Value") { Mode = BindingMode.TwoWay };
     }
 
     protected override Type StyleKeyOverride => typeof(TextBox);
@@ -102,11 +102,11 @@ public sealed class SampleEditorExtension : EditorExtension
         };
     }
 
-    public override IconSource? GetIcon()
+    public override FAIconSource? GetIcon()
     {
-        return new SymbolIconSource
+        return new FASymbolIconSource
         {
-            Symbol = Symbol.Add
+            Symbol = FASymbol.Add
         };
     }
 

--- a/samples/PackageSample/SampleToolWindowExtension.cs
+++ b/samples/PackageSample/SampleToolWindowExtension.cs
@@ -28,7 +28,7 @@ public sealed class SampleToolWindowExtension : ToolWindowExtension
 
     public override bool CanMultiple => true;
 
-    public override IconSource? GetIcon() => new SymbolIconSource { Symbol = Symbol.Mail };
+    public override FAIconSource? GetIcon() => new FASymbolIconSource { Symbol = FASymbol.Mail };
 
     public override bool TryCreateContent([NotNullWhen(true)] out Window? window)
     {

--- a/src/Beutl.Controls/ColorPicker/ColorPaletteItem.cs
+++ b/src/Beutl.Controls/ColorPicker/ColorPaletteItem.cs
@@ -6,8 +6,8 @@ using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Media;
 using Avalonia.Platform;
-using Avalonia.Utilities;
 using Avalonia.VisualTree;
+using Beutl.Utilities;
 
 namespace FluentAvalonia.UI.Controls;
 

--- a/src/Beutl.Controls/ColorPicker/ColorPickerFlyout.cs
+++ b/src/Beutl.Controls/ColorPicker/ColorPickerFlyout.cs
@@ -8,7 +8,7 @@ namespace FluentAvalonia.UI.Controls;
 /// <summary>
 /// Defines a flyout that hosts a <see cref="ColorPicker"/>
 /// </summary>
-public sealed class ColorPickerFlyout : PickerFlyoutBase
+public sealed class ColorPickerFlyout : FAPickerFlyoutBase
 {
     /// <summary>
     /// Gets the <see cref="ColorPicker"/> that this flyout hosts
@@ -30,7 +30,7 @@ public sealed class ColorPickerFlyout : PickerFlyoutBase
         if (_picker == null)
             _picker = new FAColorPicker();
 
-        var pfp = new PickerFlyoutPresenter()
+        var pfp = new FAPickerFlyoutPresenter()
         {
             Content = _picker
         };
@@ -53,13 +53,13 @@ public sealed class ColorPickerFlyout : PickerFlyoutBase
 
     protected override bool ShouldShowConfirmationButtons() => _showButtons;
 
-    private void OnFlyoutDismissed(PickerFlyoutPresenter sender, object args)
+    private void OnFlyoutDismissed(FAPickerFlyoutPresenter sender, object args)
     {
         Dismissed?.Invoke(this, EventArgs.Empty);
         Hide();
     }
 
-    private void OnFlyoutConfirmed(PickerFlyoutPresenter sender, object args)
+    private void OnFlyoutConfirmed(FAPickerFlyoutPresenter sender, object args)
     {
         OnConfirmed();
     }

--- a/src/Beutl.Controls/ColorPicker/ColorPickerStyles.axaml
+++ b/src/Beutl.Controls/ColorPicker/ColorPickerStyles.axaml
@@ -19,7 +19,7 @@
         </Border>
     </Design.PreviewWith>
 
-    <conv:ColorShadeBrushConv x:Key="ColorShadeBrushConv" />
+    <conv:FAColorShadeBrushConv x:Key="ColorShadeBrushConv" />
     <x:Double x:Key="ColorPickerTabItemHeight">46</x:Double>
     <Thickness x:Key="ColorPickerSpectrumMargin">2 48 2 2</Thickness>
     <x:Double x:Key="ColorPickerTabItemSelectionIndicatorHeight">3</x:Double>
@@ -41,8 +41,8 @@
 
 
     <ControlTheme x:Key="ColorPickerNumberBoxStyle"
-                  BasedOn="{StaticResource {x:Type ui:NumberBox}}"
-                  TargetType="ui:NumberBox">
+                  BasedOn="{StaticResource {x:Type ui:FANumberBox}}"
+                  TargetType="ui:FANumberBox">
         <Setter Property="SpinButtonPlacementMode" Value="Compact" />
         <Setter Property="MinWidth" Value="110" />
         <Setter Property="Template">
@@ -76,7 +76,7 @@
                                            HorizontalAlignment="Center"
                                            VerticalAlignment="Center"
                                            FontWeight="SemiBold"
-                                           Text="{Binding $parent[ui:NumberBox].Header}" />
+                                           Text="{Binding $parent[ui:FANumberBox].Header}" />
                             </Border>
                         </TextBox.InnerLeftContent>
                     </TextBox>
@@ -460,17 +460,17 @@
                                                 Theme="{StaticResource ColorPickerTabControlStyle}">
                                         <TabItem Name="SpectrumTab" IsVisible="{TemplateBinding UseSpectrum}">
                                             <TabItem.Header>
-                                                <ui:IconSourceElement Width="18" Height="18">
-                                                    <ui:IconSourceElement.IconSource>
-                                                        <ui:PathIconSource Data="{StaticResource ColorSpectrumGeometry}" Stretch="Fill" />
-                                                    </ui:IconSourceElement.IconSource>
-                                                </ui:IconSourceElement>
+                                                <ui:FAIconSourceElement Width="18" Height="18">
+                                                    <ui:FAIconSourceElement.IconSource>
+                                                        <ui:FAPathIconSource Data="{StaticResource ColorSpectrumGeometry}" Stretch="Fill" />
+                                                    </ui:FAIconSourceElement.IconSource>
+                                                </ui:FAIconSourceElement>
                                             </TabItem.Header>
                                         </TabItem>
                                         <TabItem Name="WheelTab" IsVisible="False">
                                             <!--  IsVisible="{TemplateBinding UseColorWheel}"  -->
                                             <TabItem.Header>
-                                                <ui:FontIcon FontFamily="{DynamicResource SymbolThemeFontFamily}"
+                                                <ui:FAFontIcon FontFamily="{DynamicResource SymbolThemeFontFamily}"
                                                              FontSize="20"
                                                              Glyph="&#xE790;" />
                                             </TabItem.Header>
@@ -478,16 +478,16 @@
                                         <TabItem Name="TriangleTab" IsVisible="False">
                                             <!--  IsVisible="{TemplateBinding UseColorTriangle}"  -->
                                             <TabItem.Header>
-                                                <ui:IconSourceElement Width="18" Height="18">
-                                                    <ui:IconSourceElement.IconSource>
-                                                        <ui:PathIconSource Data="{StaticResource ColorTriangleGeometry}" Stretch="Fill" />
-                                                    </ui:IconSourceElement.IconSource>
-                                                </ui:IconSourceElement>
+                                                <ui:FAIconSourceElement Width="18" Height="18">
+                                                    <ui:FAIconSourceElement.IconSource>
+                                                        <ui:FAPathIconSource Data="{StaticResource ColorTriangleGeometry}" Stretch="Fill" />
+                                                    </ui:FAIconSourceElement.IconSource>
+                                                </ui:FAIconSourceElement>
                                             </TabItem.Header>
                                         </TabItem>
                                         <TabItem Name="PaletteTab" IsVisible="{TemplateBinding UseColorPalette}">
                                             <TabItem.Header>
-                                                <ui:FontIcon FontFamily="{DynamicResource SymbolThemeFontFamily}"
+                                                <ui:FAFontIcon FontFamily="{DynamicResource SymbolThemeFontFamily}"
                                                              FontSize="20"
                                                              Glyph="&#xF0E2;" />
 
@@ -498,13 +498,13 @@
                                                 <ScrollViewer MaxHeight="450"
                                                               HorizontalScrollBarVisibility="Disabled"
                                                               VerticalScrollBarVisibility="Auto">
-                                                    <ui:ItemsRepeater Margin="5" ItemsSource="{TemplateBinding CustomPaletteColors}">
-                                                        <ui:ItemsRepeater.Layout>
-                                                            <ui:UniformGridLayout ItemsStretch="Fill"
+                                                    <ui:FAItemsRepeater Margin="5" ItemsSource="{TemplateBinding CustomPaletteColors}">
+                                                        <ui:FAItemsRepeater.Layout>
+                                                            <ui:FAUniformGridLayout ItemsStretch="Fill"
                                                                                   MaximumRowsOrColumns="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=PaletteColumnCount}"
                                                                                   Orientation="Horizontal" />
-                                                        </ui:ItemsRepeater.Layout>
-                                                        <ui:ItemsRepeater.ItemTemplate>
+                                                        </ui:FAItemsRepeater.Layout>
+                                                        <ui:FAItemsRepeater.ItemTemplate>
                                                             <DataTemplate x:DataType="Color">
                                                                 <ui:ColorPaletteItem Height="{Binding $self.Bounds.Width}"
                                                                                      Margin="{DynamicResource ColorPaletteItemMargin}"
@@ -512,18 +512,18 @@
                                                                                      BorderThicknessPointerOver="1"
                                                                                      Color="{Binding}" />
                                                             </DataTemplate>
-                                                        </ui:ItemsRepeater.ItemTemplate>
-                                                    </ui:ItemsRepeater>
+                                                        </ui:FAItemsRepeater.ItemTemplate>
+                                                    </ui:FAItemsRepeater>
                                                 </ScrollViewer>
                                             </Panel>
                                         </TabItem>
                                         <TabItem Name="TextEntryTab" IsVisible="{TemplateBinding IsCompact}">
                                             <TabItem.Header>
-                                                <ui:IconSourceElement Width="18" Height="18">
-                                                    <ui:IconSourceElement.IconSource>
-                                                        <ui:PathIconSource Data="{StaticResource ColorSliderGeometry}" Stretch="Fill" />
-                                                    </ui:IconSourceElement.IconSource>
-                                                </ui:IconSourceElement>
+                                                <ui:FAIconSourceElement Width="18" Height="18">
+                                                    <ui:FAIconSourceElement.IconSource>
+                                                        <ui:FAPathIconSource Data="{StaticResource ColorSliderGeometry}" Stretch="Fill" />
+                                                    </ui:FAIconSourceElement.IconSource>
+                                                </ui:FAIconSourceElement>
                                             </TabItem.Header>
                                             <Panel Name="TextEntryTabHost" />
                                         </TabItem>
@@ -626,7 +626,7 @@
                                              Grid.Row="5"
                                              MinWidth="0" />
 
-                                <ui:NumberBox Name="HueBox"
+                                <ui:FANumberBox Name="HueBox"
                                               Grid.Row="0"
                                               Grid.Column="1"
                                               Margin="0,3"
@@ -634,7 +634,7 @@
                                               Maximum="359"
                                               Minimum="0"
                                               Theme="{StaticResource ColorPickerNumberBoxStyle}" />
-                                <ui:NumberBox Name="SatBox"
+                                <ui:FANumberBox Name="SatBox"
                                               Grid.Row="1"
                                               Grid.Column="1"
                                               Margin="0,3"
@@ -642,7 +642,7 @@
                                               Maximum="100"
                                               Minimum="0"
                                               Theme="{StaticResource ColorPickerNumberBoxStyle}" />
-                                <ui:NumberBox Name="ValBox"
+                                <ui:FANumberBox Name="ValBox"
                                               Grid.Row="2"
                                               Grid.Column="1"
                                               Margin="0,3"
@@ -650,7 +650,7 @@
                                               Maximum="100"
                                               Minimum="0"
                                               Theme="{StaticResource ColorPickerNumberBoxStyle}" />
-                                <ui:NumberBox Name="RedBox"
+                                <ui:FANumberBox Name="RedBox"
                                               Grid.Row="3"
                                               Grid.Column="1"
                                               Margin="0,3"
@@ -658,7 +658,7 @@
                                               Maximum="255"
                                               Minimum="0"
                                               Theme="{StaticResource ColorPickerNumberBoxStyle}" />
-                                <ui:NumberBox Name="GreenBox"
+                                <ui:FANumberBox Name="GreenBox"
                                               Grid.Row="4"
                                               Grid.Column="1"
                                               Margin="0,3"
@@ -666,7 +666,7 @@
                                               Maximum="255"
                                               Minimum="0"
                                               Theme="{StaticResource ColorPickerNumberBoxStyle}" />
-                                <ui:NumberBox Name="BlueBox"
+                                <ui:FANumberBox Name="BlueBox"
                                               Grid.Row="5"
                                               Grid.Column="1"
                                               Margin="0,3"
@@ -674,7 +674,7 @@
                                               Maximum="255"
                                               Minimum="0"
                                               Theme="{StaticResource ColorPickerNumberBoxStyle}" />
-                                <ui:NumberBox Name="AlphaBox"
+                                <ui:FANumberBox Name="AlphaBox"
                                               Grid.Row="6"
                                               Grid.Column="1"
                                               Margin="0,3"
@@ -849,7 +849,7 @@
             <Style Selector="^ /template/ ui|ColorRamp#AlphaRamp">
                 <Setter Property="IsVisible" Value="True" />
             </Style>
-            <Style Selector="^ /template/ ui|NumberBox#AlphaBox">
+            <Style Selector="^ /template/ ui|FANumberBox#AlphaBox">
                 <Setter Property="IsVisible" Value="True" />
             </Style>
 
@@ -876,13 +876,13 @@
             </Style>
 
             <Style Selector="^:hsv">
-                <Style Selector="^ /template/ ui|NumberBox#RedBox">
+                <Style Selector="^ /template/ ui|FANumberBox#RedBox">
                     <Setter Property="IsVisible" Value="False" />
                 </Style>
-                <Style Selector="^ /template/ ui|NumberBox#GreenBox">
+                <Style Selector="^ /template/ ui|FANumberBox#GreenBox">
                     <Setter Property="IsVisible" Value="False" />
                 </Style>
-                <Style Selector="^ /template/ ui|NumberBox#BlueBox">
+                <Style Selector="^ /template/ ui|FANumberBox#BlueBox">
                     <Setter Property="IsVisible" Value="False" />
                 </Style>
                 <Style Selector="^ /template/ ui|ColorRamp#RedRamp">
@@ -897,13 +897,13 @@
             </Style>
 
             <Style Selector="^:rgb">
-                <Style Selector="^ /template/ ui|NumberBox#HueBox">
+                <Style Selector="^ /template/ ui|FANumberBox#HueBox">
                     <Setter Property="IsVisible" Value="False" />
                 </Style>
-                <Style Selector="^ /template/ ui|NumberBox#SatBox">
+                <Style Selector="^ /template/ ui|FANumberBox#SatBox">
                     <Setter Property="IsVisible" Value="False" />
                 </Style>
-                <Style Selector="^ /template/ ui|NumberBox#ValBox">
+                <Style Selector="^ /template/ ui|FANumberBox#ValBox">
                     <Setter Property="IsVisible" Value="False" />
                 </Style>
                 <Style Selector="^ /template/ ui|ColorRamp#HueRamp">

--- a/src/Beutl.Controls/ColorPicker/ColorPickerStyles.axaml
+++ b/src/Beutl.Controls/ColorPicker/ColorPickerStyles.axaml
@@ -65,7 +65,7 @@
                              SelectionBrush="{TemplateBinding SelectionHighlightColor}"
                              TextAlignment="{TemplateBinding TextAlignment}"
                              Theme="{StaticResource NumberBoxTextBoxStyle}"
-                             Watermark="{TemplateBinding PlaceholderText}">
+                             PlaceholderText="{TemplateBinding PlaceholderText}">
                         <TextBox.InnerLeftContent>
                             <Border Name="Label"
                                     Width="32"

--- a/src/Beutl.Controls/ColorPicker/ColorSpectrum.cs
+++ b/src/Beutl.Controls/ColorPicker/ColorSpectrum.cs
@@ -7,7 +7,6 @@ using Avalonia.Media.Imaging;
 using Avalonia.Media.Immutable;
 using Avalonia.Platform;
 using Avalonia.Skia;
-using FluentAvalonia.Core;
 using FluentAvalonia.UI.Media;
 using SkiaSharp;
 
@@ -782,8 +781,8 @@ public partial class ColorSpectrum : ColorPickerComponent
                 {
                     var sz = Bounds.Size;
 
-                    var pX = FAMathHelpers.Clamp(pt.X / sz.Width, 0, 1);
-                    var pY = FAMathHelpers.Clamp(pt.Y / sz.Height, 0, 1);
+                    var pX = double.Clamp(pt.X / sz.Width, 0, 1);
+                    var pY = double.Clamp(pt.Y / sz.Height, 0, 1);
 
                     switch (Component)
                     {
@@ -817,8 +816,8 @@ public partial class ColorSpectrum : ColorPickerComponent
                     if (theta < 0)
                         theta += 360;
 
-                    var dist = FAMathHelpers.Clamp(Math.Sqrt(dp.X * dp.X + dp.Y * dp.Y) / (_lastWheelRect.Width / 2), 0, 1);
-                    Color = Color2.FromHSVf((float)FAMathHelpers.Clamp(theta, 0, 360), (float)dist, Color.Valuef);
+                    var dist = double.Clamp(Math.Sqrt(dp.X * dp.X + dp.Y * dp.Y) / (_lastWheelRect.Width / 2), 0, 1);
+                    Color = Color2.FromHSVf((float)double.Clamp(theta, 0, 360), (float)dist, Color.Valuef);
                 }
                 break;
 

--- a/src/Beutl.Controls/ColorPicker/ColorSpectrum.cs
+++ b/src/Beutl.Controls/ColorPicker/ColorSpectrum.cs
@@ -782,8 +782,8 @@ public partial class ColorSpectrum : ColorPickerComponent
                 {
                     var sz = Bounds.Size;
 
-                    var pX = MathHelpers.Clamp(pt.X / sz.Width, 0, 1);
-                    var pY = MathHelpers.Clamp(pt.Y / sz.Height, 0, 1);
+                    var pX = FAMathHelpers.Clamp(pt.X / sz.Width, 0, 1);
+                    var pY = FAMathHelpers.Clamp(pt.Y / sz.Height, 0, 1);
 
                     switch (Component)
                     {
@@ -817,8 +817,8 @@ public partial class ColorSpectrum : ColorPickerComponent
                     if (theta < 0)
                         theta += 360;
 
-                    var dist = MathHelpers.Clamp(Math.Sqrt(dp.X * dp.X + dp.Y * dp.Y) / (_lastWheelRect.Width / 2), 0, 1);
-                    Color = Color2.FromHSVf((float)MathHelpers.Clamp(theta, 0, 360), (float)dist, Color.Valuef);
+                    var dist = FAMathHelpers.Clamp(Math.Sqrt(dp.X * dp.X + dp.Y * dp.Y) / (_lastWheelRect.Width / 2), 0, 1);
+                    Color = Color2.FromHSVf((float)FAMathHelpers.Clamp(theta, 0, 360), (float)dist, Color.Valuef);
                 }
                 break;
 

--- a/src/Beutl.Controls/ColorPicker/FAColorPicker.cs
+++ b/src/Beutl.Controls/ColorPicker/FAColorPicker.cs
@@ -95,43 +95,43 @@ public partial class FAColorPicker : TemplatedControl
             _blueButton.IsCheckedChanged += OnComponentRBChecked;
         }
 
-        _hueBox = e.NameScope.Find<NumberBox>("HueBox");
+        _hueBox = e.NameScope.Find<FANumberBox>("HueBox");
         if (_hueBox != null)
         {
             _hueBox.ValueChanged += OnComponentBoxValueChanged;
         }
 
-        _satBox = e.NameScope.Find<NumberBox>("SatBox");
+        _satBox = e.NameScope.Find<FANumberBox>("SatBox");
         if (_satBox != null)
         {
             _satBox.ValueChanged += OnComponentBoxValueChanged;
         }
 
-        _valBox = e.NameScope.Find<NumberBox>("ValBox");
+        _valBox = e.NameScope.Find<FANumberBox>("ValBox");
         if (_valBox != null)
         {
             _valBox.ValueChanged += OnComponentBoxValueChanged;
         }
 
-        _redBox = e.NameScope.Find<NumberBox>("RedBox");
+        _redBox = e.NameScope.Find<FANumberBox>("RedBox");
         if (_redBox != null)
         {
             _redBox.ValueChanged += OnComponentBoxValueChanged;
         }
 
-        _greenBox = e.NameScope.Find<NumberBox>("GreenBox");
+        _greenBox = e.NameScope.Find<FANumberBox>("GreenBox");
         if (_greenBox != null)
         {
             _greenBox.ValueChanged += OnComponentBoxValueChanged;
         }
 
-        _blueBox = e.NameScope.Find<NumberBox>("BlueBox");
+        _blueBox = e.NameScope.Find<FANumberBox>("BlueBox");
         if (_blueBox != null)
         {
             _blueBox.ValueChanged += OnComponentBoxValueChanged;
         }
 
-        _alphaBox = e.NameScope.Find<NumberBox>("AlphaBox");
+        _alphaBox = e.NameScope.Find<FANumberBox>("AlphaBox");
         if (_alphaBox != null)
         {
             _alphaBox.ValueChanged += OnComponentBoxValueChanged;
@@ -683,7 +683,7 @@ public partial class FAColorPicker : TemplatedControl
             UpdateColorAndControls(args.NewColor, ColorUpdateReason.AlphaRamp);
     }
 
-    private void OnComponentBoxValueChanged(NumberBox sender, NumberBoxValueChangedEventArgs args)
+    private void OnComponentBoxValueChanged(FANumberBox sender, FANumberBoxValueChangedEventArgs args)
     {
         if (!_templateApplied || _ignoreColorChange)
             return;
@@ -1006,13 +1006,13 @@ public partial class FAColorPicker : TemplatedControl
     private ColorRamp _blueRamp;
     private ColorRamp _alphaRamp;
 
-    private NumberBox _hueBox;
-    private NumberBox _satBox;
-    private NumberBox _valBox;
-    private NumberBox _redBox;
-    private NumberBox _greenBox;
-    private NumberBox _blueBox;
-    private NumberBox _alphaBox;
+    private FANumberBox _hueBox;
+    private FANumberBox _satBox;
+    private FANumberBox _valBox;
+    private FANumberBox _redBox;
+    private FANumberBox _greenBox;
+    private FANumberBox _blueBox;
+    private FANumberBox _alphaBox;
 
     private TextBox _hexBox;
 

--- a/src/Beutl.Controls/DirectoryTreeView.cs
+++ b/src/Beutl.Controls/DirectoryTreeView.cs
@@ -225,32 +225,32 @@ public sealed class DirectoryTreeView : TreeView
     {
         if (SelectedItem is DirectoryTreeItem directory)
         {
-            var dialog = new ContentDialog
+            var dialog = new FAContentDialog
             {
                 Content = MessageStrings.ConfirmDeleteDirectory,
                 PrimaryButtonText = Strings.OK,
                 CloseButtonText = Strings.Cancel,
-                DefaultButton = ContentDialogButton.Primary,
+                DefaultButton = FAContentDialogButton.Primary,
                 IsSecondaryButtonEnabled = false,
             };
 
-            if (await dialog.ShowAsync() == ContentDialogResult.Primary)
+            if (await dialog.ShowAsync() == FAContentDialogResult.Primary)
             {
                 directory.Info.Delete(true);
             }
         }
         else if (SelectedItem is FileTreeItem file)
         {
-            var dialog = new ContentDialog
+            var dialog = new FAContentDialog
             {
                 Content = MessageStrings.ConfirmDeleteFile,
                 PrimaryButtonText = Strings.OK,
                 CloseButtonText = Strings.Cancel,
-                DefaultButton = ContentDialogButton.Primary,
+                DefaultButton = FAContentDialogButton.Primary,
                 IsSecondaryButtonEnabled = false,
             };
 
-            if (await dialog.ShowAsync() == ContentDialogResult.Primary)
+            if (await dialog.ShowAsync() == FAContentDialogResult.Primary)
             {
                 file.Info.Delete();
             }
@@ -555,11 +555,11 @@ public sealed class FileTreeItem : TreeViewItem
             {
                 string content = MessageStrings.RenameConflict;
                 content = string.Format(content, Info.Name, tb.Text);
-                var dialog = new ContentDialog()
+                var dialog = new FAContentDialog()
                 {
                     CloseButtonText = Strings.Close,
                     Content = content,
-                    DefaultButton = ContentDialogButton.None,
+                    DefaultButton = FAContentDialogButton.None,
                     IsPrimaryButtonEnabled = false,
                     IsSecondaryButtonEnabled = false,
                 };
@@ -785,11 +785,11 @@ public sealed class DirectoryTreeItem : TreeViewItem
             {
                 string content = MessageStrings.RenameConflict;
                 content = string.Format(content, Info.Name, tb.Text);
-                var dialog = new ContentDialog()
+                var dialog = new FAContentDialog()
                 {
                     CloseButtonText = Strings.Close,
                     Content = content,
-                    DefaultButton = ContentDialogButton.None,
+                    DefaultButton = FAContentDialogButton.None,
                     IsPrimaryButtonEnabled = false,
                     IsSecondaryButtonEnabled = false,
                 };

--- a/src/Beutl.Controls/FileInputArea.cs
+++ b/src/Beutl.Controls/FileInputArea.cs
@@ -109,7 +109,7 @@ public class FileInputArea : ContentControl
 
     private async void OnButtonClick(object sender, RoutedEventArgs e)
     {
-        if (VisualRoot is TopLevel toplevel)
+        if (TopLevel.GetTopLevel(this) is TopLevel toplevel)
         {
             try
             {

--- a/src/Beutl.Controls/HdrBitmapView.cs
+++ b/src/Beutl.Controls/HdrBitmapView.cs
@@ -109,7 +109,7 @@ public class HdrBitmapView : NativeControlHost
     {
         if (_renderer != null && Bounds.Width > 0 && Bounds.Height > 0)
         {
-            var scaling = VisualRoot?.RenderScaling ?? 1.0;
+            var scaling = TopLevel.GetTopLevel(this)?.RenderScaling ?? 1.0;
             _renderer.Resize(
                 (uint)(Bounds.Width * scaling),
                 (uint)(Bounds.Height * scaling));
@@ -152,7 +152,7 @@ public class HdrBitmapView : NativeControlHost
 
         if (_renderer != null && e.NewSize.Width > 0 && e.NewSize.Height > 0)
         {
-            var scaling = VisualRoot?.RenderScaling ?? 1.0;
+            var scaling = TopLevel.GetTopLevel(this)?.RenderScaling ?? 1.0;
             _renderer.Resize(
                 (uint)(e.NewSize.Width * scaling),
                 (uint)(e.NewSize.Height * scaling));
@@ -202,7 +202,7 @@ public class HdrBitmapView : NativeControlHost
         {
             _renderer = new VulkanSwapchainRenderer();
 
-            var scaling = VisualRoot?.RenderScaling ?? 1.0;
+            var scaling = TopLevel.GetTopLevel(this)?.RenderScaling ?? 1.0;
             _renderer.Initialize(
                 handle.Handle,
                 handle.HandleDescriptor ?? "",

--- a/src/Beutl.Controls/Helpers/BindingHelper.cs
+++ b/src/Beutl.Controls/Helpers/BindingHelper.cs
@@ -13,7 +13,7 @@ public static class BindingHelper
 {
     private static readonly Dictionary<Type, CompiledBindingPath> s_cache = [];
 
-    public static IBinding ToPropertyBinding<T>(this IReactiveProperty<T> property, BindingMode bindingMode = BindingMode.Default)
+    public static BindingBase ToPropertyBinding<T>(this IReactiveProperty<T> property, BindingMode bindingMode = BindingMode.Default)
     {
         if (!s_cache.TryGetValue(typeof(T), out CompiledBindingPath? path))
         {

--- a/src/Beutl.Controls/HorizontalGridLayout.cs
+++ b/src/Beutl.Controls/HorizontalGridLayout.cs
@@ -1,0 +1,113 @@
+﻿// Adapted from PanelExtension (MIT).
+// https://github.com/yuto-trd/PanelExtension/blob/cb809602b4cbae93c00b0527dd6ede2d21a4c514/PanelExtension.Avalonia/HorizontalGridLayout.cs
+// Copyright (c) [year] Yuto Terada. See the PanelExtension entry in THIRD_PARTY_NOTICES.md.
+
+using Avalonia;
+using Avalonia.Layout;
+
+namespace Beutl.Controls;
+
+/// <summary>Wraps items into rows and stretches their widths to fill the available space.</summary>
+/// <remarks>Requires finite width. Disable horizontal scrolling on a containing ScrollViewer.</remarks>
+public class HorizontalGridLayout : NonVirtualizingLayout
+{
+    public static readonly StyledProperty<double> ColumnSpacingProperty =
+        AvaloniaProperty.Register<HorizontalGridLayout, double>(nameof(ColumnSpacing));
+
+    public static readonly StyledProperty<double> RowSpacingProperty =
+        AvaloniaProperty.Register<HorizontalGridLayout, double>(nameof(RowSpacing));
+
+    public static readonly StyledProperty<double> MinItemWidthProperty =
+        AvaloniaProperty.Register<HorizontalGridLayout, double>(nameof(MinItemWidth));
+
+    public static readonly StyledProperty<int> MaxColumnsProperty =
+        AvaloniaProperty.Register<HorizontalGridLayout, int>(
+            nameof(MaxColumns),
+            defaultValue: int.MaxValue,
+            coerce: (_, v) => Math.Max(v, 1));
+
+    public double ColumnSpacing
+    {
+        get => GetValue(ColumnSpacingProperty);
+        set => SetValue(ColumnSpacingProperty, value);
+    }
+
+    public double RowSpacing
+    {
+        get => GetValue(RowSpacingProperty);
+        set => SetValue(RowSpacingProperty, value);
+    }
+
+    public double MinItemWidth
+    {
+        get => GetValue(MinItemWidthProperty);
+        set => SetValue(MinItemWidthProperty, value);
+    }
+
+    public int MaxColumns
+    {
+        get => GetValue(MaxColumnsProperty);
+        set => SetValue(MaxColumnsProperty, value);
+    }
+
+    protected override Size MeasureOverride(NonVirtualizingLayoutContext context, Size availableSize)
+    {
+        if (double.IsInfinity(availableSize.Width))
+        {
+            throw new InvalidOperationException();
+        }
+
+        var columns = (int)Math.Floor(availableSize.Width / MinItemWidth);
+        columns = Math.Clamp(columns, 1, MaxColumns);
+
+        var spacingWidth = (columns - 1) * ColumnSpacing;
+
+        var itemWidth = (availableSize.Width - spacingWidth) / columns;
+
+        foreach (var item in context.Children)
+        {
+            item.Measure(new Size(itemWidth, double.PositiveInfinity));
+        }
+
+        var curColumn = 0;
+        var curMaxBottom = 0d;
+        var prevMaxBottom = 0d;
+
+        foreach (var item in context.Children)
+        {
+            var last = curColumn == columns - 1;
+
+            var margin = item.Margin;
+            var left = curColumn * itemWidth + curColumn * ColumnSpacing;
+            var top = prevMaxBottom + margin.Top;
+
+            var rect = new Rect(left, top, itemWidth, item.DesiredSize.Height + margin.Bottom);
+            item.Arrange(rect);
+
+            curMaxBottom = Math.Max(item.Bounds.Bottom, curMaxBottom);
+
+            curColumn++;
+            if (last)
+            {
+                curColumn = 0;
+
+                prevMaxBottom = curMaxBottom + RowSpacing;
+            }
+        }
+
+        return new Size(availableSize.Width, curMaxBottom);
+    }
+
+    protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+    {
+        base.OnPropertyChanged(change);
+        if (change.Property == MinItemWidthProperty
+            || change.Property == MaxColumnsProperty
+            || change.Property == ColumnSpacingProperty
+            || change.Property == RowSpacingProperty)
+        {
+            InvalidateMeasure();
+            InvalidateArrange();
+        }
+    }
+}

--- a/src/Beutl.Controls/HorizontalGridLayout.cs
+++ b/src/Beutl.Controls/HorizontalGridLayout.cs
@@ -1,6 +1,6 @@
 ﻿// Adapted from PanelExtension (MIT).
 // https://github.com/yuto-trd/PanelExtension/blob/cb809602b4cbae93c00b0527dd6ede2d21a4c514/PanelExtension.Avalonia/HorizontalGridLayout.cs
-// Copyright (c) [year] Yuto Terada. See the PanelExtension entry in THIRD_PARTY_NOTICES.md.
+// Copyright (c) 2022 Yuto Terada. See the PanelExtension entry in THIRD_PARTY_NOTICES.md.
 
 using Avalonia;
 using Avalonia.Layout;

--- a/src/Beutl.Controls/NavItemHelper.cs
+++ b/src/Beutl.Controls/NavItemHelper.cs
@@ -8,24 +8,24 @@ using FluentIconSource = FluentIcons.Avalonia.Fluent.FluentIconSource;
 
 namespace Beutl.Controls;
 
-public class NavItemHelper : Behavior<NavigationViewItem>
+public class NavItemHelper : Behavior<FANavigationViewItem>
 {
-    public static readonly StyledProperty<IconSource> RegularIconProperty
-        = AvaloniaProperty.Register<NavItemHelper, IconSource>("RegularIcon");
+    public static readonly StyledProperty<FAIconSource> RegularIconProperty
+        = AvaloniaProperty.Register<NavItemHelper, FAIconSource>("RegularIcon");
 
-    public static readonly StyledProperty<IconSource> FilledIconProperty
-        = AvaloniaProperty.Register<NavItemHelper, IconSource>("FilledIcon");
+    public static readonly StyledProperty<FAIconSource> FilledIconProperty
+        = AvaloniaProperty.Register<NavItemHelper, FAIconSource>("FilledIcon");
     private IDisposable _disposable;
-    private IconSourceElement _regular;
-    private IconSourceElement _filled;
+    private FAIconSourceElement _regular;
+    private FAIconSourceElement _filled;
 
-    public IconSource RegularIcon
+    public FAIconSource RegularIcon
     {
         get => GetValue(RegularIconProperty);
         set => SetValue(RegularIconProperty, value);
     }
 
-    public IconSource FilledIcon
+    public FAIconSource FilledIcon
     {
         get => GetValue(FilledIconProperty);
         set => SetValue(FilledIconProperty, value);
@@ -37,7 +37,7 @@ public class NavItemHelper : Behavior<NavigationViewItem>
         SetFontSize(RegularIcon);
         SetFontSize(FilledIcon);
         _disposable = AssociatedObject.GetPropertyChangedObservable(ListBoxItem.IsSelectedProperty)
-            .Subscribe(e => SelectionChanged((NavigationViewItem)e.Sender));
+            .Subscribe(e => SelectionChanged((FANavigationViewItem)e.Sender));
 
         SelectionChanged(AssociatedObject);
     }
@@ -69,9 +69,9 @@ public class NavItemHelper : Behavior<NavigationViewItem>
         }
     }
 
-    private static void SetFontSize(IconSource iconSource)
+    private static void SetFontSize(FAIconSource iconSource)
     {
-        if (iconSource is FontIconSource fontIcon)
+        if (iconSource is FAFontIconSource fontIcon)
         {
             fontIcon.FontSize = 48;
         }
@@ -81,7 +81,7 @@ public class NavItemHelper : Behavior<NavigationViewItem>
         }
     }
 
-    private void SelectionChanged(NavigationViewItem sender)
+    private void SelectionChanged(FANavigationViewItem sender)
     {
         if (sender.IsSelected)
         {

--- a/src/Beutl.Controls/Navigation/NavigationProvider.cs
+++ b/src/Beutl.Controls/Navigation/NavigationProvider.cs
@@ -11,16 +11,16 @@ namespace Beutl.Controls.Navigation;
 
 public class NavigationProvider : INavigationProvider
 {
-    private readonly Frame _frame;
+    private readonly FAFrame _frame;
     private readonly IPageResolver _pageResolver;
     private readonly TransitionMode _transitionMode;
-    private readonly EntranceNavigationTransitionInfo _transitionInfo = new();
+    private readonly FAEntranceNavigationTransitionInfo _transitionInfo = new();
     private const int Orientation_SameOrder = 0b_1_0_0_0;
     private const int Orientation_SameOrder_Reverse = 0b_0_1_0_0;
     private const int Orientation_DifferenceOrder = 0b_0_0_1_0;
     private const int Orientation_DifferenceOrder_Reverse = 0b_0_0_0_1;
 
-    public NavigationProvider(Frame frame, IPageResolver pageResolver, TransitionMode transitionMode = TransitionMode.LeftNavigationAndBreadcrumbs)
+    public NavigationProvider(FAFrame frame, IPageResolver pageResolver, TransitionMode transitionMode = TransitionMode.LeftNavigationAndBreadcrumbs)
     {
         _frame = frame;
         _pageResolver = pageResolver;
@@ -41,7 +41,7 @@ public class NavigationProvider : INavigationProvider
 
     public object? CurrentContext { get; private set; }
 
-    private void OnNavigating(object sender, NavigatingCancelEventArgs e)
+    private void OnNavigating(object sender, FANavigatingCancelEventArgs e)
     {
         static bool HasFlags(TransitionMode @enum, int flags)
         {
@@ -62,7 +62,7 @@ public class NavigationProvider : INavigationProvider
             }
         }
 
-        if (e.NavigationTransitionInfo is EntranceNavigationTransitionInfo entrance)
+        if (e.NavigationTransitionInfo is FAEntranceNavigationTransitionInfo entrance)
         {
             Type type1 = _frame.CurrentSourcePageType;
             Type type2 = e.SourcePageType;
@@ -90,7 +90,7 @@ public class NavigationProvider : INavigationProvider
         }
     }
 
-    private void OnNavigated(object sender, NavigationEventArgs e)
+    private void OnNavigated(object sender, FANavigationEventArgs e)
     {
         if (e.Content is Control control)
         {
@@ -126,7 +126,7 @@ public class NavigationProvider : INavigationProvider
     {
         for (int i = 0; i < _frame.BackStack.Count; i++)
         {
-            PageStackEntry item = _frame.BackStack[i];
+            FAPageStackEntry item = _frame.BackStack[i];
             if (item.Parameter is TContext typed && predicate(typed))
             {
                 return typed;
@@ -135,7 +135,7 @@ public class NavigationProvider : INavigationProvider
 
         for (int i = 0; i < _frame.ForwardStack.Count; i++)
         {
-            PageStackEntry item = _frame.ForwardStack[i];
+            FAPageStackEntry item = _frame.ForwardStack[i];
             if (item.Parameter is TContext typed && predicate(typed))
             {
                 return typed;
@@ -185,7 +185,7 @@ public class NavigationProvider : INavigationProvider
         {
             for (int i = _frame.BackStack.Count - 1; i >= 0; i--)
             {
-                PageStackEntry item = _frame.BackStack[i];
+                FAPageStackEntry item = _frame.BackStack[i];
                 if (item.Parameter is TContext typed && predicate(typed))
                 {
                     _frame.BackStack.RemoveAt(i);
@@ -199,7 +199,7 @@ public class NavigationProvider : INavigationProvider
 
             for (int i = _frame.ForwardStack.Count - 1; i >= 0; i--)
             {
-                PageStackEntry item = _frame.ForwardStack[i];
+                FAPageStackEntry item = _frame.ForwardStack[i];
                 if (item.Parameter is TContext typed && predicate(typed))
                 {
                     _frame.ForwardStack.RemoveAt(i);

--- a/src/Beutl.Controls/PropertyEditors/BrushEditorFlyout.cs
+++ b/src/Beutl.Controls/PropertyEditors/BrushEditorFlyout.cs
@@ -28,7 +28,7 @@ public enum BrushType
     Presenter
 }
 
-public sealed class BrushEditorFlyout : PickerFlyoutBase
+public sealed class BrushEditorFlyout : FAPickerFlyoutBase
 {
     public static readonly StyledProperty<Brush?> BrushProperty =
         AvaloniaProperty.Register<BrushEditorFlyout, Brush?>(nameof(Brush));

--- a/src/Beutl.Controls/PropertyEditors/ColorDropper.cs
+++ b/src/Beutl.Controls/PropertyEditors/ColorDropper.cs
@@ -8,7 +8,7 @@ namespace Beutl.Controls.PropertyEditors;
 
 public partial class ColorDropper : IDisposable
 {
-    private readonly DispatcherTimer _timer = new(DispatcherPriority.Normal);
+    private readonly DispatcherTimer _timer = new(DispatcherPriority.Normal, Dispatcher.UIThread);
     private readonly TaskCompletionSource<(Color2, int X, int Y)> _tcs;
     private readonly CancellationToken _ct;
 

--- a/src/Beutl.Controls/PropertyEditors/DraggablePickerFlyoutPresenter.cs
+++ b/src/Beutl.Controls/PropertyEditors/DraggablePickerFlyoutPresenter.cs
@@ -14,7 +14,7 @@ using FluentAvalonia.Core;
 
 namespace Beutl.Controls.PropertyEditors;
 
-// PickerFlyoutPresenter.cs
+// FAPickerFlyoutPresenter.cs
 public class DraggablePickerFlyoutPresenter : ContentControl
 {
     public static readonly StyledProperty<bool> ShowHideButtonsProperty =

--- a/src/Beutl.Controls/PropertyEditors/FontFamilyPickerFlyout.cs
+++ b/src/Beutl.Controls/PropertyEditors/FontFamilyPickerFlyout.cs
@@ -8,7 +8,7 @@ using FluentAvalonia.UI.Controls.Primitives;
 
 namespace Beutl.Controls.PropertyEditors;
 
-public sealed class FontFamilyPickerFlyout(FontFamilyPickerFlyoutViewModel viewModel) : PickerFlyoutBase
+public sealed class FontFamilyPickerFlyout(FontFamilyPickerFlyoutViewModel viewModel) : FAPickerFlyoutBase
 {
     public event TypedEventHandler<FontFamilyPickerFlyout, EventArgs> Confirmed;
 

--- a/src/Beutl.Controls/PropertyEditors/GradientStopsSlider.cs
+++ b/src/Beutl.Controls/PropertyEditors/GradientStopsSlider.cs
@@ -36,7 +36,7 @@ public class GradientStopsSlider : TemplatedControl
     private readonly GradientStops _unorderedStops = [];
     private IDisposable? _stopsSubscription;
     private FAMenuFlyout? _menuFlyout;
-    private MenuFlyoutItem? _deleteMenuItem;
+    private FAMenuFlyoutItem? _deleteMenuItem;
     private double _oldOffset;
     private int _oldIndex;
 
@@ -374,7 +374,7 @@ public class GradientStopsSlider : TemplatedControl
             if (_menuFlyout == null || _deleteMenuItem == null)
             {
                 _menuFlyout = new FAMenuFlyout();
-                _deleteMenuItem = new MenuFlyoutItem
+                _deleteMenuItem = new FAMenuFlyoutItem
                 {
                     Text = Strings.Delete,
                     IconSource = new FluentIconSource
@@ -384,7 +384,7 @@ public class GradientStopsSlider : TemplatedControl
                 };
                 _deleteMenuItem.Click += (s, e) =>
                 {
-                    if (s is MenuFlyoutItem { Tag: GradientStop obj } menu)
+                    if (s is FAMenuFlyoutItem { Tag: GradientStop obj } menu)
                     {
                         int index = Stops.IndexOf(obj);
                         if (ReferenceEquals(SelectedStop, obj))

--- a/src/Beutl.Controls/PropertyEditors/GradingColorPickerFlyout.cs
+++ b/src/Beutl.Controls/PropertyEditors/GradingColorPickerFlyout.cs
@@ -12,7 +12,7 @@ using FluentAvalonia.UI.Controls.Primitives;
 
 namespace Beutl.Controls.PropertyEditors;
 
-public sealed class GradingColorPickerFlyout : PickerFlyoutBase
+public sealed class GradingColorPickerFlyout : FAPickerFlyoutBase
 {
     private GradingColorPicker? _picker;
     private bool _showButtons = true;

--- a/src/Beutl.Controls/PropertyEditors/NumberEditor.cs
+++ b/src/Beutl.Controls/PropertyEditors/NumberEditor.cs
@@ -155,7 +155,7 @@ public class NumberEditor<TValue> : StringEditor
         }
     }
 
-    protected override void OnTextBoxGotFocus(GotFocusEventArgs e)
+    protected override void OnTextBoxGotFocus(FocusChangedEventArgs e)
     {
         if (!DataValidationErrors.GetHasErrors(InnerTextBox))
         {

--- a/src/Beutl.Controls/PropertyEditors/RationalEditor.cs
+++ b/src/Beutl.Controls/PropertyEditors/RationalEditor.cs
@@ -120,7 +120,7 @@ public class RationalEditor : StringEditor
         }
     }
 
-    protected override void OnTextBoxGotFocus(GotFocusEventArgs e)
+    protected override void OnTextBoxGotFocus(FocusChangedEventArgs e)
     {
         if (!DataValidationErrors.GetHasErrors(InnerTextBox))
         {

--- a/src/Beutl.Controls/PropertyEditors/RelativePointEditor.cs
+++ b/src/Beutl.Controls/PropertyEditors/RelativePointEditor.cs
@@ -123,7 +123,7 @@ public class RelativePointEditor : Vector2Editor
         UpdateErrors();
     }
 
-    private void OnInnerTextBoxGotFocus(object sender, GotFocusEventArgs e)
+    private void OnInnerTextBoxGotFocus(object sender, FocusChangedEventArgs e)
     {
         if (!DataValidationErrors.GetHasErrors(this))
         {

--- a/src/Beutl.Controls/PropertyEditors/RelativeRectEditor.cs
+++ b/src/Beutl.Controls/PropertyEditors/RelativeRectEditor.cs
@@ -174,7 +174,7 @@ public class RelativeRectEditor : Vector4Editor
         UpdateErrors();
     }
 
-    private void OnInnerTextBoxGotFocus(object sender, GotFocusEventArgs e)
+    private void OnInnerTextBoxGotFocus(object sender, FocusChangedEventArgs e)
     {
         if (!DataValidationErrors.GetHasErrors(this))
         {

--- a/src/Beutl.Controls/PropertyEditors/SimpleColorPicker.cs
+++ b/src/Beutl.Controls/PropertyEditors/SimpleColorPicker.cs
@@ -425,7 +425,7 @@ public class SimpleColorPicker : TemplatedControl
         }
     }
 
-    private void OnHexBoxGotFocus(object? sender, GotFocusEventArgs e)
+    private void OnHexBoxGotFocus(object? sender, FocusChangedEventArgs e)
     {
         _oldColor = Color;
     }

--- a/src/Beutl.Controls/PropertyEditors/SimpleColorPickerFlyout.cs
+++ b/src/Beutl.Controls/PropertyEditors/SimpleColorPickerFlyout.cs
@@ -8,7 +8,7 @@ using FluentAvalonia.UI.Controls.Primitives;
 
 namespace Beutl.Controls.PropertyEditors;
 
-public sealed class SimpleColorPickerFlyout : PickerFlyoutBase
+public sealed class SimpleColorPickerFlyout : FAPickerFlyoutBase
 {
     public SimpleColorPicker ColorPicker => _picker ??= new SimpleColorPicker();
 

--- a/src/Beutl.Controls/PropertyEditors/StorageFileEditor.cs
+++ b/src/Beutl.Controls/PropertyEditors/StorageFileEditor.cs
@@ -72,7 +72,7 @@ public class StorageFileEditor : StringEditor
         }
     }
 
-    protected override void OnTextBoxGotFocus(GotFocusEventArgs e)
+    protected override void OnTextBoxGotFocus(FocusChangedEventArgs e)
     {
         if (!DataValidationErrors.GetHasErrors(InnerTextBox))
         {

--- a/src/Beutl.Controls/PropertyEditors/StorageFileEditor.cs
+++ b/src/Beutl.Controls/PropertyEditors/StorageFileEditor.cs
@@ -60,7 +60,7 @@ public class StorageFileEditor : StringEditor
 
     private async void OnButtonClick(object sender, RoutedEventArgs e)
     {
-        if (VisualRoot is TopLevel { StorageProvider: { } storage })
+        if (TopLevel.GetTopLevel(this) is TopLevel { StorageProvider: { } storage })
         {
             IReadOnlyList<IStorageFile> result = await storage.OpenFilePickerAsync(OpenOptions);
             if (result is [var file] && file.TryGetLocalPath() is string localPath)

--- a/src/Beutl.Controls/PropertyEditors/StringEditor.cs
+++ b/src/Beutl.Controls/PropertyEditors/StringEditor.cs
@@ -81,7 +81,7 @@ public class StringEditor : PropertyEditor
         return measured;
     }
 
-    protected virtual void OnTextBoxGotFocus(GotFocusEventArgs e)
+    protected virtual void OnTextBoxGotFocus(FocusChangedEventArgs e)
     {
         _oldValue = Text;
     }

--- a/src/Beutl.Controls/PropertyEditors/TimeSpanEditor.cs
+++ b/src/Beutl.Controls/PropertyEditors/TimeSpanEditor.cs
@@ -50,7 +50,7 @@ public class TimeSpanEditor : StringEditor
             .DisposeWith(_disposables);
     }
 
-    protected override void OnTextBoxGotFocus(GotFocusEventArgs e)
+    protected override void OnTextBoxGotFocus(FocusChangedEventArgs e)
     {
         if (!DataValidationErrors.GetHasErrors(InnerTextBox))
         {

--- a/src/Beutl.Controls/PropertyEditors/Vector2Editor.cs
+++ b/src/Beutl.Controls/PropertyEditors/Vector2Editor.cs
@@ -218,7 +218,7 @@ public class Vector2Editor<TElement> : Vector2Editor
         }
     }
 
-    private void OnInnerTextBoxGotFocus(object sender, GotFocusEventArgs e)
+    private void OnInnerTextBoxGotFocus(object sender, FocusChangedEventArgs e)
     {
         if (!DataValidationErrors.GetHasErrors(this))
         {
@@ -498,7 +498,7 @@ public class Vector2Editor : PropertyEditor
         }
     }
 
-    private void OnInnerTextBoxGotFocus(object sender, GotFocusEventArgs e)
+    private void OnInnerTextBoxGotFocus(object sender, FocusChangedEventArgs e)
     {
         UpdateFocusState();
     }

--- a/src/Beutl.Controls/PropertyEditors/Vector3Editor.cs
+++ b/src/Beutl.Controls/PropertyEditors/Vector3Editor.cs
@@ -251,7 +251,7 @@ public class Vector3Editor<TElement> : Vector3Editor
         }
     }
 
-    private void OnInnerTextBoxGotFocus(object sender, GotFocusEventArgs e)
+    private void OnInnerTextBoxGotFocus(object sender, FocusChangedEventArgs e)
     {
         if (!DataValidationErrors.GetHasErrors(this))
         {
@@ -580,7 +580,7 @@ public class Vector3Editor : PropertyEditor
         }
     }
 
-    private void OnInnerTextBoxGotFocus(object sender, GotFocusEventArgs e)
+    private void OnInnerTextBoxGotFocus(object sender, FocusChangedEventArgs e)
     {
         UpdateFocusState();
     }

--- a/src/Beutl.Controls/PropertyEditors/Vector4Editor.cs
+++ b/src/Beutl.Controls/PropertyEditors/Vector4Editor.cs
@@ -258,7 +258,7 @@ public class Vector4Editor<TElement> : Vector4Editor
         }
     }
 
-    private void OnInnerTextBoxGotFocus(object sender, GotFocusEventArgs e)
+    private void OnInnerTextBoxGotFocus(object sender, FocusChangedEventArgs e)
     {
         if (!DataValidationErrors.GetHasErrors(this))
         {
@@ -639,7 +639,7 @@ public class Vector4Editor : PropertyEditor
         }
     }
 
-    private void OnInnerTextBoxGotFocus(object sender, GotFocusEventArgs e)
+    private void OnInnerTextBoxGotFocus(object sender, FocusChangedEventArgs e)
     {
         UpdateFocusState();
     }

--- a/src/Beutl.Controls/RenameFlyout.cs
+++ b/src/Beutl.Controls/RenameFlyout.cs
@@ -9,7 +9,7 @@ using FluentAvalonia.UI.Controls.Primitives;
 
 namespace Beutl.Controls;
 
-public sealed class RenameFlyout : PickerFlyoutBase
+public sealed class RenameFlyout : FAPickerFlyoutBase
 {
     public static readonly StyledProperty<string?> TextProperty
         = TextBox.TextProperty.AddOwner<RenameFlyout>();
@@ -27,7 +27,7 @@ public sealed class RenameFlyout : PickerFlyoutBase
     protected override Control CreatePresenter()
     {
         _textBox ??= new TextBox();
-        var pfp = new PickerFlyoutPresenter()
+        var pfp = new FAPickerFlyoutPresenter()
         {
             Width = 240,
             Padding = new(8, 4),
@@ -63,12 +63,12 @@ public sealed class RenameFlyout : PickerFlyoutBase
         _textBox.Text = Text;
     }
 
-    private void OnFlyoutDismissed(PickerFlyoutPresenter sender, object args)
+    private void OnFlyoutDismissed(FAPickerFlyoutPresenter sender, object args)
     {
         Hide();
     }
 
-    private void OnFlyoutConfirmed(PickerFlyoutPresenter sender, object args)
+    private void OnFlyoutConfirmed(FAPickerFlyoutPresenter sender, object args)
     {
         OnConfirmed();
     }

--- a/src/Beutl.Controls/SaveAsTemplateFlyout.cs
+++ b/src/Beutl.Controls/SaveAsTemplateFlyout.cs
@@ -8,7 +8,7 @@ using FluentAvalonia.UI.Controls.Primitives;
 
 namespace Beutl.Controls;
 
-public sealed class SaveAsTemplateFlyout : PickerFlyoutBase
+public sealed class SaveAsTemplateFlyout : FAPickerFlyoutBase
 {
     private TextBox? _textBox;
     private string _text = string.Empty;
@@ -30,7 +30,7 @@ public sealed class SaveAsTemplateFlyout : PickerFlyoutBase
     {
         _textBox ??= new TextBox { Watermark = Strings.EnterTemplateName };
         _textBox.Text = _text;
-        var pfp = new PickerFlyoutPresenter()
+        var pfp = new FAPickerFlyoutPresenter()
         {
             Width = 280,
             Padding = new(8, 4),
@@ -68,12 +68,12 @@ public sealed class SaveAsTemplateFlyout : PickerFlyoutBase
         _textBox.Focus();
     }
 
-    private void OnFlyoutDismissed(PickerFlyoutPresenter sender, object args)
+    private void OnFlyoutDismissed(FAPickerFlyoutPresenter sender, object args)
     {
         Hide();
     }
 
-    private void OnFlyoutConfirmed(PickerFlyoutPresenter sender, object args)
+    private void OnFlyoutConfirmed(FAPickerFlyoutPresenter sender, object args)
     {
         OnConfirmed();
     }

--- a/src/Beutl.Controls/SaveAsTemplateFlyout.cs
+++ b/src/Beutl.Controls/SaveAsTemplateFlyout.cs
@@ -28,7 +28,7 @@ public sealed class SaveAsTemplateFlyout : FAPickerFlyoutBase
 
     protected override Control CreatePresenter()
     {
-        _textBox ??= new TextBox { Watermark = Strings.EnterTemplateName };
+        _textBox ??= new TextBox { PlaceholderText = Strings.EnterTemplateName };
         _textBox.Text = _text;
         var pfp = new FAPickerFlyoutPresenter()
         {
@@ -62,7 +62,7 @@ public sealed class SaveAsTemplateFlyout : FAPickerFlyoutBase
     protected override void OnOpening(CancelEventArgs args)
     {
         base.OnOpening(args);
-        _textBox ??= new TextBox { Watermark = Strings.EnterTemplateName };
+        _textBox ??= new TextBox { PlaceholderText = Strings.EnterTemplateName };
         _textBox.Text = _text;
         _textBox.SelectAll();
         _textBox.Focus();

--- a/src/Beutl.Controls/Styles.axaml
+++ b/src/Beutl.Controls/Styles.axaml
@@ -187,7 +187,7 @@
         </Style>
     </Style>
 
-    <Style Selector="ui|ContentDialog /template/ ContentControl#Title">
+    <Style Selector="ui|FAContentDialog /template/ ContentControl#Title">
         <Setter Property="FontFamily" Value="{DynamicResource ContentControlThemeFontFamily}" />
     </Style>
 

--- a/src/Beutl.Controls/Styling/FlipButton.axaml
+++ b/src/Beutl.Controls/Styling/FlipButton.axaml
@@ -28,7 +28,7 @@
                             BorderThickness="{TemplateBinding BorderThickness}"
                             CornerRadius="{TemplateBinding CornerRadius}"
                             Opacity="0.8" />
-                    <ui:FontIcon Name="PART_Icon"
+                    <ui:FAFontIcon Name="PART_Icon"
                                  Margin="{TemplateBinding Padding}"
                                  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                  VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
@@ -40,23 +40,23 @@
             </ControlTemplate>
         </Setter>
 
-        <Style Selector="^.left /template/ ui|FontIcon#PART_Icon">
+        <Style Selector="^.left /template/ ui|FAFontIcon#PART_Icon">
             <Setter Property="Glyph" Value="&#xEDD9;" />
         </Style>
-        <Style Selector="^.right /template/ ui|FontIcon#PART_Icon">
+        <Style Selector="^.right /template/ ui|FAFontIcon#PART_Icon">
             <Setter Property="Glyph" Value="&#xEDDA;" />
         </Style>
         <Style Selector="^.up,^.down">
             <Setter Property="Padding" Value="16,5,16,5" />
         </Style>
-        <Style Selector="^.up /template/ ui|FontIcon#PART_Icon">
+        <Style Selector="^.up /template/ ui|FAFontIcon#PART_Icon">
             <Setter Property="Glyph" Value="&#xEDDB;" />
         </Style>
-        <Style Selector="^.down /template/ ui|FontIcon#PART_Icon">
+        <Style Selector="^.down /template/ ui|FAFontIcon#PART_Icon">
             <Setter Property="Glyph" Value="&#xEDDC;" />
         </Style>
 
-        <Style Selector="^ /template/ ui|FontIcon#PART_Icon">
+        <Style Selector="^ /template/ ui|FAFontIcon#PART_Icon">
             <Setter Property="Transitions">
                 <Transitions>
                     <BrushTransition Property="Foreground" Duration="00:00:00.083" />
@@ -65,11 +65,11 @@
             </Setter>
         </Style>
 
-        <Style Selector="^:pointerover /template/ ui|FontIcon#PART_Icon">
+        <Style Selector="^:pointerover /template/ ui|FAFontIcon#PART_Icon">
             <Setter Property="Foreground" Value="{DynamicResource TextFillColorSecondaryBrush}" />
         </Style>
 
-        <Style Selector="^:pressed /template/ ui|FontIcon#PART_Icon">
+        <Style Selector="^:pressed /template/ ui|FAFontIcon#PART_Icon">
             <Setter Property="Foreground" Value="{DynamicResource TextFillColorSecondaryBrush}" />
             <Setter Property="RenderTransform" Value="scale(0.9)" />
         </Style>
@@ -77,7 +77,7 @@
         <Style Selector="^:disabled /template/ Border#PART_Background">
             <Setter Property="Opacity" Value="0.5" />
         </Style>
-        <Style Selector="^:disabled /template/ ui|FontIcon#PART_Icon">
+        <Style Selector="^:disabled /template/ ui|FAFontIcon#PART_Icon">
             <Setter Property="Opacity" Value="0.5" />
         </Style>
     </ControlTheme>

--- a/src/Beutl.Controls/Styling/NavigationView.axaml
+++ b/src/Beutl.Controls/Styling/NavigationView.axaml
@@ -6,25 +6,25 @@
         xmlns:uip="using:FluentAvalonia.UI.Controls.Primitives">
     <Design.PreviewWith>
         <Border Width="700" Height="500">
-            <ui:NavigationView Classes="SideNavigationView">
-                <ui:NavigationView.MenuItems>
-                    <ui:NavigationViewItem Classes="SideNavigationViewItem" Content="Home">
-                        <ui:NavigationViewItem.IconSource>
+            <ui:FANavigationView Classes="SideNavigationView">
+                <ui:FANavigationView.MenuItems>
+                    <ui:FANavigationViewItem Classes="SideNavigationViewItem" Content="Home">
+                        <ui:FANavigationViewItem.IconSource>
                             <icons:FluentIconSource Icon="Home" />
-                        </ui:NavigationViewItem.IconSource>
-                    </ui:NavigationViewItem>
-                </ui:NavigationView.MenuItems>
-            </ui:NavigationView>
+                        </ui:FANavigationViewItem.IconSource>
+                    </ui:FANavigationViewItem>
+                </ui:FANavigationView.MenuItems>
+            </ui:FANavigationView>
         </Border>
     </Design.PreviewWith>
 
-    <Style Selector="ui|NavigationView.SideNavigationView">
+    <Style Selector="ui|FANavigationView.SideNavigationView">
         <Setter Property="CompactPaneLength" Value="64" />
         <Setter Property="IsPaneToggleButtonVisible" Value="False" />
         <Setter Property="PaneDisplayMode" Value="LeftCompact" />
     </Style>
 
-    <!--<Style Selector="ui|NavigationView.SideNavigationView /template/ SplitView Border#ContentGridBorder">
+    <!--<Style Selector="ui|FANavigationView.SideNavigationView /template/ SplitView Border#ContentGridBorder">
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="BorderBrush" Value="Transparent" />
         <Setter Property="BorderThickness" Value="0" />
@@ -32,11 +32,11 @@
         <Setter Property="CornerRadius" Value="{DynamicResource NavigationViewContentGridCornerRadius}" />
     </Style>-->
 
-    <Style Selector="ui|NavigationViewItem.SideNavigationViewItem">
+    <Style Selector="ui|FANavigationViewItem.SideNavigationViewItem">
         <Setter Property="Height" Value="56" />
     </Style>
 
-    <Style Selector="ui|NavigationViewItem.SideNavigationViewItem /template/ uip|NavigationViewItemPresenter#NVIPresenter:selected /template/ ContentPresenter#Icon">
+    <Style Selector="ui|FANavigationViewItem.SideNavigationViewItem /template/ uip|FANavigationViewItemPresenter#NVIPresenter:selected /template/ ContentPresenter#Icon">
         <Setter Property="TextBlock.Foreground" Value="{DynamicResource NavigationViewSelectionIndicatorForeground}" />
     </Style>
 </Styles>

--- a/src/Beutl.Controls/Styling/Player.axaml
+++ b/src/Beutl.Controls/Styling/Player.axaml
@@ -64,7 +64,7 @@
                                  controls:TextBoxAttachment.EnterDownBehavior="None"
                                  FontWeight="SemiBold"
                                  IsVisible="False"
-                                 Watermark="{x:Static lang:Strings.GotoTimecode_InputHint}" />
+                                 PlaceholderText="{x:Static lang:Strings.GotoTimecode_InputHint}" />
 
                         <Popup Name="PART_MarkerPopup"
                                Grid.Row="1"

--- a/src/Beutl.Controls/Styling/PropertyEditors/BrushEditorFlyoutPresenter.axaml
+++ b/src/Beutl.Controls/Styling/PropertyEditors/BrushEditorFlyoutPresenter.axaml
@@ -72,7 +72,7 @@
                                     </Border>
                                 </ToggleButton>
                                 <ToggleButton Name="PaletteTabButton">
-                                    <ui:FontIcon Glyph="&#xF0E2;" />
+                                    <ui:FAFontIcon Glyph="&#xF0E2;" />
                                 </ToggleButton>
                             </WrapPanel>
 
@@ -86,7 +86,7 @@
                                     HorizontalContentAlignment="Center"
                                     VerticalContentAlignment="Center"
                                     Theme="{StaticResource TransparentButton}">
-                                <ui:FontIcon FontFamily="{DynamicResource SymbolThemeFontFamily}" Glyph="&#xE711;" />
+                                <ui:FAFontIcon FontFamily="{DynamicResource SymbolThemeFontFamily}" Glyph="&#xE711;" />
                             </Button>
                         </Grid>
 
@@ -145,7 +145,7 @@
                                                    VerticalAlignment="Center"
                                                    Text="{TemplateBinding DrawableName}" />
 
-                                        <ui:FontIcon Grid.Column="1"
+                                        <ui:FAFontIcon Grid.Column="1"
                                                      MinHeight="{DynamicResource ComboBoxMinHeight}"
                                                      Margin="0,0,14,0"
                                                      HorizontalAlignment="Right"
@@ -248,7 +248,7 @@
                 <Setter Property="Margin" Value="0,0,4,0" />
                 <Setter Property="Theme" Value="{StaticResource ColorPickerTypeTransparentToggleButtonStyle}" />
 
-                <Style Selector="^ &gt; ui|FontIcon">
+                <Style Selector="^ &gt; ui|FAFontIcon">
                     <Setter Property="FontFamily" Value="{DynamicResource SymbolThemeFontFamily}" />
                 </Style>
 

--- a/src/Beutl.Controls/Styling/PropertyEditors/DraggablePickerFlyoutPresenter.axaml
+++ b/src/Beutl.Controls/Styling/PropertyEditors/DraggablePickerFlyoutPresenter.axaml
@@ -59,7 +59,7 @@
                                     HorizontalContentAlignment="Center"
                                     VerticalContentAlignment="Center"
                                     Theme="{StaticResource TransparentButton}">
-                                <ui:FontIcon FontFamily="{DynamicResource SymbolThemeFontFamily}" Glyph="&#xE711;" />
+                                <ui:FAFontIcon FontFamily="{DynamicResource SymbolThemeFontFamily}" Glyph="&#xE711;" />
                             </Button>
                         </Panel>
 

--- a/src/Beutl.Controls/Styling/PropertyEditors/ExpressionEditorFlyoutPresenter.axaml
+++ b/src/Beutl.Controls/Styling/PropertyEditors/ExpressionEditorFlyoutPresenter.axaml
@@ -56,7 +56,7 @@
                                     HorizontalContentAlignment="Center"
                                     VerticalContentAlignment="Center"
                                     Theme="{StaticResource TransparentButton}">
-                                <ui:FontIcon FontFamily="{DynamicResource SymbolThemeFontFamily}" Glyph="&#xE711;" />
+                                <ui:FAFontIcon FontFamily="{DynamicResource SymbolThemeFontFamily}" Glyph="&#xE711;" />
                             </Button>
                         </Grid>
 

--- a/src/Beutl.Controls/Styling/PropertyEditors/ExpressionEditorFlyoutPresenter.axaml
+++ b/src/Beutl.Controls/Styling/PropertyEditors/ExpressionEditorFlyoutPresenter.axaml
@@ -73,7 +73,7 @@
                                          MinHeight="100"
                                          MaxHeight="200"
                                          TextWrapping="Wrap"
-                                         Watermark="Sin(Time * 2 * PI) * 100"
+                                         PlaceholderText="Sin(Time * 2 * PI) * 100"
                                          Text="{TemplateBinding ExpressionText, Mode=TwoWay}"
                                          VerticalContentAlignment="Top" />
                                 <TextBlock Name="ErrorTextBlock"

--- a/src/Beutl.Controls/Styling/PropertyEditors/GradingColorPicker.axaml
+++ b/src/Beutl.Controls/Styling/PropertyEditors/GradingColorPicker.axaml
@@ -83,7 +83,7 @@
                                         Orientation="Horizontal"
                                         Spacing="4">
                                 <ToggleButton Name="ToggleDetailsButton" ToolTip.Tip="{x:Static lang:Strings.ShowSliders}">
-                                    <ui:FontIcon Glyph="&#xE9E9;" />
+                                    <ui:FAFontIcon Glyph="&#xE9E9;" />
                                 </ToggleButton>
                             </StackPanel>
 
@@ -111,7 +111,7 @@
             <Setter Property="VerticalContentAlignment" Value="Center" />
             <Setter Property="Theme" Value="{StaticResource TransparentToggleButton}" />
 
-            <Style Selector="^ &gt; ui|FontIcon">
+            <Style Selector="^ &gt; ui|FAFontIcon">
                 <Setter Property="FontFamily" Value="{DynamicResource SymbolThemeFontFamily}" />
             </Style>
         </Style>

--- a/src/Beutl.Controls/Styling/PropertyEditors/LibraryItemPickerFlyoutPresenter.axaml
+++ b/src/Beutl.Controls/Styling/PropertyEditors/LibraryItemPickerFlyoutPresenter.axaml
@@ -209,7 +209,7 @@
                                     HorizontalContentAlignment="Center"
                                     VerticalContentAlignment="Center"
                                     Theme="{StaticResource TransparentButton}">
-                                <ui:FontIcon FontFamily="{DynamicResource SymbolThemeFontFamily}" Glyph="&#xE711;" />
+                                <ui:FAFontIcon FontFamily="{DynamicResource SymbolThemeFontFamily}" Glyph="&#xE711;" />
                             </Button>
                         </Grid>
 

--- a/src/Beutl.Controls/Styling/PropertyEditors/LibraryItemPickerFlyoutPresenter.axaml
+++ b/src/Beutl.Controls/Styling/PropertyEditors/LibraryItemPickerFlyoutPresenter.axaml
@@ -247,7 +247,7 @@
                                      Classes="clearButton"
                                      IsVisible="False"
                                      Text="{TemplateBinding SearchText, Mode=TwoWay}"
-                                     Watermark="{x:Static lang:Strings.Search}" />
+                                     PlaceholderText="{x:Static lang:Strings.Search}" />
 
                             <ListBox x:Name="PART_ListBox"
                                      Height="250"

--- a/src/Beutl.Controls/Styling/PropertyEditors/OutputPickerFlyoutPresenter.axaml
+++ b/src/Beutl.Controls/Styling/PropertyEditors/OutputPickerFlyoutPresenter.axaml
@@ -229,7 +229,7 @@
                                     HorizontalContentAlignment="Center"
                                     VerticalContentAlignment="Center"
                                     Theme="{StaticResource TransparentButton}">
-                                <ui:FontIcon FontFamily="{DynamicResource SymbolThemeFontFamily}" Glyph="&#xE711;" />
+                                <ui:FAFontIcon FontFamily="{DynamicResource SymbolThemeFontFamily}" Glyph="&#xE711;" />
                             </Button>
                         </Grid>
 

--- a/src/Beutl.Controls/Styling/PropertyEditors/OutputPickerFlyoutPresenter.axaml
+++ b/src/Beutl.Controls/Styling/PropertyEditors/OutputPickerFlyoutPresenter.axaml
@@ -267,7 +267,7 @@
                                      Classes="clearButton"
                                      IsVisible="False"
                                      Text="{TemplateBinding SearchText, Mode=TwoWay}"
-                                     Watermark="{x:Static lang:Strings.Search}" />
+                                     PlaceholderText="{x:Static lang:Strings.Search}" />
 
                             <ListBox x:Name="PART_ProfileListBox"
                                      Height="250"

--- a/src/Beutl.Controls/Styling/PropertyEditors/SimpleColorPicker.axaml
+++ b/src/Beutl.Controls/Styling/PropertyEditors/SimpleColorPicker.axaml
@@ -83,13 +83,13 @@
                                         Orientation="Horizontal"
                                         Spacing="4">
                                 <ToggleButton Name="ToggleDetailsButton" ToolTip.Tip="{x:Static lang:Strings.ShowSliders}">
-                                    <ui:FontIcon Glyph="&#xE9E9;" />
+                                    <ui:FAFontIcon Glyph="&#xE9E9;" />
                                 </ToggleButton>
                                 <ToggleButton Name="ToggleSpectrumShapeButton" ToolTip.Tip="{x:Static lang:Strings.ShowRing}">
-                                    <ui:FontIcon Glyph="&#xEA3A;" />
+                                    <ui:FAFontIcon Glyph="&#xEA3A;" />
                                 </ToggleButton>
                                 <ToggleButton Name="ColorDropperButton" IsVisible="False">
-                                    <ui:FontIcon Glyph="&#xEF3C;" />
+                                    <ui:FAFontIcon Glyph="&#xEF3C;" />
                                 </ToggleButton>
                             </StackPanel>
 
@@ -129,7 +129,7 @@
             <Setter Property="VerticalContentAlignment" Value="Center" />
             <Setter Property="Theme" Value="{StaticResource TransparentToggleButton}" />
 
-            <Style Selector="^ > ui|FontIcon">
+            <Style Selector="^ > ui|FAFontIcon">
                 <Setter Property="FontFamily" Value="{DynamicResource SymbolThemeFontFamily}" />
             </Style>
         </Style>

--- a/src/Beutl.Controls/Styling/PropertyEditors/SimpleColorPickerFlyoutPresenter.axaml
+++ b/src/Beutl.Controls/Styling/PropertyEditors/SimpleColorPickerFlyoutPresenter.axaml
@@ -41,10 +41,10 @@
                               ColumnDefinitions="*,Auto">
                             <WrapPanel Name="TabLayout" Margin="4,4,0,4">
                                 <RadioButton Name="SpectrumTabButton">
-                                    <ui:FontIcon Glyph="&#xE76D;" />
+                                    <ui:FAFontIcon Glyph="&#xE76D;" />
                                 </RadioButton>
                                 <RadioButton Name="PaletteTabButton">
-                                    <ui:FontIcon Glyph="&#xF0E2;" />
+                                    <ui:FAFontIcon Glyph="&#xF0E2;" />
                                 </RadioButton>
                             </WrapPanel>
 
@@ -58,7 +58,7 @@
                                     HorizontalContentAlignment="Center"
                                     VerticalContentAlignment="Center"
                                     Theme="{StaticResource TransparentButton}">
-                                <ui:FontIcon FontFamily="{DynamicResource SymbolThemeFontFamily}" Glyph="&#xE711;" />
+                                <ui:FAFontIcon FontFamily="{DynamicResource SymbolThemeFontFamily}" Glyph="&#xE711;" />
                             </Button>
                         </Grid>
 
@@ -151,7 +151,7 @@
                 <Setter Property="Margin" Value="0,0,4,0" />
                 <Setter Property="Theme" Value="{StaticResource ColorPickerTypeTransparentToggleButtonStyle}" />
 
-                <Style Selector="^ &gt; ui|FontIcon">
+                <Style Selector="^ &gt; ui|FAFontIcon">
                     <Setter Property="FontFamily" Value="{DynamicResource SymbolThemeFontFamily}" />
                 </Style>
             </Style>

--- a/src/Beutl.Controls/Styling/PropertyEditors/Vector2Editor.axaml
+++ b/src/Beutl.Controls/Styling/PropertyEditors/Vector2Editor.axaml
@@ -73,7 +73,7 @@
                                            FontSize="{TemplateBinding FontSize}"
                                            Foreground="{DynamicResource SystemAccentColor}"
                                            IsVisible="False"
-                                           Text="{TemplateBinding Watermark}" />
+                                           Text="{TemplateBinding PlaceholderText}" />
                                 <ScrollViewer AllowAutoHide="{TemplateBinding (ScrollViewer.AllowAutoHide)}"
                                               HorizontalScrollBarVisibility="{TemplateBinding (ScrollViewer.HorizontalScrollBarVisibility)}"
                                               IsScrollChainingEnabled="{TemplateBinding (ScrollViewer.IsScrollChainingEnabled)}"
@@ -84,7 +84,7 @@
                                                    VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                                    IsVisible="{TemplateBinding Text, Converter={x:Static StringConverters.IsNullOrEmpty}}"
                                                    Opacity="0.5"
-                                                   Text="{TemplateBinding Watermark}"
+                                                   Text="{TemplateBinding PlaceholderText}"
                                                    TextAlignment="{TemplateBinding TextAlignment}"
                                                    TextWrapping="{TemplateBinding TextWrapping}" />
                                         <TextPresenter Name="PART_TextPresenter"

--- a/src/Beutl.Editor.Components/AudioVisualizerTab/Views/AudioVisualizerControlBase.cs
+++ b/src/Beutl.Editor.Components/AudioVisualizerTab/Views/AudioVisualizerControlBase.cs
@@ -60,7 +60,7 @@ public abstract class AudioVisualizerControlBase : Control
     protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
     {
         base.OnAttachedToVisualTree(e);
-        _timer ??= new DispatcherTimer(TimeSpan.FromMilliseconds(33), DispatcherPriority.Render, (_, _) => InvalidateVisual());
+        _timer ??= new DispatcherTimer(TimeSpan.FromMilliseconds(33), DispatcherPriority.Render, Dispatcher, (_, _) => InvalidateVisual());
         UpdateTimerState();
     }
 

--- a/src/Beutl.Editor.Components/EqualizerProperties/Views/EqualizerCurveEditor.cs
+++ b/src/Beutl.Editor.Components/EqualizerProperties/Views/EqualizerCurveEditor.cs
@@ -313,7 +313,7 @@ public sealed class EqualizerCurveEditor : Control
     {
         if (_wheelCommitTimer is null)
         {
-            _wheelCommitTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(400) };
+            _wheelCommitTimer = new DispatcherTimer(DispatcherPriority.Background, Dispatcher) { Interval = TimeSpan.FromMilliseconds(400) };
             _wheelCommitTimer.Tick += OnWheelCommitTick;
         }
         _wheelCommitTimer.Stop();

--- a/src/Beutl.Editor.Components/FileBrowserTab/ViewModels/FileBrowserTabViewModel.cs
+++ b/src/Beutl.Editor.Components/FileBrowserTab/ViewModels/FileBrowserTabViewModel.cs
@@ -329,17 +329,17 @@ public sealed class FileBrowserTabViewModel : IToolContext
     public async Task DeleteItemAsync(FileSystemItemViewModel item)
     {
         if (!CanMutateItem(item)) return;
-        var dialog = new ContentDialog
+        var dialog = new FAContentDialog
         {
             Title = Strings.Delete,
             Content = string.Format(MessageStrings.ConfirmDeleteFile, item.Name.Value),
             PrimaryButtonText = Strings.Yes,
             CloseButtonText = Strings.No,
-            DefaultButton = ContentDialogButton.Close
+            DefaultButton = FAContentDialogButton.Close
         };
 
         var result = await dialog.ShowAsync();
-        if (result == ContentDialogResult.Primary)
+        if (result == FAContentDialogResult.Primary)
         {
             try
             {
@@ -373,17 +373,17 @@ public sealed class FileBrowserTabViewModel : IToolContext
             return;
         }
 
-        var dialog = new ContentDialog
+        var dialog = new FAContentDialog
         {
             Title = Strings.Delete,
             Content = string.Format(Strings.DeleteSelectedItems, items.Count),
             PrimaryButtonText = Strings.Yes,
             CloseButtonText = Strings.No,
-            DefaultButton = ContentDialogButton.Close
+            DefaultButton = FAContentDialogButton.Close
         };
 
         var result = await dialog.ShowAsync();
-        if (result == ContentDialogResult.Primary)
+        if (result == FAContentDialogResult.Primary)
         {
             foreach (var item in items)
             {
@@ -444,7 +444,7 @@ public sealed class FileBrowserTabViewModel : IToolContext
 
         if (File.Exists(newPath) || Directory.Exists(newPath))
         {
-            var dialog = new ContentDialog
+            var dialog = new FAContentDialog
             {
                 Title = Strings.Error,
                 Content = string.Format(MessageStrings.RenameConflict, item.Name.Value, newName),

--- a/src/Beutl.Editor.Components/FileBrowserTab/Views/FileBrowserTabView.axaml
+++ b/src/Beutl.Editor.Components/FileBrowserTab/Views/FileBrowserTabView.axaml
@@ -134,24 +134,24 @@
                 </Button>
 
                 <!--  パス表示（ディレクトリブラウズ時）  -->
-                <ui:BreadcrumbBar Grid.Column="1"
+                <ui:FABreadcrumbBar Grid.Column="1"
                                   Margin="8,0"
                                   VerticalAlignment="Center"
                                   IsVisible="{Binding !IsHomeView.Value}"
                                   ItemClicked="BreadcrumbBarItemClicked"
                                   ItemsSource="{Binding BreadcrumbItems}">
-                    <ui:BreadcrumbBar.ItemTemplate>
+                    <ui:FABreadcrumbBar.ItemTemplate>
                         <DataTemplate x:DataType="vm:BreadcrumbPathItem">
-                            <ui:BreadcrumbBarItem Content="{Binding}">
-                                <ui:BreadcrumbBarItem.ContentTemplate>
+                            <ui:FABreadcrumbBarItem Content="{Binding}">
+                                <ui:FABreadcrumbBarItem.ContentTemplate>
                                     <DataTemplate DataType="vm:BreadcrumbPathItem">
                                         <TextBlock Text="{Binding Name}" />
                                     </DataTemplate>
-                                </ui:BreadcrumbBarItem.ContentTemplate>
-                            </ui:BreadcrumbBarItem>
+                                </ui:FABreadcrumbBarItem.ContentTemplate>
+                            </ui:FABreadcrumbBarItem>
                         </DataTemplate>
-                    </ui:BreadcrumbBar.ItemTemplate>
-                </ui:BreadcrumbBar>
+                    </ui:FABreadcrumbBar.ItemTemplate>
+                </ui:FABreadcrumbBar>
 
                 <!--  ホームヘッダー（ホームビュー時）  -->
                 <TextBlock Grid.Column="1"
@@ -375,7 +375,7 @@
                                         IsVisible="{Binding IsLoadingMediaFiles.Value}"
                                         Orientation="Horizontal"
                                         Spacing="8">
-                                <ui:ProgressRing Width="20"
+                                <ui:FAProgressRing Width="20"
                                                  Height="20"
                                                  IsIndeterminate="True" />
                                 <TextBlock VerticalAlignment="Center"

--- a/src/Beutl.Editor.Components/FileBrowserTab/Views/FileBrowserTabView.axaml.cs
+++ b/src/Beutl.Editor.Components/FileBrowserTab/Views/FileBrowserTabView.axaml.cs
@@ -196,7 +196,7 @@ public partial class FileBrowserTabView : UserControl
         flyout.ShowAt(target, true);
     }
 
-    private void BreadcrumbBarItemClicked(BreadcrumbBar sender, BreadcrumbBarItemClickedEventArgs args)
+    private void BreadcrumbBarItemClicked(FABreadcrumbBar sender, FABreadcrumbBarItemClickedEventArgs args)
     {
         ViewModel?.NavigateToBreadcrumb(args.Index);
     }

--- a/src/Beutl.Editor.Components/FileBrowserTab/Views/FileItemDragBehavior.cs
+++ b/src/Beutl.Editor.Components/FileBrowserTab/Views/FileItemDragBehavior.cs
@@ -13,6 +13,7 @@ public class FileItemDragBehavior : Behavior<Control>
 {
     private const double DragThreshold = 5;
     private Point? _dragStartPoint;
+    private PointerPressedEventArgs? _dragStartEvent;
     private FileSystemItemViewModel? _dragItem;
     private bool _isDragStarting;
 
@@ -28,6 +29,7 @@ public class FileItemDragBehavior : Behavior<Control>
         {
             AssociatedObject.PointerPressed += OnPointerPressed;
             AssociatedObject.PointerMoved += OnPointerMoved;
+            AssociatedObject.PointerReleased += OnPointerReleased;
         }
     }
 
@@ -37,9 +39,23 @@ public class FileItemDragBehavior : Behavior<Control>
         {
             AssociatedObject.PointerPressed -= OnPointerPressed;
             AssociatedObject.PointerMoved -= OnPointerMoved;
+            AssociatedObject.PointerReleased -= OnPointerReleased;
         }
 
+        _dragStartEvent = null;
+        _dragStartPoint = null;
+        _dragItem = null;
         base.OnDetaching();
+    }
+
+    private void OnPointerReleased(object? sender, PointerReleasedEventArgs e)
+    {
+        if (!_isDragStarting)
+        {
+            _dragStartEvent = null;
+            _dragStartPoint = null;
+            _dragItem = null;
+        }
     }
 
     private void OnPointerPressed(object? sender, PointerPressedEventArgs e)
@@ -50,6 +66,7 @@ public class FileItemDragBehavior : Behavior<Control>
         if (e.GetCurrentPoint(AssociatedObject).Properties.IsLeftButtonPressed
             && sender is Control { DataContext: FileSystemItemViewModel item })
         {
+            _dragStartEvent = e;
             _dragStartPoint = e.GetPosition(AssociatedObject);
             _dragItem = item;
         }
@@ -57,11 +74,12 @@ public class FileItemDragBehavior : Behavior<Control>
 
     private async void OnPointerMoved(object? sender, PointerEventArgs e)
     {
-        if (_dragStartPoint == null || _dragItem == null || _isDragStarting || AssociatedObject == null)
+        if (_dragStartEvent == null || _dragStartPoint == null || _dragItem == null || _isDragStarting || AssociatedObject == null)
             return;
 
         if (!e.GetCurrentPoint(AssociatedObject).Properties.IsLeftButtonPressed)
         {
+            _dragStartEvent = null;
             _dragStartPoint = null;
             _dragItem = null;
             return;
@@ -77,6 +95,7 @@ public class FileItemDragBehavior : Behavior<Control>
         if (TopLevel.GetTopLevel(AssociatedObject) is not { StorageProvider: IStorageProvider storageProvider })
             return;
 
+        PointerPressedEventArgs dragStartEvent = _dragStartEvent;
         _isDragStarting = true;
         IsInternalDragInProgress = true;
         try
@@ -104,10 +123,11 @@ public class FileItemDragBehavior : Behavior<Control>
 
             // 外部アプリ（Finder/Explorer等）にMoveを要求させないため、ソース側ではCopyのみを許可する。
             // FileBrowserTab内部での移動は、ドロップハンドラ側で IsInternalDragInProgress を見て実施する。
-            await DragDrop.DoDragDropAsync(e, data, DragDropEffects.Copy);
+            await DragDrop.DoDragDropAsync(dragStartEvent, data, DragDropEffects.Copy);
         }
         finally
         {
+            _dragStartEvent = null;
             _dragStartPoint = null;
             _dragItem = null;
             _isDragStarting = false;

--- a/src/Beutl.Editor.Components/Helpers/DataContextEvents.cs
+++ b/src/Beutl.Editor.Components/Helpers/DataContextEvents.cs
@@ -8,9 +8,12 @@ public static class DataContextEvents
         where T : class
     {
         T? prevContext = null;
+        bool isDisposed = false;
 
         void OnAttachedToLogicalTree(object? sender, Avalonia.LogicalTree.LogicalTreeAttachmentEventArgs e)
         {
+            if (isDisposed) return;
+
             if (self.DataContext is T newContext && prevContext != newContext)
             {
                 attached?.Invoke(newContext);
@@ -20,6 +23,8 @@ public static class DataContextEvents
 
         void OnDetachedFromLogicalTree(object? sender, Avalonia.LogicalTree.LogicalTreeAttachmentEventArgs e)
         {
+            if (isDisposed) return;
+
             if (prevContext != null)
             {
                 detached?.Invoke(prevContext);
@@ -29,6 +34,8 @@ public static class DataContextEvents
 
         void OnDataContextChanged(object? sender, EventArgs e)
         {
+            if (isDisposed) return;
+
             if (prevContext != null)
             {
                 detached?.Invoke(prevContext);
@@ -54,8 +61,16 @@ public static class DataContextEvents
 
         return Disposable.Create(self, s =>
         {
+            // An event invocation may already hold this handler when another handler disposes us.
+            isDisposed = true;
             s.AttachedToLogicalTree -= OnAttachedToLogicalTree;
             s.DetachedFromLogicalTree -= OnDetachedFromLogicalTree;
+            s.DataContextChanged -= OnDataContextChanged;
+            if (prevContext is { } context)
+            {
+                prevContext = null;
+                detached?.Invoke(context);
+            }
         });
     }
 }

--- a/src/Beutl.Editor.Components/Helpers/DataContextEvents.cs
+++ b/src/Beutl.Editor.Components/Helpers/DataContextEvents.cs
@@ -10,54 +10,52 @@ public static class DataContextEvents
         T? prevContext = null;
         bool isDisposed = false;
 
-        void OnAttachedToLogicalTree(object? sender, Avalonia.LogicalTree.LogicalTreeAttachmentEventArgs e)
+        void AttachContext()
         {
             if (isDisposed) return;
 
             if (self.DataContext is T newContext && prevContext != newContext)
             {
-                attached?.Invoke(newContext);
+                // Callbacks may synchronously dispose the subscription or change the context.
                 prevContext = newContext;
+                attached?.Invoke(newContext);
             }
+        }
+
+        void DetachContext()
+        {
+            if (prevContext is { } context)
+            {
+                prevContext = null;
+                detached?.Invoke(context);
+            }
+        }
+
+        void OnAttachedToLogicalTree(object? sender, Avalonia.LogicalTree.LogicalTreeAttachmentEventArgs e)
+        {
+            AttachContext();
         }
 
         void OnDetachedFromLogicalTree(object? sender, Avalonia.LogicalTree.LogicalTreeAttachmentEventArgs e)
         {
             if (isDisposed) return;
 
-            if (prevContext != null)
-            {
-                detached?.Invoke(prevContext);
-                prevContext = null;
-            }
+            DetachContext();
         }
 
         void OnDataContextChanged(object? sender, EventArgs e)
         {
             if (isDisposed) return;
 
-            if (prevContext != null)
-            {
-                detached?.Invoke(prevContext);
-                prevContext = null;
-            }
-
-            if (self.DataContext is T newContext && prevContext != newContext)
-            {
-                attached?.Invoke(newContext);
-                prevContext = newContext;
-            }
+            DetachContext();
+            AttachContext();
         }
 
         self.AttachedToLogicalTree += OnAttachedToLogicalTree;
         self.DetachedFromLogicalTree += OnDetachedFromLogicalTree;
         self.DataContextChanged += OnDataContextChanged;
 
-        if (self.DataContext is T newContext && prevContext != newContext)
-        {
-            attached?.Invoke(newContext);
-            prevContext = newContext;
-        }
+        AttachContext();
 
         return Disposable.Create(self, s =>
         {
@@ -66,11 +64,7 @@ public static class DataContextEvents
             s.AttachedToLogicalTree -= OnAttachedToLogicalTree;
             s.DetachedFromLogicalTree -= OnDetachedFromLogicalTree;
             s.DataContextChanged -= OnDataContextChanged;
-            if (prevContext is { } context)
-            {
-                prevContext = null;
-                detached?.Invoke(context);
-            }
+            DetachContext();
         });
     }
 }

--- a/src/Beutl.Editor.Components/LibraryTab/Views/LibraryTabView.axaml.cs
+++ b/src/Beutl.Editor.Components/LibraryTab/Views/LibraryTabView.axaml.cs
@@ -36,8 +36,9 @@ public sealed partial class LibraryTabView : UserControl
             .Select(item =>
             {
                 var tabItem = new TabStripItem();
-                var binding = new Binding($"{nameof(LibraryTabViewModel.LibraryTabDisplayModes)}[{item.Id}]", BindingMode.OneWay)
+                var binding = new ReflectionBinding($"{nameof(LibraryTabViewModel.LibraryTabDisplayModes)}[{item.Id}]")
                 {
+                    Mode = BindingMode.OneWay,
                     Converter = new FuncValueConverter<LibraryTabDisplayMode, bool>(v => v == LibraryTabDisplayMode.Show)
                 };
                 tabItem.Bind(IsVisibleProperty, binding);
@@ -49,9 +50,9 @@ public sealed partial class LibraryTabView : UserControl
                         new TextBlock { Text = item.Text }
                     }
                 };
-                var switchMenu = new ToggleMenuFlyoutItem
+                var switchMenu = new FAToggleMenuFlyoutItem
                 {
-                    [!ToggleMenuFlyoutItem.IsCheckedProperty] = binding,
+                    [!FAToggleMenuFlyoutItem.IsCheckedProperty] = binding,
                     Text = Strings.AlwaysDisplay
                 };
                 switchMenu.Click += (s, e) =>
@@ -75,13 +76,14 @@ public sealed partial class LibraryTabView : UserControl
         {
             ItemsSource = s_tabItems.Select(item =>
             {
-                var binding = new Binding($"{nameof(LibraryTabViewModel.LibraryTabDisplayModes)}[{item.Id}]", BindingMode.OneWay)
+                var binding = new ReflectionBinding($"{nameof(LibraryTabViewModel.LibraryTabDisplayModes)}[{item.Id}]")
                 {
+                    Mode = BindingMode.OneWay,
                     Converter = new FuncValueConverter<LibraryTabDisplayMode, bool>(v => v == LibraryTabDisplayMode.Show)
                 };
-                var switchMenu = new ToggleMenuFlyoutItem
+                var switchMenu = new FAToggleMenuFlyoutItem
                 {
-                    [!ToggleMenuFlyoutItem.IsCheckedProperty] = binding,
+                    [!FAToggleMenuFlyoutItem.IsCheckedProperty] = binding,
                     Text = item.Text
                 };
                 switchMenu.Click += (s, e) =>

--- a/src/Beutl.Editor.Components/LibraryTab/Views/LibraryViews/SearchView.axaml
+++ b/src/Beutl.Editor.Components/LibraryTab/Views/LibraryViews/SearchView.axaml
@@ -15,7 +15,7 @@
         <TextBox x:Name="SearchBox"
                  Classes="clearButton"
                  InputMethod.IsInputMethodEnabled="True"
-                 Watermark="{x:Static lang:Strings.Search}" />
+                 PlaceholderText="{x:Static lang:Strings.Search}" />
 
         <ListBox x:Name="searchResult"
                  Grid.Row="2"

--- a/src/Beutl.Editor.Components/NodeGraphTab/Views/GraphNodeView.axaml
+++ b/src/Beutl.Editor.Components/NodeGraphTab/Views/GraphNodeView.axaml
@@ -35,18 +35,18 @@
                 Focusable="True">
             <Border.ContextFlyout>
                 <ui:FAMenuFlyout>
-                    <ui:MenuFlyoutItem Command="{Binding Delete}"
+                    <ui:FAMenuFlyoutItem Command="{Binding Delete}"
                                        InputGesture="Delete"
                                        Text="{x:Static lang:Strings.Delete}">
-                        <ui:MenuFlyoutItem.IconSource>
+                        <ui:FAMenuFlyoutItem.IconSource>
                             <icons:FluentIconSource Icon="Delete" />
-                        </ui:MenuFlyoutItem.IconSource>
-                    </ui:MenuFlyoutItem>
-                    <ui:MenuFlyoutItem Click="RenameClick" Text="{x:Static lang:Strings.Rename}">
-                        <ui:MenuFlyoutItem.IconSource>
+                        </ui:FAMenuFlyoutItem.IconSource>
+                    </ui:FAMenuFlyoutItem>
+                    <ui:FAMenuFlyoutItem Click="RenameClick" Text="{x:Static lang:Strings.Rename}">
+                        <ui:FAMenuFlyoutItem.IconSource>
                             <icons:FluentIconSource Icon="Rename" />
-                        </ui:MenuFlyoutItem.IconSource>
-                    </ui:MenuFlyoutItem>
+                        </ui:FAMenuFlyoutItem.IconSource>
+                    </ui:FAMenuFlyoutItem>
                 </ui:FAMenuFlyout>
             </Border.ContextFlyout>
             <Border.KeyBindings>

--- a/src/Beutl.Editor.Components/NodeGraphTab/Views/NodeGraphTabView.axaml
+++ b/src/Beutl.Editor.Components/NodeGraphTab/Views/NodeGraphTabView.axaml
@@ -15,20 +15,20 @@
     <Grid RowDefinitions="Auto,*">
         <local:NodeGraphView Grid.RowSpan="2" DataContext="{Binding NodeGraph.Value}" />
 
-        <ui:BreadcrumbBar Margin="8"
+        <ui:FABreadcrumbBar Margin="8"
                           ItemClicked="BreadcrumbBarItemClicked"
                           ItemsSource="{Binding Items}">
-            <ui:BreadcrumbBar.ItemTemplate>
+            <ui:FABreadcrumbBar.ItemTemplate>
                 <DataTemplate x:DataType="viewModel:NodeGraphNavigationItem">
-                     <ui:BreadcrumbBarItem Content="{Binding}">
-                            <ui:BreadcrumbBarItem.ContentTemplate>
+                     <ui:FABreadcrumbBarItem Content="{Binding}">
+                            <ui:FABreadcrumbBarItem.ContentTemplate>
                                 <DataTemplate DataType="viewModel:NodeGraphNavigationItem">
                                     <TextBlock Text="{Binding Name.Value}" />
                                 </DataTemplate>
-                            </ui:BreadcrumbBarItem.ContentTemplate>
-                        </ui:BreadcrumbBarItem>
+                            </ui:FABreadcrumbBarItem.ContentTemplate>
+                        </ui:FABreadcrumbBarItem>
                 </DataTemplate>
-            </ui:BreadcrumbBar.ItemTemplate>
-        </ui:BreadcrumbBar>
+            </ui:FABreadcrumbBar.ItemTemplate>
+        </ui:FABreadcrumbBar>
     </Grid>
 </UserControl>

--- a/src/Beutl.Editor.Components/NodeGraphTab/Views/NodeGraphTabView.axaml.cs
+++ b/src/Beutl.Editor.Components/NodeGraphTab/Views/NodeGraphTabView.axaml.cs
@@ -13,7 +13,7 @@ public partial class NodeGraphTabView : UserControl
         InitializeComponent();
     }
 
-    private void BreadcrumbBarItemClicked(BreadcrumbBar sender, BreadcrumbBarItemClickedEventArgs args)
+    private void BreadcrumbBarItemClicked(FABreadcrumbBar sender, FABreadcrumbBarItemClickedEventArgs args)
     {
         if (DataContext is NodeGraphTabViewModel viewModel)
         {

--- a/src/Beutl.Editor.Components/PathEditorTab/Views/PathEditorTabView.axaml
+++ b/src/Beutl.Editor.Components/PathEditorTab/Views/PathEditorTabView.axaml
@@ -34,36 +34,36 @@
         <Canvas Name="canvas" Background="Transparent">
             <Canvas.ContextFlyout>
                 <ui:FAMenuFlyout>
-                    <ui:MenuFlyoutItem Click="AddOpClicked"
+                    <ui:FAMenuFlyoutItem Click="AddOpClicked"
                                        Tag="Cubic"
                                        Text="{x:Static lang:GraphicsStrings.CubicBezierSegment}" />
-                    <ui:MenuFlyoutItem Click="AddOpClicked"
+                    <ui:FAMenuFlyoutItem Click="AddOpClicked"
                                        Tag="Quad"
                                        Text="{x:Static lang:GraphicsStrings.QuadraticBezierSegment}" />
-                    <ui:MenuFlyoutItem Click="AddOpClicked"
+                    <ui:FAMenuFlyoutItem Click="AddOpClicked"
                                        Tag="Line"
                                        Text="{x:Static lang:GraphicsStrings.LineSegment}" />
-                    <ui:MenuFlyoutItem Click="AddOpClicked"
+                    <ui:FAMenuFlyoutItem Click="AddOpClicked"
                                        Tag="Arc"
                                        Text="{x:Static lang:GraphicsStrings.ArcSegment}" />
-                    <ui:MenuFlyoutItem Click="AddOpClicked"
+                    <ui:FAMenuFlyoutItem Click="AddOpClicked"
                                        Tag="Conic"
                                        Text="{x:Static lang:GraphicsStrings.ConicSegment}" />
-                    <ui:MenuFlyoutSeparator />
-                    <ui:RadioMenuFlyoutItem Click="ToggleDragModeClick"
+                    <ui:FAMenuFlyoutSeparator />
+                    <ui:FARadioMenuFlyoutItem Click="ToggleDragModeClick"
                                             IsChecked="{Binding Symmetry.Value, Mode=OneWay}"
                                             Tag="Symmetry"
                                             Text="{x:Static lang:Strings.Symmetry}" />
-                    <ui:RadioMenuFlyoutItem Click="ToggleDragModeClick"
+                    <ui:FARadioMenuFlyoutItem Click="ToggleDragModeClick"
                                             IsChecked="{Binding Asymmetry.Value, Mode=OneWay}"
                                             Tag="Asymmetry"
                                             Text="{x:Static lang:Strings.Asymmetry}" />
-                    <ui:RadioMenuFlyoutItem Click="ToggleDragModeClick"
+                    <ui:FARadioMenuFlyoutItem Click="ToggleDragModeClick"
                                             IsChecked="{Binding Separately.Value, Mode=OneWay}"
                                             Tag="Separately"
                                             Text="{x:Static lang:Strings.Separately}" />
-                    <ui:MenuFlyoutSeparator />
-                    <ui:MenuFlyoutItem Click="ResetZoomClicked" Text="{x:Static lang:Strings.ResetZoom}" />
+                    <ui:FAMenuFlyoutSeparator />
+                    <ui:FAMenuFlyoutItem Click="ResetZoomClicked" Text="{x:Static lang:Strings.ResetZoom}" />
                 </ui:FAMenuFlyout>
             </Canvas.ContextFlyout>
         </Canvas>

--- a/src/Beutl.Editor.Components/PathEditorTab/Views/PathEditorTabView.axaml.cs
+++ b/src/Beutl.Editor.Components/PathEditorTab/Views/PathEditorTabView.axaml.cs
@@ -448,7 +448,7 @@ public partial class PathEditorTabView : UserControl, IPathEditorView
             [!ThemeProperty] = new DynamicResourceExtension("PathEditorControlPointThumbTheme")
         };
         var flyout = new FAMenuFlyout();
-        var delete = new MenuFlyoutItem
+        var delete = new FAMenuFlyoutItem
         {
             Text = Strings.Delete,
             IconSource = new FluentIconSource { Icon = Icon.Delete }
@@ -465,7 +465,7 @@ public partial class PathEditorTabView : UserControl, IPathEditorView
 
     private void OnDeleteClicked(object? sender, RoutedEventArgs e)
     {
-        if (sender is MenuFlyoutItem { DataContext: PathSegment op }
+        if (sender is FAMenuFlyoutItem { DataContext: PathSegment op }
             && DataContext is PathEditorTabViewModel viewModel
             && viewModel.FigureContext.Value is IPathFigureEditorContext figureContext)
         {
@@ -487,7 +487,7 @@ public partial class PathEditorTabView : UserControl, IPathEditorView
     private void ToggleDragModeClick(object? sender, RoutedEventArgs e)
     {
         string? tag = null;
-        if (sender is RadioMenuFlyoutItem button1)
+        if (sender is FARadioMenuFlyoutItem button1)
         {
             tag = button1.Tag as string;
         }
@@ -519,7 +519,7 @@ public partial class PathEditorTabView : UserControl, IPathEditorView
 
     private void AddOpClicked(object? sender, RoutedEventArgs e)
     {
-        if (sender is MenuFlyoutItem item
+        if (sender is FAMenuFlyoutItem item
             && DataContext is PathEditorTabViewModel viewModel
             && viewModel.PathFigure.Value is { } figure
             && viewModel.FigureContext.Value is IPathFigureEditorContext figureContext)

--- a/src/Beutl.Editor.Components/PathEditorTab/Views/PathEditorView.axaml
+++ b/src/Beutl.Editor.Components/PathEditorTab/Views/PathEditorView.axaml
@@ -19,31 +19,31 @@
     <Canvas Name="canvas" Background="Transparent">
         <Canvas.ContextFlyout>
             <ui:FAMenuFlyout>
-                <ui:MenuFlyoutItem Click="AddOpClicked"
+                <ui:FAMenuFlyoutItem Click="AddOpClicked"
                                    Tag="Cubic"
                                    Text="{x:Static lang:GraphicsStrings.CubicBezierSegment}" />
-                <ui:MenuFlyoutItem Click="AddOpClicked"
+                <ui:FAMenuFlyoutItem Click="AddOpClicked"
                                    Tag="Quad"
                                    Text="{x:Static lang:GraphicsStrings.QuadraticBezierSegment}" />
-                <ui:MenuFlyoutItem Click="AddOpClicked"
+                <ui:FAMenuFlyoutItem Click="AddOpClicked"
                                    Tag="Line"
                                    Text="{x:Static lang:GraphicsStrings.LineSegment}" />
-                <ui:MenuFlyoutItem Click="AddOpClicked"
+                <ui:FAMenuFlyoutItem Click="AddOpClicked"
                                    Tag="Arc"
                                    Text="{x:Static lang:GraphicsStrings.ArcSegment}" />
-                <ui:MenuFlyoutItem Click="AddOpClicked"
+                <ui:FAMenuFlyoutItem Click="AddOpClicked"
                                    Tag="Conic"
                                    Text="{x:Static lang:GraphicsStrings.ConicSegment}" />
-                <ui:MenuFlyoutSeparator />
-                <ui:RadioMenuFlyoutItem Click="ToggleDragModeClick"
+                <ui:FAMenuFlyoutSeparator />
+                <ui:FARadioMenuFlyoutItem Click="ToggleDragModeClick"
                                         IsChecked="{Binding Symmetry.Value, Mode=OneWay}"
                                         Tag="Symmetry"
                                         Text="{x:Static lang:Strings.Symmetry}" />
-                <ui:RadioMenuFlyoutItem Click="ToggleDragModeClick"
+                <ui:FARadioMenuFlyoutItem Click="ToggleDragModeClick"
                                         IsChecked="{Binding Asymmetry.Value, Mode=OneWay}"
                                         Tag="Asymmetry"
                                         Text="{x:Static lang:Strings.Asymmetry}" />
-                <ui:RadioMenuFlyoutItem Click="ToggleDragModeClick"
+                <ui:FARadioMenuFlyoutItem Click="ToggleDragModeClick"
                                         IsChecked="{Binding Separately.Value, Mode=OneWay}"
                                         Tag="Separately"
                                         Text="{x:Static lang:Strings.Separately}" />

--- a/src/Beutl.Editor.Components/PathEditorTab/Views/PathEditorView.axaml.cs
+++ b/src/Beutl.Editor.Components/PathEditorTab/Views/PathEditorView.axaml.cs
@@ -182,7 +182,7 @@ public partial class PathEditorView : UserControl, IPathEditorView
             [!ThemeProperty] = new DynamicResourceExtension("PathEditorControlPointThumbTheme")
         };
         var flyout = new FAMenuFlyout();
-        var delete = new MenuFlyoutItem
+        var delete = new FAMenuFlyoutItem
         {
             Text = Strings.Delete,
             IconSource = new FluentIconSource
@@ -202,7 +202,7 @@ public partial class PathEditorView : UserControl, IPathEditorView
 
     private void OnDeleteClicked(object? sender, RoutedEventArgs e)
     {
-        if (sender is MenuFlyoutItem { DataContext: PathSegment op }
+        if (sender is FAMenuFlyoutItem { DataContext: PathSegment op }
             && DataContext is PathEditorViewModel viewModel
             && viewModel.FigureContext.Value is IPathFigureEditorContext figureContext)
         {
@@ -223,7 +223,7 @@ public partial class PathEditorView : UserControl, IPathEditorView
 
     private void ToggleDragModeClick(object? sender, RoutedEventArgs e)
     {
-        if (sender is RadioMenuFlyoutItem button && DataContext is PathEditorViewModel viewModel)
+        if (sender is FARadioMenuFlyoutItem button && DataContext is PathEditorViewModel viewModel)
         {
             viewModel.Symmetry.Value = false;
             viewModel.Asymmetry.Value = false;
@@ -246,7 +246,7 @@ public partial class PathEditorView : UserControl, IPathEditorView
 
     private void AddOpClicked(object? sender, RoutedEventArgs e)
     {
-        if (sender is MenuFlyoutItem item
+        if (sender is FAMenuFlyoutItem item
             && DataContext is PathEditorViewModel viewModel
             && viewModel.PathFigure.Value is { } figure
             && viewModel.FigureContext.Value is IPathFigureEditorContext figureContext)

--- a/src/Beutl.Editor.Components/PreviewSettingsTab/Views/PreviewSettingsTabView.axaml
+++ b/src/Beutl.Editor.Components/PreviewSettingsTab/Views/PreviewSettingsTabView.axaml
@@ -99,7 +99,7 @@
                               Theme="{StaticResource CompactToggleSwitchStyle}" />
             </Grid>
 
-            <ui:InfoBar Margin="8,8,8,0"
+            <ui:FAInfoBar Margin="8,8,8,0"
                         IsClosable="False"
                         IsOpen="{CompiledBinding IsNodeCacheEnabled.Value}"
                         Message="{x:Static lang:SettingsStrings.NodeCacheWarning}"

--- a/src/Beutl.Editor.Components/ProxiesTab/ViewModels/ProxiesTabViewModel.cs
+++ b/src/Beutl.Editor.Components/ProxiesTab/ViewModels/ProxiesTabViewModel.cs
@@ -561,7 +561,7 @@ public sealed class ProxiesTabViewModel : IDisposable, IToolContext
 
     private static async Task<bool> ShowDeleteAllForProjectConfirmationAsync(int entryCount)
     {
-        var dialog = new ContentDialog
+        var dialog = new FAContentDialog
         {
             Title = Strings.ProxyDeleteProjectProxies,
             Content = string.Format(
@@ -570,10 +570,10 @@ public sealed class ProxiesTabViewModel : IDisposable, IToolContext
                 entryCount),
             PrimaryButtonText = Strings.Yes,
             CloseButtonText = Strings.No,
-            DefaultButton = ContentDialogButton.Close,
+            DefaultButton = FAContentDialogButton.Close,
         };
 
-        return await dialog.ShowAsync() == ContentDialogResult.Primary;
+        return await dialog.ShowAsync() == FAContentDialogResult.Primary;
     }
 
     // Collapse a burst of store/job events (e.g. a "Generate all" completing N clips raises ~2N

--- a/src/Beutl.Editor.Components/Services/AvaloniaClipboardGateway.cs
+++ b/src/Beutl.Editor.Components/Services/AvaloniaClipboardGateway.cs
@@ -1,5 +1,6 @@
 ﻿using Avalonia.Input;
 using Avalonia.Input.Platform;
+using Avalonia.Media.Imaging;
 using Avalonia.Platform.Storage;
 using Beutl.Editor.Components.Helpers;
 using Beutl.Editor.Services;
@@ -70,7 +71,7 @@ public sealed class AvaloniaClipboardGateway : IClipboardGateway
         if (bitmap is null) return null;
 
         using var ms = new MemoryStream();
-        bitmap.Save(ms);
+        bitmap.Save(ms, PngBitmapEncoderOptions.Default);
         return ms.ToArray();
     }
 

--- a/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/ElementView.axaml
@@ -56,145 +56,145 @@
         </Border.Styles>
         <Border.ContextFlyout>
             <ui:FAMenuFlyout>
-                <ui:ToggleMenuFlyoutItem x:Name="enableElement"
+                <ui:FAToggleMenuFlyoutItem x:Name="enableElement"
                                          Click="EnableElementClick"
                                          IsChecked="{Binding IsEnabled.Value}"
                                          Text="{x:Static lang:Strings.EnableElement}">
-                    <ui:ToggleMenuFlyoutItem.Styles>
-                        <Style Selector="ui|ToggleMenuFlyoutItem /template/ Viewbox#IconRoot">
+                    <ui:FAToggleMenuFlyoutItem.Styles>
+                        <Style Selector="ui|FAToggleMenuFlyoutItem /template/ Viewbox#IconRoot">
                             <Setter Property="Width" Value="0" />
                         </Style>
-                    </ui:ToggleMenuFlyoutItem.Styles>
-                </ui:ToggleMenuFlyoutItem>
-                <ui:ToggleMenuFlyoutItem x:Name="lockElement"
+                    </ui:FAToggleMenuFlyoutItem.Styles>
+                </ui:FAToggleMenuFlyoutItem>
+                <ui:FAToggleMenuFlyoutItem x:Name="lockElement"
                                          Click="LockElement_Click"
                                          IsChecked="{Binding IsLocked.Value}"
                                          Text="{x:Static lang:Strings.Lock}">
-                    <ui:ToggleMenuFlyoutItem.Styles>
-                        <Style Selector="ui|ToggleMenuFlyoutItem /template/ Viewbox#IconRoot">
+                    <ui:FAToggleMenuFlyoutItem.Styles>
+                        <Style Selector="ui|FAToggleMenuFlyoutItem /template/ Viewbox#IconRoot">
                             <Setter Property="Width" Value="0" />
                         </Style>
-                    </ui:ToggleMenuFlyoutItem.Styles>
-                </ui:ToggleMenuFlyoutItem>
-                <ui:MenuFlyoutSubItem Text="{x:Static lang:Strings.EditingMode}">
-                    <ui:MenuFlyoutSubItem.IconSource>
+                    </ui:FAToggleMenuFlyoutItem.Styles>
+                </ui:FAToggleMenuFlyoutItem>
+                <ui:FAMenuFlyoutSubItem Text="{x:Static lang:Strings.EditingMode}">
+                    <ui:FAMenuFlyoutSubItem.IconSource>
                         <icons:FluentIconSource Icon="Edit" />
-                    </ui:MenuFlyoutSubItem.IconSource>
-                    <ui:ToggleMenuFlyoutItem IsChecked="{Binding Timeline.IsRazorMode.Value, Mode=TwoWay}"
+                    </ui:FAMenuFlyoutSubItem.IconSource>
+                    <ui:FAToggleMenuFlyoutItem IsChecked="{Binding Timeline.IsRazorMode.Value, Mode=TwoWay}"
                                              InputGesture="{h:GetCommandGesture ToggleRazorMode,
                                                                                 ExtensionType={x:Type p:TimelineTabExtension}}"
                                              Text="{x:Static lang:Strings.RazorTool}">
-                        <ui:ToggleMenuFlyoutItem.IconSource>
+                        <ui:FAToggleMenuFlyoutItem.IconSource>
                             <icons:FluentIconSource Icon="Cut" />
-                        </ui:ToggleMenuFlyoutItem.IconSource>
-                    </ui:ToggleMenuFlyoutItem>
-                    <ui:ToggleMenuFlyoutItem IsChecked="{Binding Timeline.IsSlipMode.Value, Mode=TwoWay}"
+                        </ui:FAToggleMenuFlyoutItem.IconSource>
+                    </ui:FAToggleMenuFlyoutItem>
+                    <ui:FAToggleMenuFlyoutItem IsChecked="{Binding Timeline.IsSlipMode.Value, Mode=TwoWay}"
                                              InputGesture="{h:GetCommandGesture ToggleSlipMode,
                                                                                 ExtensionType={x:Type p:TimelineTabExtension}}"
                                              Text="{x:Static lang:Strings.SlipTool}" />
-                    <ui:ToggleMenuFlyoutItem IsChecked="{Binding Timeline.IsRollMode.Value, Mode=TwoWay}"
+                    <ui:FAToggleMenuFlyoutItem IsChecked="{Binding Timeline.IsRollMode.Value, Mode=TwoWay}"
                                              InputGesture="{h:GetCommandGesture ToggleRollMode,
                                                                                 ExtensionType={x:Type p:TimelineTabExtension}}"
                                              Text="{x:Static lang:Strings.RollTool}" />
-                    <ui:ToggleMenuFlyoutItem IsChecked="{Binding Timeline.IsSlideMode.Value, Mode=TwoWay}"
+                    <ui:FAToggleMenuFlyoutItem IsChecked="{Binding Timeline.IsSlideMode.Value, Mode=TwoWay}"
                                              InputGesture="{h:GetCommandGesture ToggleSlideMode,
                                                                                 ExtensionType={x:Type p:TimelineTabExtension}}"
                                              Text="{x:Static lang:Strings.SlideTool}" />
-                    <ui:MenuFlyoutSeparator />
-                    <ui:ToggleMenuFlyoutItem IsChecked="{Binding Timeline.IsRippleEnabled.Value, Mode=TwoWay}"
+                    <ui:FAMenuFlyoutSeparator />
+                    <ui:FAToggleMenuFlyoutItem IsChecked="{Binding Timeline.IsRippleEnabled.Value, Mode=TwoWay}"
                                              InputGesture="{h:GetCommandGesture ToggleRippleMode,
                                                                                 ExtensionType={x:Type p:TimelineTabExtension}}"
                                              Text="{x:Static lang:Strings.RippleEdit}" />
-                </ui:MenuFlyoutSubItem>
-                <ui:MenuFlyoutSeparator />
-                <ui:MenuFlyoutItem x:Name="split"
+                </ui:FAMenuFlyoutSubItem>
+                <ui:FAMenuFlyoutSeparator />
+                <ui:FAMenuFlyoutItem x:Name="split"
                                    Command="{Binding Split}"
                                    Text="{x:Static lang:Strings.Split}">
-                    <ui:MenuFlyoutItem.IconSource>
+                    <ui:FAMenuFlyoutItem.IconSource>
                         <icons:FluentIconSource Icon="SplitVertical" />
-                    </ui:MenuFlyoutItem.IconSource>
-                </ui:MenuFlyoutItem>
-                <ui:MenuFlyoutItem x:Name="splitByCurrent"
+                    </ui:FAMenuFlyoutItem.IconSource>
+                </ui:FAMenuFlyoutItem>
+                <ui:FAMenuFlyoutItem x:Name="splitByCurrent"
                                    Command="{Binding SplitByCurrentFrame}"
                                    InputGesture="{h:GetCommandGesture Split,
                                                                       ExtensionType={x:Type p:TimelineTabExtension}}"
                                    Text="{x:Static lang:Strings.SplitByCurrentFrame}" />
-                <ui:MenuFlyoutItem x:Name="cut"
+                <ui:FAMenuFlyoutItem x:Name="cut"
                                    Command="{Binding Cut}"
                                    InputGesture="{h:GetCommandGesture Cut,
                                                                       ExtensionType={x:Type p:TimelineTabExtension}}"
                                    Text="{x:Static lang:Strings.Cut}">
-                    <ui:MenuFlyoutItem.IconSource>
+                    <ui:FAMenuFlyoutItem.IconSource>
                         <icons:FluentIconSource Icon="Cut" />
-                    </ui:MenuFlyoutItem.IconSource>
-                </ui:MenuFlyoutItem>
-                <ui:MenuFlyoutItem Command="{Binding Copy}"
+                    </ui:FAMenuFlyoutItem.IconSource>
+                </ui:FAMenuFlyoutItem>
+                <ui:FAMenuFlyoutItem Command="{Binding Copy}"
                                    InputGesture="{h:GetCommandGesture Copy,
                                                                       ExtensionType={x:Type p:TimelineTabExtension}}"
                                    Text="{x:Static lang:Strings.Copy}">
-                    <ui:MenuFlyoutItem.IconSource>
+                    <ui:FAMenuFlyoutItem.IconSource>
                         <icons:FluentIconSource Icon="Copy" />
-                    </ui:MenuFlyoutItem.IconSource>
-                </ui:MenuFlyoutItem>
-                <ui:MenuFlyoutItem x:Name="delete"
+                    </ui:FAMenuFlyoutItem.IconSource>
+                </ui:FAMenuFlyoutItem>
+                <ui:FAMenuFlyoutItem x:Name="delete"
                                    Command="{Binding Delete}"
                                    InputGesture="{h:GetCommandGesture Delete,
                                                                       ExtensionType={x:Type p:TimelineTabExtension}}"
                                    Text="{x:Static lang:Strings.Delete}">
-                    <ui:MenuFlyoutItem.IconSource>
+                    <ui:FAMenuFlyoutItem.IconSource>
                         <icons:FluentIconSource Icon="DeleteDismiss" />
-                    </ui:MenuFlyoutItem.IconSource>
-                </ui:MenuFlyoutItem>
-                <ui:MenuFlyoutItem x:Name="exclude"
+                    </ui:FAMenuFlyoutItem.IconSource>
+                </ui:FAMenuFlyoutItem>
+                <ui:FAMenuFlyoutItem x:Name="exclude"
                                    Command="{Binding Exclude}"
                                    InputGesture="{h:GetCommandGesture Exclude,
                                                                       ExtensionType={x:Type p:TimelineTabExtension}}"
                                    Text="{x:Static lang:Strings.Exclude}">
-                    <ui:MenuFlyoutItem.IconSource>
+                    <ui:FAMenuFlyoutItem.IconSource>
                         <icons:FluentIconSource Icon="Delete" />
-                    </ui:MenuFlyoutItem.IconSource>
-                </ui:MenuFlyoutItem>
-                <ui:MenuFlyoutItem x:Name="groupSelectedElements"
+                    </ui:FAMenuFlyoutItem.IconSource>
+                </ui:FAMenuFlyoutItem>
+                <ui:FAMenuFlyoutItem x:Name="groupSelectedElements"
                                    Command="{Binding GroupSelectedElements}"
                                    Text="{x:Static lang:Strings.GroupSelectedElements}" />
-                <ui:MenuFlyoutItem x:Name="ungroupSelectedElements"
+                <ui:FAMenuFlyoutItem x:Name="ungroupSelectedElements"
                                    Command="{Binding UngroupSelectedElements}"
                                    Text="{x:Static lang:Strings.UngroupSelectedElements}" />
-                <ui:MenuFlyoutItem x:Name="rename"
+                <ui:FAMenuFlyoutItem x:Name="rename"
                                    Click="Rename_Click"
                                    InputGesture="{h:GetCommandGesture Rename,
                                                                       ExtensionType={x:Type p:TimelineTabExtension}}"
                                    Text="{x:Static lang:Strings.Rename}">
-                    <ui:MenuFlyoutItem.IconSource>
+                    <ui:FAMenuFlyoutItem.IconSource>
                         <icons:FluentIconSource Icon="Rename" />
-                    </ui:MenuFlyoutItem.IconSource>
-                </ui:MenuFlyoutItem>
-                <ui:MenuFlyoutItem x:Name="change2OriginalDuration"
+                    </ui:FAMenuFlyoutItem.IconSource>
+                </ui:FAMenuFlyoutItem>
+                <ui:FAMenuFlyoutItem x:Name="change2OriginalDuration"
                                    Command="{Binding ChangeToOriginalDuration}"
                                    Text="{x:Static lang:Strings.ChangeToOriginalLength}" />
-                <ui:MenuFlyoutItem x:Name="changeColor"
+                <ui:FAMenuFlyoutItem x:Name="changeColor"
                                    Click="ChangeColor_Click"
                                    Text="{x:Static lang:Strings.ChangeColor}" />
-                <ui:ToggleMenuFlyoutItem IsChecked="{Binding IsThumbnailsDisabled.Value}" Text="{x:Static lang:Strings.DisableThumbnails}">
-                    <ui:ToggleMenuFlyoutItem.Styles>
-                        <Style Selector="ui|ToggleMenuFlyoutItem /template/ Viewbox#IconRoot">
+                <ui:FAToggleMenuFlyoutItem IsChecked="{Binding IsThumbnailsDisabled.Value}" Text="{x:Static lang:Strings.DisableThumbnails}">
+                    <ui:FAToggleMenuFlyoutItem.Styles>
+                        <Style Selector="ui|FAToggleMenuFlyoutItem /template/ Viewbox#IconRoot">
                             <Setter Property="Width" Value="0" />
                         </Style>
-                    </ui:ToggleMenuFlyoutItem.Styles>
-                </ui:ToggleMenuFlyoutItem>
-                <ui:MenuFlyoutSeparator />
-                <ui:MenuFlyoutItem Click="SaveAsTemplate_Click" Text="{x:Static lang:Strings.SaveAsTemplate}">
-                    <ui:MenuFlyoutItem.IconSource>
+                    </ui:FAToggleMenuFlyoutItem.Styles>
+                </ui:FAToggleMenuFlyoutItem>
+                <ui:FAMenuFlyoutSeparator />
+                <ui:FAMenuFlyoutItem Click="SaveAsTemplate_Click" Text="{x:Static lang:Strings.SaveAsTemplate}">
+                    <ui:FAMenuFlyoutItem.IconSource>
                         <icons:FluentIconSource Icon="DocumentCopy" />
-                    </ui:MenuFlyoutItem.IconSource>
-                </ui:MenuFlyoutItem>
-                <ui:MenuFlyoutSeparator />
-                <ui:MenuFlyoutSubItem Text="{x:Static lang:Strings.Animation}">
-                    <ui:MenuFlyoutItem x:Name="finishEditingAnimation"
+                    </ui:FAMenuFlyoutItem.IconSource>
+                </ui:FAMenuFlyoutItem>
+                <ui:FAMenuFlyoutSeparator />
+                <ui:FAMenuFlyoutSubItem Text="{x:Static lang:Strings.Animation}">
+                    <ui:FAMenuFlyoutItem x:Name="finishEditingAnimation"
                                        Command="{Binding FinishEditingAnimation}"
                                        Text="{x:Static lang:Strings.FinishEditing}" />
-                    <ui:MenuFlyoutItem Command="{Binding BringAnimationToTop}" Text="{x:Static lang:Strings.BringToTop}" />
-                </ui:MenuFlyoutSubItem>
+                    <ui:FAMenuFlyoutItem Command="{Binding BringAnimationToTop}" Text="{x:Static lang:Strings.BringToTop}" />
+                </ui:FAMenuFlyoutSubItem>
             </ui:FAMenuFlyout>
         </Border.ContextFlyout>
         <Panel>

--- a/src/Beutl.Editor.Components/TimelineTab/Views/TimelineTabView.axaml
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/TimelineTabView.axaml
@@ -56,15 +56,15 @@
                            Offset="{Binding #ContentScroll.Offset, Mode=OneWay}">
             <ecv:TimelineScale.ContextFlyout>
                 <ui:FAMenuFlyout>
-                    <ui:MenuFlyoutItem Command="{Binding DeleteAllFrameCache}" Text="{x:Static lang:Strings.DeleteAll}" />
-                    <ui:MenuFlyoutItem Command="{Binding DeleteFrameCache}" Text="{x:Static lang:Strings.Delete}" />
-                    <ui:MenuFlyoutItem Command="{Binding LockFrameCache}" Text="{x:Static lang:Strings.Lock}" />
-                    <ui:MenuFlyoutItem Command="{Binding UnlockFrameCache}" Text="{x:Static lang:Strings.Unlock}" />
+                    <ui:FAMenuFlyoutItem Command="{Binding DeleteAllFrameCache}" Text="{x:Static lang:Strings.DeleteAll}" />
+                    <ui:FAMenuFlyoutItem Command="{Binding DeleteFrameCache}" Text="{x:Static lang:Strings.Delete}" />
+                    <ui:FAMenuFlyoutItem Command="{Binding LockFrameCache}" Text="{x:Static lang:Strings.Lock}" />
+                    <ui:FAMenuFlyoutItem Command="{Binding UnlockFrameCache}" Text="{x:Static lang:Strings.Unlock}" />
                 </ui:FAMenuFlyout>
             </ecv:TimelineScale.ContextFlyout>
         </ecv:TimelineScale>
 
-        <ui:TeachingTip x:Name="CacheTip"
+        <ui:FATeachingTip x:Name="CacheTip"
                         Title="{x:Static lang:Strings.FrameCache}"
                         Subtitle="{x:Static lang:Strings.RightClickToOperateCache}"
                         Target="{Binding #Scale}" />
@@ -237,126 +237,126 @@
                    PointerReleased="TimelinePanel_PointerReleased">
                 <Panel.ContextFlyout>
                     <ui:FAMenuFlyout>
-                        <ui:MenuFlyoutSubItem Text="{x:Static lang:Strings.EditingMode}">
-                            <ui:MenuFlyoutSubItem.IconSource>
+                        <ui:FAMenuFlyoutSubItem Text="{x:Static lang:Strings.EditingMode}">
+                            <ui:FAMenuFlyoutSubItem.IconSource>
                                 <icons:FluentIconSource Icon="Edit" />
-                            </ui:MenuFlyoutSubItem.IconSource>
-                            <ui:ToggleMenuFlyoutItem InputGesture="{h:GetCommandGesture ToggleRazorMode,
+                            </ui:FAMenuFlyoutSubItem.IconSource>
+                            <ui:FAToggleMenuFlyoutItem InputGesture="{h:GetCommandGesture ToggleRazorMode,
                                                                                         ExtensionType={x:Type p:TimelineTabExtension}}"
                                                      IsChecked="{CompiledBinding IsRazorMode.Value,
                                                                                  Mode=TwoWay}"
                                                      Text="{x:Static lang:Strings.RazorTool}">
-                                <ui:ToggleMenuFlyoutItem.IconSource>
+                                <ui:FAToggleMenuFlyoutItem.IconSource>
                                     <icons:FluentIconSource Icon="Cut" />
-                                </ui:ToggleMenuFlyoutItem.IconSource>
-                            </ui:ToggleMenuFlyoutItem>
-                            <ui:ToggleMenuFlyoutItem InputGesture="{h:GetCommandGesture ToggleSlipMode,
+                                </ui:FAToggleMenuFlyoutItem.IconSource>
+                            </ui:FAToggleMenuFlyoutItem>
+                            <ui:FAToggleMenuFlyoutItem InputGesture="{h:GetCommandGesture ToggleSlipMode,
                                                                                         ExtensionType={x:Type p:TimelineTabExtension}}"
                                                      IsChecked="{CompiledBinding IsSlipMode.Value,
                                                                                  Mode=TwoWay}"
                                                      Text="{x:Static lang:Strings.SlipTool}" />
-                            <ui:ToggleMenuFlyoutItem InputGesture="{h:GetCommandGesture ToggleRollMode,
+                            <ui:FAToggleMenuFlyoutItem InputGesture="{h:GetCommandGesture ToggleRollMode,
                                                                                         ExtensionType={x:Type p:TimelineTabExtension}}"
                                                      IsChecked="{CompiledBinding IsRollMode.Value,
                                                                                  Mode=TwoWay}"
                                                      Text="{x:Static lang:Strings.RollTool}" />
-                            <ui:ToggleMenuFlyoutItem InputGesture="{h:GetCommandGesture ToggleSlideMode,
+                            <ui:FAToggleMenuFlyoutItem InputGesture="{h:GetCommandGesture ToggleSlideMode,
                                                                                         ExtensionType={x:Type p:TimelineTabExtension}}"
                                                      IsChecked="{CompiledBinding IsSlideMode.Value,
                                                                                  Mode=TwoWay}"
                                                      Text="{x:Static lang:Strings.SlideTool}" />
-                            <ui:MenuFlyoutSeparator />
-                            <ui:ToggleMenuFlyoutItem InputGesture="{h:GetCommandGesture ToggleRippleMode,
+                            <ui:FAMenuFlyoutSeparator />
+                            <ui:FAToggleMenuFlyoutItem InputGesture="{h:GetCommandGesture ToggleRippleMode,
                                                                                         ExtensionType={x:Type p:TimelineTabExtension}}"
                                                      IsChecked="{CompiledBinding IsRippleEnabled.Value,
                                                                                  Mode=TwoWay}"
                                                      Text="{x:Static lang:Strings.RippleEdit}" />
-                        </ui:MenuFlyoutSubItem>
-                        <ui:MenuFlyoutSeparator />
-                        <ui:MenuFlyoutSubItem x:Name="AddElementSubMenu" Text="{x:Static lang:Strings.AddElement}" />
-                        <ui:MenuFlyoutSubItem x:Name="AddFromTemplateSubMenu" Text="{x:Static lang:Strings.AddFromTemplate}" />
-                        <ui:MenuFlyoutItem Click="AddAdjustmentLayerClick" Text="{x:Static lang:Strings.AddAdjustmentLayer}">
-                            <ui:MenuFlyoutItem.IconSource>
+                        </ui:FAMenuFlyoutSubItem>
+                        <ui:FAMenuFlyoutSeparator />
+                        <ui:FAMenuFlyoutSubItem x:Name="AddElementSubMenu" Text="{x:Static lang:Strings.AddElement}" />
+                        <ui:FAMenuFlyoutSubItem x:Name="AddFromTemplateSubMenu" Text="{x:Static lang:Strings.AddFromTemplate}" />
+                        <ui:FAMenuFlyoutItem Click="AddAdjustmentLayerClick" Text="{x:Static lang:Strings.AddAdjustmentLayer}">
+                            <ui:FAMenuFlyoutItem.IconSource>
                                 <icons:FluentIconSource Icon="Color" />
-                            </ui:MenuFlyoutItem.IconSource>
-                        </ui:MenuFlyoutItem>
-                        <ui:MenuFlyoutItem Command="{CompiledBinding Paste}"
+                            </ui:FAMenuFlyoutItem.IconSource>
+                        </ui:FAMenuFlyoutItem>
+                        <ui:FAMenuFlyoutItem Command="{CompiledBinding Paste}"
                                            InputGesture="{h:GetCommandGesture Paste}"
                                            Text="{x:Static lang:Strings.Paste}">
-                            <ui:MenuFlyoutItem.IconSource>
+                            <ui:FAMenuFlyoutItem.IconSource>
                                 <icons:FluentIconSource Icon="ClipboardPaste" />
-                            </ui:MenuFlyoutItem.IconSource>
-                        </ui:MenuFlyoutItem>
-                        <ui:MenuFlyoutSeparator />
-                        <ui:MenuFlyoutItem Command="{Binding SetStartTimeToPointerPosition}"
+                            </ui:FAMenuFlyoutItem.IconSource>
+                        </ui:FAMenuFlyoutItem>
+                        <ui:FAMenuFlyoutSeparator />
+                        <ui:FAMenuFlyoutItem Command="{Binding SetStartTimeToPointerPosition}"
                                            InputGesture="{h:GetCommandGesture SetStartTime}"
                                            Text="{x:Static lang:Strings.SetStartTime}" />
-                        <ui:MenuFlyoutItem Command="{Binding SetEndTimeToPointerPosition}"
+                        <ui:FAMenuFlyoutItem Command="{Binding SetEndTimeToPointerPosition}"
                                            InputGesture="{h:GetCommandGesture SetEndTime}"
                                            Text="{x:Static lang:Strings.SetEndTime}" />
-                        <ui:MenuFlyoutSubItem Text="{x:Static lang:Strings.Gaps}">
-                            <ui:MenuFlyoutSubItem.IconSource>
+                        <ui:FAMenuFlyoutSubItem Text="{x:Static lang:Strings.Gaps}">
+                            <ui:FAMenuFlyoutSubItem.IconSource>
                                 <icons:SymbolIconSource Symbol="ArrowMoveInward" />
-                            </ui:MenuFlyoutSubItem.IconSource>
-                            <ui:MenuFlyoutItem Command="{CompiledBinding CloseGapAtPointerPosition}" Text="{x:Static lang:Strings.CloseGap}" />
-                            <ui:MenuFlyoutItem Command="{CompiledBinding CloseAllGaps}"
+                            </ui:FAMenuFlyoutSubItem.IconSource>
+                            <ui:FAMenuFlyoutItem Command="{CompiledBinding CloseGapAtPointerPosition}" Text="{x:Static lang:Strings.CloseGap}" />
+                            <ui:FAMenuFlyoutItem Command="{CompiledBinding CloseAllGaps}"
                                                InputGesture="{h:GetCommandGesture CloseAllGaps,
                                                                                   ExtensionType={x:Type p:TimelineTabExtension}}"
                                                Text="{x:Static lang:Strings.CloseAllGaps}" />
-                            <ui:MenuFlyoutSeparator />
-                            <ui:MenuFlyoutItem Command="{CompiledBinding GoToNextGap}"
+                            <ui:FAMenuFlyoutSeparator />
+                            <ui:FAMenuFlyoutItem Command="{CompiledBinding GoToNextGap}"
                                                InputGesture="{h:GetCommandGesture GoToNextGap,
                                                                                   ExtensionType={x:Type p:TimelineTabExtension}}"
                                                Text="{x:Static lang:Strings.GoToNextGap}" />
-                            <ui:MenuFlyoutItem Command="{CompiledBinding GoToPreviousGap}"
+                            <ui:FAMenuFlyoutItem Command="{CompiledBinding GoToPreviousGap}"
                                                InputGesture="{h:GetCommandGesture GoToPreviousGap,
                                                                                   ExtensionType={x:Type p:TimelineTabExtension}}"
                                                Text="{x:Static lang:Strings.GoToPreviousGap}" />
-                        </ui:MenuFlyoutSubItem>
-                        <ui:ToggleMenuFlyoutItem IsChecked="{Binding AutoAdjustSceneDuration.Value, Mode=TwoWay}" Text="{x:Static lang:SettingsStrings.AutoAdjustSceneDuration}" />
-                        <ui:ToggleMenuFlyoutItem IsChecked="{Binding IsSnapEnabled.Value, Mode=TwoWay}" Text="{x:Static lang:Strings.TimelineSnap}" />
-                        <ui:MenuFlyoutSeparator />
-                        <ui:MenuFlyoutItem Click="ShowSceneSettings" Text="{x:Static lang:Strings.Settings}">
-                            <ui:MenuFlyoutItem.IconSource>
+                        </ui:FAMenuFlyoutSubItem>
+                        <ui:FAToggleMenuFlyoutItem IsChecked="{Binding AutoAdjustSceneDuration.Value, Mode=TwoWay}" Text="{x:Static lang:SettingsStrings.AutoAdjustSceneDuration}" />
+                        <ui:FAToggleMenuFlyoutItem IsChecked="{Binding IsSnapEnabled.Value, Mode=TwoWay}" Text="{x:Static lang:Strings.TimelineSnap}" />
+                        <ui:FAMenuFlyoutSeparator />
+                        <ui:FAMenuFlyoutItem Click="ShowSceneSettings" Text="{x:Static lang:Strings.Settings}">
+                            <ui:FAMenuFlyoutItem.IconSource>
                                 <icons:FluentIconSource Icon="Settings" />
-                            </ui:MenuFlyoutItem.IconSource>
-                        </ui:MenuFlyoutItem>
-                        <ui:MenuFlyoutItem x:Name="BpmGridMenuItem"
+                            </ui:FAMenuFlyoutItem.IconSource>
+                        </ui:FAMenuFlyoutItem>
+                        <ui:FAMenuFlyoutItem x:Name="BpmGridMenuItem"
                                            Click="ShowBpmGridFlyout"
                                            Text="{x:Static lang:Strings.BpmGrid}">
-                            <ui:MenuFlyoutItem.IconSource>
+                            <ui:FAMenuFlyoutItem.IconSource>
                                 <icons:FluentIconSource Icon="MusicNote1" />
-                            </ui:MenuFlyoutItem.IconSource>
-                        </ui:MenuFlyoutItem>
-                        <ui:MenuFlyoutSubItem Text="{x:Static lang:Strings.TimelineZoom}">
-                            <ui:MenuFlyoutSubItem.IconSource>
+                            </ui:FAMenuFlyoutItem.IconSource>
+                        </ui:FAMenuFlyoutItem>
+                        <ui:FAMenuFlyoutSubItem Text="{x:Static lang:Strings.TimelineZoom}">
+                            <ui:FAMenuFlyoutSubItem.IconSource>
                                 <icons:FluentIconSource Icon="ZoomIn" />
-                            </ui:MenuFlyoutSubItem.IconSource>
-                            <ui:MenuFlyoutItem Click="ZoomClick"
+                            </ui:FAMenuFlyoutSubItem.IconSource>
+                            <ui:FAMenuFlyoutItem Click="ZoomClick"
                                                CommandParameter="2.0"
                                                Text="200%" />
-                            <ui:MenuFlyoutItem Click="ZoomClick"
+                            <ui:FAMenuFlyoutItem Click="ZoomClick"
                                                CommandParameter="1.7"
                                                Text="170%" />
-                            <ui:MenuFlyoutItem Click="ZoomClick"
+                            <ui:FAMenuFlyoutItem Click="ZoomClick"
                                                CommandParameter="1.5"
                                                Text="150%" />
-                            <ui:MenuFlyoutItem Click="ZoomClick"
+                            <ui:FAMenuFlyoutItem Click="ZoomClick"
                                                CommandParameter="1.2"
                                                Text="120%" />
-                            <ui:MenuFlyoutItem Click="ZoomClick"
+                            <ui:FAMenuFlyoutItem Click="ZoomClick"
                                                CommandParameter="1.0"
                                                Text="100%" />
-                            <ui:MenuFlyoutItem Click="ZoomClick"
+                            <ui:FAMenuFlyoutItem Click="ZoomClick"
                                                CommandParameter="0.7"
                                                Text="70%" />
-                            <ui:MenuFlyoutItem Click="ZoomClick"
+                            <ui:FAMenuFlyoutItem Click="ZoomClick"
                                                CommandParameter="0.5"
                                                Text="50%" />
-                            <ui:MenuFlyoutItem Click="ZoomClick"
+                            <ui:FAMenuFlyoutItem Click="ZoomClick"
                                                CommandParameter="0.2"
                                                Text="20%" />
-                        </ui:MenuFlyoutSubItem>
+                        </ui:FAMenuFlyoutSubItem>
                     </ui:FAMenuFlyout>
                 </Panel.ContextFlyout>
 

--- a/src/Beutl.Editor.Components/TimelineTab/Views/TimelineTabView.axaml.cs
+++ b/src/Beutl.Editor.Components/TimelineTab/Views/TimelineTabView.axaml.cs
@@ -602,14 +602,14 @@ public sealed partial class TimelineTabView : UserControl
         {
             case SingleTypeLibraryItem single when single.Format == KnownLibraryItemFormats.EngineObject:
                 {
-                    var menuItem = new MenuFlyoutItem { Text = single.DisplayName, Tag = single.ImplementationType };
+                    var menuItem = new FAMenuFlyoutItem { Text = single.DisplayName, Tag = single.ImplementationType };
                     menuItem.Click += AddElementWithTypeClick;
                     return menuItem;
                 }
 
             case MultipleTypeLibraryItem multiple when multiple.Types.TryGetValue(KnownLibraryItemFormats.EngineObject, out Type? type):
                 {
-                    var menuItem = new MenuFlyoutItem { Text = multiple.DisplayName, Tag = type };
+                    var menuItem = new FAMenuFlyoutItem { Text = multiple.DisplayName, Tag = type };
                     menuItem.Click += AddElementWithTypeClick;
                     return menuItem;
                 }
@@ -629,7 +629,7 @@ public sealed partial class TimelineTabView : UserControl
                     if (subItems.Count == 0)
                         return null;
 
-                    var subMenu = new MenuFlyoutSubItem { Text = group.DisplayName };
+                    var subMenu = new FAMenuFlyoutSubItem { Text = group.DisplayName };
                     foreach (Control subItem in subItems)
                     {
                         subMenu.Items.Add(subItem);
@@ -645,7 +645,7 @@ public sealed partial class TimelineTabView : UserControl
     private void AddElementWithTypeClick(object? sender, RoutedEventArgs e)
     {
         if (ViewModel == null) return;
-        if (sender is not MenuFlyoutItem { Tag: Type operatorType }) return;
+        if (sender is not FAMenuFlyoutItem { Tag: Type operatorType }) return;
 
         ViewModel.AddElement.Execute(new ElementDescription(
             ViewModel.ClickedFrame,
@@ -673,7 +673,7 @@ public sealed partial class TimelineTabView : UserControl
         foreach (ObjectTemplateItem template in ObjectTemplateService.Instance
             .FindByBaseType(typeof(Element)))
         {
-            var menuItem = new MenuFlyoutItem { Text = template.Name.Value, Tag = template };
+            var menuItem = new FAMenuFlyoutItem { Text = template.Name.Value, Tag = template };
             menuItem.Click += AddElementFromTemplateClick;
             AddFromTemplateSubMenu.Items.Add(menuItem);
         }
@@ -684,7 +684,7 @@ public sealed partial class TimelineTabView : UserControl
     private void AddElementFromTemplateClick(object? sender, RoutedEventArgs e)
     {
         if (ViewModel == null) return;
-        if (sender is not MenuFlyoutItem { Tag: ObjectTemplateItem template }) return;
+        if (sender is not FAMenuFlyoutItem { Tag: ObjectTemplateItem template }) return;
 
         ViewModel.AddElement.Execute(ElementTemplateResolver.CreateDescription(
             template,
@@ -782,7 +782,7 @@ public sealed partial class TimelineTabView : UserControl
 
     private void ZoomClick(object? sender, RoutedEventArgs e)
     {
-        if (e.Source is MenuFlyoutItem menuItem && ViewModel != null)
+        if (e.Source is FAMenuFlyoutItem menuItem && ViewModel != null)
         {
             float zoom;
             switch (menuItem.CommandParameter)

--- a/src/Beutl.Editor.Components/VersionControl/Views/VersionControlPickerFlyout.cs
+++ b/src/Beutl.Editor.Components/VersionControl/Views/VersionControlPickerFlyout.cs
@@ -90,7 +90,7 @@ internal sealed class VersionControlPickerFlyout : FAPickerFlyoutBase
         ConfigureContent(title);
         PrimaryLabelTextBlock.IsVisible = false;
         PrimaryTextBox.IsVisible = true;
-        PrimaryTextBox.Watermark = watermark;
+        PrimaryTextBox.PlaceholderText = watermark;
         PrimaryTextBox.Text = initialText;
         _confirmOnEnter = true;
 
@@ -196,12 +196,12 @@ internal sealed class VersionControlPickerFlyout : FAPickerFlyoutBase
         MessageTextBlock.IsVisible = false;
         PrimaryLabelTextBlock.Text = null;
         PrimaryLabelTextBlock.IsVisible = false;
-        PrimaryTextBox.Watermark = null;
+        PrimaryTextBox.PlaceholderText = null;
         PrimaryTextBox.Text = null;
         PrimaryTextBox.IsVisible = false;
         SecondaryLabelTextBlock.Text = null;
         SecondaryLabelTextBlock.IsVisible = false;
-        SecondaryTextBox.Watermark = null;
+        SecondaryTextBox.PlaceholderText = null;
         SecondaryTextBox.Text = null;
         SecondaryTextBox.IsVisible = false;
         _confirmOnEnter = false;

--- a/src/Beutl.Editor.Components/VersionControl/Views/VersionControlPickerFlyout.cs
+++ b/src/Beutl.Editor.Components/VersionControl/Views/VersionControlPickerFlyout.cs
@@ -10,7 +10,7 @@ using FluentAvalonia.UI.Controls.Primitives;
 
 namespace Beutl.Editor.Components.VersionControl.Views;
 
-internal sealed class VersionControlPickerFlyout : PickerFlyoutBase
+internal sealed class VersionControlPickerFlyout : FAPickerFlyoutBase
 {
     private sealed record CancellationRequest(
         VersionControlPickerFlyout Flyout,
@@ -77,7 +77,7 @@ internal sealed class VersionControlPickerFlyout : PickerFlyoutBase
 
     internal TextBox SecondaryTextBox { get; }
 
-    internal PickerFlyoutPresenter? Presenter { get; private set; }
+    internal FAPickerFlyoutPresenter? Presenter { get; private set; }
 
     public async Task<string?> ShowTextInputAsync(
         Control anchor,
@@ -150,7 +150,7 @@ internal sealed class VersionControlPickerFlyout : PickerFlyoutBase
 
     protected override Control CreatePresenter()
     {
-        Presenter = new PickerFlyoutPresenter
+        Presenter = new FAPickerFlyoutPresenter
         {
             Width = PresenterWidth,
             Padding = new(PresenterHorizontalPadding, 4),
@@ -267,14 +267,14 @@ internal sealed class VersionControlPickerFlyout : PickerFlyoutBase
     }
 
     private void OnPresenterConfirmed(
-        PickerFlyoutPresenter sender,
+        FAPickerFlyoutPresenter sender,
         object args)
     {
         OnConfirmed();
     }
 
     private void OnPresenterDismissed(
-        PickerFlyoutPresenter sender,
+        FAPickerFlyoutPresenter sender,
         object args)
     {
         Complete(confirmed: false, hide: true);

--- a/src/Beutl.Editor.Components/VersionControlTab/Views/VersionControlTabView.axaml
+++ b/src/Beutl.Editor.Components/VersionControlTab/Views/VersionControlTabView.axaml
@@ -165,7 +165,7 @@
                                 Command="{Binding EnableVersionControlCommand}"
                                 IsVisible="{Binding CanEnableVersionControl.Value}">
                             <StackPanel Orientation="Horizontal" Spacing="8">
-                                <ui:ProgressRing x:Name="EnableVersionControlProgress"
+                                <ui:FAProgressRing x:Name="EnableVersionControlProgress"
                                                  Width="16"
                                                  Height="16"
                                                  IsIndeterminate="True"

--- a/src/Beutl.Editor.Components/VersionControlTab/Views/VersionControlTabView.axaml
+++ b/src/Beutl.Editor.Components/VersionControlTab/Views/VersionControlTabView.axaml
@@ -197,7 +197,7 @@
                                  ScrollViewer.VerticalScrollBarVisibility="Auto"
                                  Text="{Binding CommitMessage.Value}"
                                  TextWrapping="Wrap"
-                                 Watermark="{x:Static lang:Strings.VersionControl_CommitMessage}" />
+                                 PlaceholderText="{x:Static lang:Strings.VersionControl_CommitMessage}" />
                         <SplitButton x:Name="PrimaryActionSplitButton"
                                      Grid.Row="1"
                                      HorizontalAlignment="Stretch"

--- a/src/Beutl.Editor.Components/Views/BpmGridFlyout.cs
+++ b/src/Beutl.Editor.Components/Views/BpmGridFlyout.cs
@@ -7,7 +7,7 @@ using FluentAvalonia.UI.Controls.Primitives;
 
 namespace Beutl.Editor.Components.Views;
 
-public sealed class BpmGridFlyout : PickerFlyoutBase
+public sealed class BpmGridFlyout : FAPickerFlyoutBase
 {
     public static readonly StyledProperty<bool> IsEnabledCheckedProperty
         = AvaloniaProperty.Register<BpmGridFlyout, bool>(nameof(IsEnabledChecked));
@@ -109,7 +109,7 @@ public sealed class BpmGridFlyout : PickerFlyoutBase
             }
         };
 
-        var pfp = new PickerFlyoutPresenter
+        var pfp = new FAPickerFlyoutPresenter
         {
             Width = 240,
             Padding = new Thickness(8),
@@ -146,12 +146,12 @@ public sealed class BpmGridFlyout : PickerFlyoutBase
 
     protected override bool ShouldShowConfirmationButtons() => true;
 
-    private void OnFlyoutConfirmed(PickerFlyoutPresenter sender, object args)
+    private void OnFlyoutConfirmed(FAPickerFlyoutPresenter sender, object args)
     {
         OnConfirmed();
     }
 
-    private void OnFlyoutDismissed(PickerFlyoutPresenter sender, object args)
+    private void OnFlyoutDismissed(FAPickerFlyoutPresenter sender, object args)
     {
         IsEnabledChecked = _initialOptions.IsEnabled;
         Bpm = (decimal)_initialOptions.Bpm;

--- a/src/Beutl.Editor.Components/Views/FallbackObjectView.axaml
+++ b/src/Beutl.Editor.Components/Views/FallbackObjectView.axaml
@@ -20,27 +20,27 @@
         <SelectableTextBlock Text="{Binding ActualTypeName.Value}" />
 
         <WrapPanel Margin="-6">
-            <ui:CommandBar DefaultLabelPosition="Right">
-                <ui:CommandBar.Styles>
-                    <Style Selector="ui|CommandBarButton /template/ TextBlock#TextLabel">
+            <ui:FACommandBar DefaultLabelPosition="Right">
+                <ui:FACommandBar.Styles>
+                    <Style Selector="ui|FACommandBarButton /template/ TextBlock#TextLabel">
                         <Setter Property="VerticalAlignment" Value="Center" />
                         <Setter Property="Margin" Value="8,0,12,0" />
                     </Style>
-                    <Style Selector="ui|CommandBarToggleButton /template/ TextBlock#TextLabel">
+                    <Style Selector="ui|FACommandBarToggleButton /template/ TextBlock#TextLabel">
                         <Setter Property="VerticalAlignment" Value="Center" />
                         <Setter Property="Margin" Value="8,0,12,0" />
                     </Style>
-                </ui:CommandBar.Styles>
-                <ui:CommandBar.PrimaryCommands>
-                    <ui:CommandBarToggleButton x:Name="editJsonToggle"
+                </ui:FACommandBar.Styles>
+                <ui:FACommandBar.PrimaryCommands>
+                    <ui:FACommandBarToggleButton x:Name="editJsonToggle"
                                                IconSource="Edit"
                                                Label="{x:Static lang:Strings.EditJson}" />
 
-                    <ui:CommandBarButton x:Name="jsonSaveButton"
+                    <ui:FACommandBarButton x:Name="jsonSaveButton"
                                          IconSource="Save"
                                          Label="{x:Static lang:Strings.Save}" />
-                </ui:CommandBar.PrimaryCommands>
-            </ui:CommandBar>
+                </ui:FACommandBar.PrimaryCommands>
+            </ui:FACommandBar>
         </WrapPanel>
         <TextBox x:Name="jsonTextBox"
                  MinHeight="80"

--- a/src/Beutl.Editor.Components/Views/MarkerEditFlyout.cs
+++ b/src/Beutl.Editor.Components/Views/MarkerEditFlyout.cs
@@ -12,7 +12,7 @@ using Icon = FluentIcons.Common.Icon;
 
 namespace Beutl.Editor.Components.Views;
 
-public sealed class MarkerEditFlyout : PickerFlyoutBase
+public sealed class MarkerEditFlyout : FAPickerFlyoutBase
 {
     public static readonly StyledProperty<TimeSpan> TimeProperty
         = AvaloniaProperty.Register<MarkerEditFlyout, TimeSpan>(nameof(Time));
@@ -119,7 +119,7 @@ public sealed class MarkerEditFlyout : PickerFlyoutBase
             },
         };
 
-        var pfp = new PickerFlyoutPresenter
+        var pfp = new FAPickerFlyoutPresenter
         {
             Width = 240,
             Padding = new Thickness(8),
@@ -153,12 +153,12 @@ public sealed class MarkerEditFlyout : PickerFlyoutBase
 
     protected override bool ShouldShowConfirmationButtons() => true;
 
-    private void OnFlyoutConfirmed(PickerFlyoutPresenter sender, object args)
+    private void OnFlyoutConfirmed(FAPickerFlyoutPresenter sender, object args)
     {
         OnConfirmed();
     }
 
-    private void OnFlyoutDismissed(PickerFlyoutPresenter sender, object args)
+    private void OnFlyoutDismissed(FAPickerFlyoutPresenter sender, object args)
     {
         MarkerName = _initial.Name;
         Note = _initial.Note;

--- a/src/Beutl.ExceptionHandler/App.axaml.cs
+++ b/src/Beutl.ExceptionHandler/App.axaml.cs
@@ -1,4 +1,7 @@
 ﻿using Avalonia;
+#if DEBUG
+using Avalonia.Diagnostics;
+#endif
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
 
@@ -9,6 +12,9 @@ public class App : Application
     public override void Initialize()
     {
         AvaloniaXamlLoader.Load(this);
+#if DEBUG
+        this.AttachDeveloperTools();
+#endif
     }
 
     public override void OnFrameworkInitializationCompleted()

--- a/src/Beutl.ExceptionHandler/Beutl.ExceptionHandler.csproj
+++ b/src/Beutl.ExceptionHandler/Beutl.ExceptionHandler.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Avalonia" />
     <PackageReference Include="Avalonia.Desktop" />
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" />
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="AvaloniaUI.DiagnosticsSupport" />
     <PackageReference Include="FluentAvaloniaUI" />
     <PackageReference Include="HarfBuzzSharp" />
     <PackageReference Include="ReactiveProperty" />

--- a/src/Beutl.ExceptionHandler/MainWindow.axaml
+++ b/src/Beutl.ExceptionHandler/MainWindow.axaml
@@ -28,7 +28,7 @@
                      Margin="{DynamicResource TaskDialogIconMargin}"
                      HorizontalAlignment="Left"
                      VerticalAlignment="Center">
-                <ui:FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}"
+                <ui:FAFontIcon FontFamily="{StaticResource SymbolThemeFontFamily}"
                              Foreground="{DynamicResource InfoBarErrorSeverityIconBackground}"
                              Glyph="&#xE783;" />
             </Viewbox>
@@ -90,11 +90,11 @@
                 Grid.Row="3"
                 Padding="{StaticResource TaskDialogButtonHostMargin}"
                 Background="{DynamicResource TaskDialogButtonAreaBackground}">
-            <uip:TaskDialogButtonsPanel KeyboardNavigation.TabNavigation="Continue" Spacing="8">
-                <uip:TaskDialogButtonHost x:Name="CloseButton"
+            <uip:FATaskDialogButtonsPanel KeyboardNavigation.TabNavigation="Continue" Spacing="8">
+                <uip:FATaskDialogButtonHost x:Name="CloseButton"
                                           Click="OnCloseClick"
                                           Content="{x:Static lang:Resources.Close}" />
-            </uip:TaskDialogButtonsPanel>
+            </uip:FATaskDialogButtonsPanel>
         </Border>
     </Grid>
 </Window>

--- a/src/Beutl.Extensibility/EditorExtension.cs
+++ b/src/Beutl.Extensibility/EditorExtension.cs
@@ -10,7 +10,7 @@ public abstract class EditorExtension : ViewExtension
 {
     public abstract FilePickerFileType GetFilePickerFileType();
 
-    public abstract IconSource? GetIcon();
+    public abstract FAIconSource? GetIcon();
 
     public abstract bool TryCreateEditor(
         CoreObject obj,

--- a/src/Beutl.Extensibility/EditorExtension.cs
+++ b/src/Beutl.Extensibility/EditorExtension.cs
@@ -10,6 +10,12 @@ public abstract class EditorExtension : ViewExtension
 {
     public abstract FilePickerFileType GetFilePickerFileType();
 
+    /// <summary>Gets the editor icon using FluentAvalonia 3's icon source contract.</summary>
+    /// <remarks>
+    /// The Avalonia 12 host requires extensions to be rebuilt against the matching Beutl SDK.
+    /// Overrides compiled with FluentAvalonia 2's IconSource return type are not binary compatible.
+    /// See docs/extension-authoring/avalonia-12-migration.md for the migration steps.
+    /// </remarks>
     public abstract FAIconSource? GetIcon();
 
     public abstract bool TryCreateEditor(

--- a/src/Beutl.Extensibility/ToolWindowExtension.cs
+++ b/src/Beutl.Extensibility/ToolWindowExtension.cs
@@ -23,7 +23,7 @@ public abstract class ToolWindowExtension : Extension
 
     public virtual bool CanMultiple => false;
 
-    public virtual IconSource? GetIcon() => null;
+    public virtual FAIconSource? GetIcon() => null;
 
     public abstract bool TryCreateContent([NotNullWhen(true)] out Window? window);
 

--- a/src/Beutl.Extensibility/ToolWindowExtension.cs
+++ b/src/Beutl.Extensibility/ToolWindowExtension.cs
@@ -23,6 +23,12 @@ public abstract class ToolWindowExtension : Extension
 
     public virtual bool CanMultiple => false;
 
+    /// <summary>Gets the tool window icon using FluentAvalonia 3's icon source contract.</summary>
+    /// <remarks>
+    /// The Avalonia 12 host requires extensions to be rebuilt against the matching Beutl SDK.
+    /// Overrides compiled with FluentAvalonia 2's IconSource return type are not binary compatible.
+    /// See docs/extension-authoring/avalonia-12-migration.md for the migration steps.
+    /// </remarks>
     public virtual FAIconSource? GetIcon() => null;
 
     public abstract bool TryCreateContent([NotNullWhen(true)] out Window? window);

--- a/src/Beutl.Extensions.FFmpeg/FFmpegInstallDialog.axaml
+++ b/src/Beutl.Extensions.FFmpeg/FFmpegInstallDialog.axaml
@@ -1,4 +1,4 @@
-<ui:ContentDialog x:Class="Beutl.Extensions.FFmpeg.FFmpegInstallDialog"
+<ui:FAContentDialog x:Class="Beutl.Extensions.FFmpeg.FFmpegInstallDialog"
                   xmlns="https://github.com/avaloniaui"
                   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                   xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -14,9 +14,9 @@
                   x:DataType="local:FFmpegInstallDialogViewModel"
                   CloseButtonText="{Binding CloseButtonText.Value}"
                   mc:Ignorable="d">
-    <ui:ContentDialog.Resources>
+    <ui:FAContentDialog.Resources>
         <StaticResource x:Key="ContentDialogMaxWidth" ResourceKey="ContentDialogMinWidth" />
-    </ui:ContentDialog.Resources>
+    </ui:FAContentDialog.Resources>
 
     <StackPanel Spacing="12">
         <TextBlock IsVisible="{Binding !IsCompleted.Value}"
@@ -33,4 +33,4 @@
                      Maximum="{Binding ProgressMax.Value}"
                      Value="{Binding ProgressValue.Value}" />
     </StackPanel>
-</ui:ContentDialog>
+</ui:FAContentDialog>

--- a/src/Beutl.Extensions.FFmpeg/FFmpegInstallDialog.axaml.cs
+++ b/src/Beutl.Extensions.FFmpeg/FFmpegInstallDialog.axaml.cs
@@ -2,16 +2,16 @@
 
 namespace Beutl.Extensions.FFmpeg;
 
-public partial class FFmpegInstallDialog : ContentDialog
+public partial class FFmpegInstallDialog : FAContentDialog
 {
     public FFmpegInstallDialog()
     {
         InitializeComponent();
     }
 
-    protected override Type StyleKeyOverride => typeof(ContentDialog);
+    protected override Type StyleKeyOverride => typeof(FAContentDialog);
 
-    protected override void OnCloseButtonClick(ContentDialogButtonClickEventArgs args)
+    protected override void OnCloseButtonClick(FAContentDialogButtonClickEventArgs args)
     {
         base.OnCloseButtonClick(args);
         if (DataContext is FFmpegInstallDialogViewModel vm)
@@ -20,7 +20,7 @@ public partial class FFmpegInstallDialog : ContentDialog
         }
     }
 
-    protected override void OnClosed(ContentDialogClosedEventArgs args)
+    protected override void OnClosed(FAContentDialogClosedEventArgs args)
     {
         base.OnClosed(args);
         if (DataContext is FFmpegInstallDialogViewModel vm)

--- a/src/Beutl.PackageTools.UI/App.axaml
+++ b/src/Beutl.PackageTools.UI/App.axaml
@@ -23,7 +23,7 @@
             </Setter>
         </Style>
 
-        <Style Selector="ui|InfoBadge.step">
+        <Style Selector="ui|FAInfoBadge.step">
             <Setter Property="Margin" Value="0,2,0,6" />
             <Setter Property="VerticalAlignment" Value="Top" />
         </Style>

--- a/src/Beutl.PackageTools.UI/App.axaml.cs
+++ b/src/Beutl.PackageTools.UI/App.axaml.cs
@@ -1,6 +1,9 @@
 ﻿using System.Globalization;
 
 using Avalonia;
+#if DEBUG
+using Avalonia.Diagnostics;
+#endif
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
@@ -25,6 +28,9 @@ public partial class App : Application
         CultureInfo.CurrentUICulture = view.UICulture;
 
         AvaloniaXamlLoader.Load(this);
+#if DEBUG
+        this.AttachDeveloperTools();
+#endif
         var theme = (FluentAvaloniaTheme)Styles[0];
 
         Color? designAccent = null;

--- a/src/Beutl.PackageTools.UI/Beutl.PackageTools.UI.csproj
+++ b/src/Beutl.PackageTools.UI/Beutl.PackageTools.UI.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Avalonia" />
     <PackageReference Include="Avalonia.Desktop" />
     <PackageReference Include="Avalonia.Themes.Fluent" />
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" />
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="AvaloniaUI.DiagnosticsSupport" />
     <PackageReference Include="DynamicData" />
     <PackageReference Include="FluentAvaloniaUI" />
     <PackageReference Include="FluentIcons.Avalonia.Fluent" />

--- a/src/Beutl.PackageTools.UI/Views/AcceptLicenseTask.axaml
+++ b/src/Beutl.PackageTools.UI/Views/AcceptLicenseTask.axaml
@@ -12,7 +12,7 @@
              mc:Ignorable="d">
     <Grid ColumnDefinitions="16,8,*">
         <Grid HorizontalAlignment="Center" RowDefinitions="Auto,*">
-            <ui:InfoBadge Classes="step"
+            <ui:FAInfoBadge Classes="step"
                           Classes.Critical="{Binding Failed.Value, FallbackValue=False}"
                           Classes.Informational="{Binding !IsRunning.Value, FallbackValue=True}"
                           Classes.Success="{Binding Succeeded.Value, FallbackValue=False}"

--- a/src/Beutl.PackageTools.UI/Views/CleanPage.axaml.cs
+++ b/src/Beutl.PackageTools.UI/Views/CleanPage.axaml.cs
@@ -24,18 +24,18 @@ public partial class CleanPage : PackageToolPage
     {
         _backButton = new(() =>
         {
-            var panel = new TaskDialogButtonsPanel
+            var panel = new FATaskDialogButtonsPanel
             {
                 [KeyboardNavigation.TabNavigationProperty] = KeyboardNavigationMode.Continue,
                 Spacing = 8
             };
-            var backButton = new TaskDialogButtonHost()
+            var backButton = new FATaskDialogButtonHost()
             {
                 Content = Strings.Back
             };
             backButton.Click += (s, e) =>
             {
-                Frame? frame = this.FindAncestorOfType<Frame>();
+                FAFrame? frame = this.FindAncestorOfType<FAFrame>();
                 frame?.GoBack();
             };
             panel.Children.Add(backButton);
@@ -45,17 +45,17 @@ public partial class CleanPage : PackageToolPage
 
         _buttons = new(() =>
         {
-            var panel = new TaskDialogButtonsPanel
+            var panel = new FATaskDialogButtonsPanel
             {
                 [KeyboardNavigation.TabNavigationProperty] = KeyboardNavigationMode.Continue,
                 Spacing = 8
             };
-            var cancelButton = new TaskDialogButtonHost()
+            var cancelButton = new FATaskDialogButtonHost()
             {
                 Content = Strings.Cancel,
                 IsEnabled = false
             };
-            var runButton = new TaskDialogButtonHost()
+            var runButton = new FATaskDialogButtonHost()
             {
                 Content = Strings.Start,
                 Classes = { "accent" }
@@ -75,7 +75,7 @@ public partial class CleanPage : PackageToolPage
                     {
                         cancelButton.IsEnabled = true;
                         runButton.IsEnabled = false;
-                        Frame? frame = this.FindAncestorOfType<Frame>();
+                        FAFrame? frame = this.FindAncestorOfType<FAFrame>();
                         if (frame is not { DataContext: MainViewModel main })
                             return;
 
@@ -112,11 +112,11 @@ public partial class CleanPage : PackageToolPage
             return panel;
         });
 
-        AddHandler(Frame.NavigatedToEvent, OnNavigatedTo, RoutingStrategies.Direct);
+        AddHandler(FAFrame.NavigatedToEvent, OnNavigatedTo, RoutingStrategies.Direct);
         InitializeComponent();
     }
 
-    private void OnNavigatedTo(object? sender, NavigationEventArgs e)
+    private void OnNavigatedTo(object? sender, FANavigationEventArgs e)
     {
         Scroll.SetCurrentValue(ScrollViewer.OffsetProperty, new Vector(0, 0));
         if (e.Parameter is CleanViewModel)

--- a/src/Beutl.PackageTools.UI/Views/DisplayPackagesPage.axaml
+++ b/src/Beutl.PackageTools.UI/Views/DisplayPackagesPage.axaml
@@ -71,12 +71,12 @@
         </DataTemplate>
     </local:PackageToolPage.Resources>
     <local:PackageToolPage.ButtonsContainer>
-        <uip:TaskDialogButtonsPanel KeyboardNavigation.TabNavigation="Continue" Spacing="8">
-            <uip:TaskDialogButtonHost Classes="accent"
+        <uip:FATaskDialogButtonsPanel KeyboardNavigation.TabNavigation="Continue" Spacing="8">
+            <uip:FATaskDialogButtonHost Classes="accent"
                                       Click="OnNextClick"
                                       Content="{x:Static res:Strings.Start}"
                                       IsEnabled="{Binding !IsBusy.Value}" />
-        </uip:TaskDialogButtonsPanel>
+        </uip:FATaskDialogButtonsPanel>
     </local:PackageToolPage.ButtonsContainer>
 
     <Grid Margin="18,9" RowDefinitions="Auto,*">

--- a/src/Beutl.PackageTools.UI/Views/DisplayPackagesPage.axaml.cs
+++ b/src/Beutl.PackageTools.UI/Views/DisplayPackagesPage.axaml.cs
@@ -13,10 +13,10 @@ public partial class DisplayPackagesPage : PackageToolPage
     public DisplayPackagesPage()
     {
         InitializeComponent();
-        AddHandler(Frame.NavigatedToEvent, OnNavigatedTo, RoutingStrategies.Direct);
+        AddHandler(FAFrame.NavigatedToEvent, OnNavigatedTo, RoutingStrategies.Direct);
     }
 
-    private void OnNavigatedTo(object? sender, NavigationEventArgs e)
+    private void OnNavigatedTo(object? sender, FANavigationEventArgs e)
     {
         if (e.Parameter is MainViewModel viewModel)
         {
@@ -26,7 +26,7 @@ public partial class DisplayPackagesPage : PackageToolPage
 
     private void OnNextClick(object? sender, RoutedEventArgs e)
     {
-        Frame? frame = this.FindAncestorOfType<Frame>();
+        FAFrame? frame = this.FindAncestorOfType<FAFrame>();
         if (frame == null) return;
 
         if (frame.CanGoForward)

--- a/src/Beutl.PackageTools.UI/Views/DownloadTask.axaml
+++ b/src/Beutl.PackageTools.UI/Views/DownloadTask.axaml
@@ -12,7 +12,7 @@
              mc:Ignorable="d">
     <Grid ColumnDefinitions="16,8,*">
         <Grid HorizontalAlignment="Center" RowDefinitions="Auto,*">
-            <ui:InfoBadge Classes="step"
+            <ui:FAInfoBadge Classes="step"
                           Classes.Critical="{Binding Failed.Value, FallbackValue=False}"
                           Classes.Informational="{Binding !IsRunning.Value, FallbackValue=True}"
                           Classes.Success="{Binding Succeeded.Value, FallbackValue=False}"

--- a/src/Beutl.PackageTools.UI/Views/InstallPage.axaml
+++ b/src/Beutl.PackageTools.UI/Views/InstallPage.axaml
@@ -14,10 +14,10 @@
                        mc:Ignorable="d">
     <!--  コードビハインドから指定  -->
     <!--<local:PackageToolPage.ButtonsContainer>
-        <uip:TaskDialogButtonsPanel KeyboardNavigation.TabNavigation="Continue" Spacing="8">
-            <uip:TaskDialogButtonHost Content="戻る" />
-            <uip:TaskDialogButtonHost Classes="accent" Content="次へ" />
-        </uip:TaskDialogButtonsPanel>
+        <uip:FATaskDialogButtonsPanel KeyboardNavigation.TabNavigation="Continue" Spacing="8">
+            <uip:FATaskDialogButtonHost Content="戻る" />
+            <uip:FATaskDialogButtonHost Classes="accent" Content="次へ" />
+        </uip:FATaskDialogButtonsPanel>
     </local:PackageToolPage.ButtonsContainer>-->
 
     <Grid Margin="18,9" RowDefinitions="Auto,*">

--- a/src/Beutl.PackageTools.UI/Views/InstallPage.axaml.cs
+++ b/src/Beutl.PackageTools.UI/Views/InstallPage.axaml.cs
@@ -29,18 +29,18 @@ public partial class InstallPage : PackageToolPage
     {
         _buttons = new(() =>
         {
-            var panel = new TaskDialogButtonsPanel
+            var panel = new FATaskDialogButtonsPanel
             {
                 [KeyboardNavigation.TabNavigationProperty] = KeyboardNavigationMode.Continue,
                 Spacing = 8
             };
-            var backButton = new TaskDialogButtonHost()
+            var backButton = new FATaskDialogButtonHost()
             {
                 Content = Strings.Back
             };
             backButton.Click += (s, e) =>
             {
-                Frame? frame = this.FindAncestorOfType<Frame>();
+                FAFrame? frame = this.FindAncestorOfType<FAFrame>();
                 frame?.GoBack();
             };
             panel.Children.Add(backButton);
@@ -50,12 +50,12 @@ public partial class InstallPage : PackageToolPage
 
         _cancelButton = new(() =>
         {
-            var panel = new TaskDialogButtonsPanel
+            var panel = new FATaskDialogButtonsPanel
             {
                 [KeyboardNavigation.TabNavigationProperty] = KeyboardNavigationMode.Continue,
                 Spacing = 8
             };
-            var button = new TaskDialogButtonHost()
+            var button = new FATaskDialogButtonHost()
             {
                 Content = Strings.Cancel
             };
@@ -68,7 +68,7 @@ public partial class InstallPage : PackageToolPage
             return panel;
         });
 
-        AddHandler(Frame.NavigatedToEvent, OnNavigatedTo, RoutingStrategies.Direct);
+        AddHandler(FAFrame.NavigatedToEvent, OnNavigatedTo, RoutingStrategies.Direct);
         InitializeComponent();
 
         // 現在のタスクに応じて、スクロールする
@@ -110,7 +110,7 @@ public partial class InstallPage : PackageToolPage
             });
     }
 
-    private async void OnNavigatedTo(object? sender, NavigationEventArgs e)
+    private async void OnNavigatedTo(object? sender, FANavigationEventArgs e)
     {
         Scroll.SetCurrentValue(ScrollViewer.OffsetProperty, new Vector(0, 0));
         if (e.Parameter is InstallViewModel)
@@ -130,7 +130,7 @@ public partial class InstallPage : PackageToolPage
                 _cts?.Cancel();
                 _cts = new CancellationTokenSource();
                 CancellationToken token = _cts.Token;
-                Frame? frame = this.FindAncestorOfType<Frame>();
+                FAFrame? frame = this.FindAncestorOfType<FAFrame>();
                 if (frame is not { DataContext: MainViewModel main })
                     return;
 

--- a/src/Beutl.PackageTools.UI/Views/MainWindow.axaml
+++ b/src/Beutl.PackageTools.UI/Views/MainWindow.axaml
@@ -13,7 +13,7 @@
         WindowStartupLocation="CenterScreen"
         mc:Ignorable="d">
     <Grid RowDefinitions="*,Auto">
-        <ui:Frame x:Name="frame" />
+        <ui:FAFrame x:Name="frame" />
 
         <Border Grid.Row="1"
                 Padding="{StaticResource TaskDialogButtonHostMargin}"

--- a/src/Beutl.PackageTools.UI/Views/MainWindow.axaml.cs
+++ b/src/Beutl.PackageTools.UI/Views/MainWindow.axaml.cs
@@ -51,7 +51,7 @@ public partial class MainWindow : Window
         frame.NavigateFromObject(viewmodel);
     }
 
-    public sealed class MyNavigationPageFactory : INavigationPageFactory
+    public sealed class MyNavigationPageFactory : IFANavigationPageFactory
     {
         public Control GetPage(Type srcType)
         {

--- a/src/Beutl.PackageTools.UI/Views/ResolveTask.axaml
+++ b/src/Beutl.PackageTools.UI/Views/ResolveTask.axaml
@@ -12,7 +12,7 @@
              mc:Ignorable="d">
     <Grid ColumnDefinitions="16,8,*">
         <Grid HorizontalAlignment="Center" RowDefinitions="Auto,*">
-            <ui:InfoBadge Classes="step"
+            <ui:FAInfoBadge Classes="step"
                           Classes.Critical="{Binding Failed.Value, FallbackValue=False}"
                           Classes.Informational="{Binding !IsRunning.Value, FallbackValue=True}"
                           Classes.Success="{Binding Succeeded.Value, FallbackValue=False}"

--- a/src/Beutl.PackageTools.UI/Views/ResultPage.axaml
+++ b/src/Beutl.PackageTools.UI/Views/ResultPage.axaml
@@ -15,9 +15,9 @@
                        x:DataType="viewModels:ResultViewModel"
                        mc:Ignorable="d">
     <local:PackageToolPage.ButtonsContainer>
-        <uip:TaskDialogButtonsPanel KeyboardNavigation.TabNavigation="Continue" Spacing="8">
-            <uip:TaskDialogButtonHost Click="OnCloseButtonClick" Content="{x:Static res:Strings.Close}" />
-        </uip:TaskDialogButtonsPanel>
+        <uip:FATaskDialogButtonsPanel KeyboardNavigation.TabNavigation="Continue" Spacing="8">
+            <uip:FATaskDialogButtonHost Click="OnCloseButtonClick" Content="{x:Static res:Strings.Close}" />
+        </uip:FATaskDialogButtonsPanel>
     </local:PackageToolPage.ButtonsContainer>
     <local:PackageToolPage.Resources>
         <DataTemplate x:Key="PackageItemDataTemplate" DataType="viewModels:ActionViewModel">
@@ -40,7 +40,7 @@
                                                     RenderOptions.BitmapInterpolationMode="HighQuality"
                                                     Source="{Binding LogoUrl}" />
 
-                    <ui:InfoBadge HorizontalAlignment="Right"
+                    <ui:FAInfoBadge HorizontalAlignment="Right"
                                   VerticalAlignment="Bottom"
                                   Classes="Icon"
                                   Classes.Caution="{Binding Canceled.Value}"
@@ -128,19 +128,19 @@
                         <StackPanel IsVisible="{Binding Succeeded.Value}"
                                     Orientation="Horizontal"
                                     Spacing="4">
-                            <ui:InfoBadge Classes="Success Icon" />
+                            <ui:FAInfoBadge Classes="Success Icon" />
                             <TextBlock Text="{x:Static res:Strings.Succeeded}" />
                         </StackPanel>
                         <StackPanel IsVisible="{Binding Failed.Value}"
                                     Orientation="Horizontal"
                                     Spacing="4">
-                            <ui:InfoBadge Classes="Critical Icon" />
+                            <ui:FAInfoBadge Classes="Critical Icon" />
                             <TextBlock Text="{x:Static res:Strings.Failed}" />
                         </StackPanel>
                         <StackPanel IsVisible="{Binding Canceled.Value}"
                                     Orientation="Horizontal"
                                     Spacing="4">
-                            <ui:InfoBadge Classes="Caution Icon" />
+                            <ui:FAInfoBadge Classes="Caution Icon" />
                             <TextBlock Text="{x:Static res:Strings.Canceled}" />
                         </StackPanel>
 

--- a/src/Beutl.PackageTools.UI/Views/ResultPage.axaml.cs
+++ b/src/Beutl.PackageTools.UI/Views/ResultPage.axaml.cs
@@ -15,10 +15,10 @@ public partial class ResultPage : PackageToolPage
     public ResultPage()
     {
         InitializeComponent();
-        AddHandler(Frame.NavigatedToEvent, OnNavigatedTo, RoutingStrategies.Direct);
+        AddHandler(FAFrame.NavigatedToEvent, OnNavigatedTo, RoutingStrategies.Direct);
     }
 
-    private void OnNavigatedTo(object? sender, NavigationEventArgs e)
+    private void OnNavigatedTo(object? sender, FANavigationEventArgs e)
     {
         if (e.Parameter is ResultViewModel viewModel)
         {
@@ -37,7 +37,7 @@ public partial class ResultPage : PackageToolPage
 
     private void ShowDetailsClick(object? sender, RoutedEventArgs e)
     {
-        Frame? frame = this.FindAncestorOfType<Frame>();
+        FAFrame? frame = this.FindAncestorOfType<FAFrame>();
         if (frame == null) return;
 
         if (sender is StyledElement { DataContext: ActionViewModel item })

--- a/src/Beutl.PackageTools.UI/Views/UninstallPage.axaml.cs
+++ b/src/Beutl.PackageTools.UI/Views/UninstallPage.axaml.cs
@@ -25,18 +25,18 @@ public partial class UninstallPage : PackageToolPage
     {
         _buttons = new(() =>
         {
-            var panel = new TaskDialogButtonsPanel
+            var panel = new FATaskDialogButtonsPanel
             {
                 [KeyboardNavigation.TabNavigationProperty] = KeyboardNavigationMode.Continue,
                 Spacing = 8
             };
-            var backButton = new TaskDialogButtonHost()
+            var backButton = new FATaskDialogButtonHost()
             {
                 Content = Strings.Back
             };
             backButton.Click += (s, e) =>
             {
-                Frame? frame = this.FindAncestorOfType<Frame>();
+                FAFrame? frame = this.FindAncestorOfType<FAFrame>();
                 frame?.GoBack();
             };
             panel.Children.Add(backButton);
@@ -46,12 +46,12 @@ public partial class UninstallPage : PackageToolPage
 
         _cancelButton = new(() =>
         {
-            var panel = new TaskDialogButtonsPanel
+            var panel = new FATaskDialogButtonsPanel
             {
                 [KeyboardNavigation.TabNavigationProperty] = KeyboardNavigationMode.Continue,
                 Spacing = 8
             };
-            var button = new TaskDialogButtonHost()
+            var button = new FATaskDialogButtonHost()
             {
                 Content = Strings.Cancel
             };
@@ -64,11 +64,11 @@ public partial class UninstallPage : PackageToolPage
             return panel;
         });
 
-        AddHandler(Frame.NavigatedToEvent, OnNavigatedTo, RoutingStrategies.Direct);
+        AddHandler(FAFrame.NavigatedToEvent, OnNavigatedTo, RoutingStrategies.Direct);
         InitializeComponent();
     }
 
-    private async void OnNavigatedTo(object? sender, NavigationEventArgs e)
+    private async void OnNavigatedTo(object? sender, FANavigationEventArgs e)
     {
         Scroll.SetCurrentValue(ScrollViewer.OffsetProperty, new Vector(0, 0));
         if (e.Parameter is UninstallViewModel)
@@ -88,7 +88,7 @@ public partial class UninstallPage : PackageToolPage
                 _cts?.Cancel();
                 _cts = new CancellationTokenSource();
                 CancellationToken token = _cts.Token;
-                Frame? frame = this.FindAncestorOfType<Frame>();
+                FAFrame? frame = this.FindAncestorOfType<FAFrame>();
                 if (frame is not { DataContext: MainViewModel main })
                     return;
 

--- a/src/Beutl.PackageTools.UI/Views/VerifyTask.axaml
+++ b/src/Beutl.PackageTools.UI/Views/VerifyTask.axaml
@@ -12,7 +12,7 @@
              mc:Ignorable="d">
     <Grid ColumnDefinitions="16,8,*">
         <Grid HorizontalAlignment="Center" RowDefinitions="Auto,*">
-            <ui:InfoBadge Classes="step"
+            <ui:FAInfoBadge Classes="step"
                           Classes.Critical="{Binding Failed.Value, FallbackValue=False}"
                           Classes.Informational="{Binding !IsRunning.Value, FallbackValue=True}"
                           Classes.Success="{Binding Succeeded.Value, FallbackValue=False}"

--- a/src/Beutl.WaitingDialog/App.axaml.cs
+++ b/src/Beutl.WaitingDialog/App.axaml.cs
@@ -1,4 +1,7 @@
 ﻿using Avalonia;
+#if DEBUG
+using Avalonia.Diagnostics;
+#endif
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
 
@@ -9,6 +12,9 @@ public class App : Application
     public override void Initialize()
     {
         AvaloniaXamlLoader.Load(this);
+#if DEBUG
+        this.AttachDeveloperTools();
+#endif
     }
 
     public override void OnFrameworkInitializationCompleted()

--- a/src/Beutl.WaitingDialog/Beutl.WaitingDialog.csproj
+++ b/src/Beutl.WaitingDialog/Beutl.WaitingDialog.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Avalonia" />
     <PackageReference Include="Avalonia.Desktop" />
     <PackageReference Include="Avalonia.Themes.Fluent" />
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" />
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="AvaloniaUI.DiagnosticsSupport" />
     <PackageReference Include="FluentAvaloniaUI" />
     <PackageReference Include="FluentIcons.Avalonia.Fluent" />
     <PackageReference Include="System.Reactive" />

--- a/src/Beutl.WaitingDialog/MainWindow.axaml
+++ b/src/Beutl.WaitingDialog/MainWindow.axaml
@@ -1,4 +1,4 @@
-<wnd:AppWindow x:Class="Beutl.WaitingDialog.MainWindow"
+<wnd:FAAppWindow x:Class="Beutl.WaitingDialog.MainWindow"
                xmlns="https://github.com/avaloniaui"
                xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -38,7 +38,7 @@
                      Margin="0,0,12,0"
                      DockPanel.Dock="Left"
                      IsVisible="False">
-                <ui:IconSourceElement x:Name="iconSourceElement" />
+                <ui:FAIconSourceElement x:Name="iconSourceElement" />
             </Viewbox>
 
             <TextBlock x:Name="subheader"
@@ -70,4 +70,4 @@
             </StackPanel>
         </ScrollViewer>
     </Grid>
-</wnd:AppWindow>
+</wnd:FAAppWindow>

--- a/src/Beutl.WaitingDialog/MainWindow.axaml.cs
+++ b/src/Beutl.WaitingDialog/MainWindow.axaml.cs
@@ -15,7 +15,7 @@ using Icon = FluentIcons.Common.Icon;
 
 namespace Beutl.WaitingDialog;
 
-public partial class MainWindow : AppWindow
+public partial class MainWindow : FAAppWindow
 {
     private bool _closable;
     private Process? _parentProcess;
@@ -25,9 +25,6 @@ public partial class MainWindow : AppWindow
         InitializeComponent();
         ShowAsDialog = true;
         Topmost = true;
-#if DEBUG
-        this.AttachDevTools();
-#endif
         var titleOption = new Option<string?>("--title");
         var subtitleOption = new Option<string?>("--subtitle");
         var iconOption = new Option<string?>("--icon");

--- a/src/Beutl/App.axaml.cs
+++ b/src/Beutl/App.axaml.cs
@@ -1,4 +1,7 @@
 ﻿using Avalonia;
+#if DEBUG
+using Avalonia.Diagnostics;
+#endif
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Input.Platform;
@@ -57,6 +60,9 @@ public sealed class App : Application
         GraphicsContextFactory.SelectGpuByName(config.GraphicsConfig.SelectedGpuName);
 
         AvaloniaXamlLoader.Load(this);
+#if DEBUG
+        this.AttachDeveloperTools();
+#endif
         RegisterBundledEngineFonts();
         _startUp = GetMainViewModel().RunStartupTask();
         _sideloadExtensionTask = _startUp.GetTask<LoadSideloadExtensionTask>();

--- a/src/Beutl/Beutl.csproj
+++ b/src/Beutl/Beutl.csproj
@@ -60,7 +60,7 @@
     <PackageReference Include="Avalonia.Controls.ItemsRepeater" />
     <PackageReference Include="PanAndZoom" />
     <PackageReference Include="Avalonia.Desktop" />
-    <PackageReference Include="Avalonia.Diagnostics" Condition="'$(Configuration)' == 'Debug'" />
+    <PackageReference Include="AvaloniaUI.DiagnosticsSupport" Condition="'$(Configuration)' == 'Debug'" />
     <PackageReference Include="ReactiveUI.Avalonia" />
     <PackageReference Include="Svg.Controls.Skia.Avalonia" />
     <PackageReference Include="Avalonia.Themes.Fluent" />

--- a/src/Beutl/Beutl.csproj
+++ b/src/Beutl/Beutl.csproj
@@ -77,7 +77,6 @@
     <PackageReference Include="ModelContextProtocol" />
     <PackageReference Include="ModelContextProtocol.AspNetCore" />
     <PackageReference Include="OpenTelemetry" />
-    <PackageReference Include="PanelExtension" />
     <PackageReference Include="ReactiveProperty" />
     <PackageReference Include="Dock.Avalonia" />
     <PackageReference Include="Dock.Model.Inpc" />

--- a/src/Beutl/Helpers/FAFrameHelper.cs
+++ b/src/Beutl/Helpers/FAFrameHelper.cs
@@ -5,11 +5,11 @@ namespace Beutl;
 
 public static class FAFrameHelper
 {
-    public static void RemoveAllStack(this Frame frame, Func<object, bool> func)
+    public static void RemoveAllStack(this FAFrame frame, Func<object, bool> func)
     {
         for (int i = frame.BackStack.Count - 1; i >= 0; i--)
         {
-            PageStackEntry item = frame.BackStack[i];
+            FAPageStackEntry item = frame.BackStack[i];
             if (func(item.Parameter))
             {
                 frame.BackStack.RemoveAt(i);
@@ -18,7 +18,7 @@ public static class FAFrameHelper
 
         for (int i = frame.ForwardStack.Count - 1; i >= 0; i--)
         {
-            PageStackEntry item = frame.ForwardStack[i];
+            FAPageStackEntry item = frame.ForwardStack[i];
             if (func(item.Parameter))
             {
                 frame.ForwardStack.RemoveAt(i);
@@ -26,11 +26,11 @@ public static class FAFrameHelper
         }
     }
 
-    public static T? FindParameter<T>(this Frame frame, Func<T, bool> func)
+    public static T? FindParameter<T>(this FAFrame frame, Func<T, bool> func)
     {
         for (int i = 0; i < frame.BackStack.Count; i++)
         {
-            PageStackEntry item = frame.BackStack[i];
+            FAPageStackEntry item = frame.BackStack[i];
             if (item.Parameter is T typed && func(typed))
             {
                 return typed;
@@ -39,7 +39,7 @@ public static class FAFrameHelper
 
         for (int i = 0; i < frame.ForwardStack.Count; i++)
         {
-            PageStackEntry item = frame.ForwardStack[i];
+            FAPageStackEntry item = frame.ForwardStack[i];
             if (item.Parameter is T typed && func(typed))
             {
                 return typed;

--- a/src/Beutl/Helpers/MacOSTitleBar.cs
+++ b/src/Beutl/Helpers/MacOSTitleBar.cs
@@ -1,0 +1,134 @@
+﻿using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Threading;
+
+namespace Beutl.Helpers;
+
+// Avalonia 12 removed OSXThickTitleBar. Restore its empty NSToolbar for the main window.
+// https://github.com/AvaloniaUI/Avalonia/issues/21119
+internal sealed partial class MacOSTitleBar : IDisposable
+{
+    private readonly Window _window;
+    private readonly INativeToolbar _toolbar;
+    private bool _updateQueued;
+    private bool _disposed;
+
+    internal MacOSTitleBar(Window window, INativeToolbar toolbar)
+    {
+        _window = window;
+        _toolbar = toolbar;
+        _window.PropertyChanged += OnPropertyChanged;
+        _window.Closed += OnClosed;
+        Update();
+    }
+
+    public static MacOSTitleBar? TryAttach(Window window)
+    {
+        window.VerifyAccess();
+        if (!OperatingSystem.IsMacOS()
+            || !window.ExtendClientAreaToDecorationsHint
+            || window.TryGetPlatformHandle() is not { HandleDescriptor: "NSWindow", Handle: not 0 } handle)
+        {
+            return null;
+        }
+
+        NativeToolbar? toolbar = NativeToolbar.TryCreate(handle.Handle);
+        return toolbar is null ? null : new MacOSTitleBar(window, toolbar);
+    }
+
+    private void OnPropertyChanged(object? sender, AvaloniaPropertyChangedEventArgs e)
+    {
+        if (e.Property != Window.WindowStateProperty || _updateQueued || _disposed)
+            return;
+
+        // Avalonia updates the native titlebar during fullscreen transitions. Apply afterward,
+        // using the latest state if more than one transition arrives before the callback runs.
+        _updateQueued = true;
+        _window.Dispatcher.Post(() =>
+        {
+            _updateQueued = false;
+            if (!_disposed)
+                Update();
+        }, DispatcherPriority.Background);
+    }
+
+    private void Update() => _toolbar.Update(_window.WindowState == WindowState.FullScreen);
+
+    private void OnClosed(object? sender, EventArgs e) => Dispose();
+
+    public void Dispose()
+    {
+        _window.VerifyAccess();
+        if (_disposed)
+            return;
+
+        _disposed = true;
+        _window.PropertyChanged -= OnPropertyChanged;
+        _window.Closed -= OnClosed;
+        _toolbar.Dispose();
+    }
+
+    internal interface INativeToolbar : IDisposable
+    {
+        void Update(bool fullScreen);
+    }
+
+    [SupportedOSPlatform("macos")]
+    private sealed partial class NativeToolbar(nint window, nint toolbar) : INativeToolbar
+    {
+        private const string LibObjC = "/usr/lib/libobjc.A.dylib";
+        private readonly nint _window = window;
+        private nint _toolbar = toolbar;
+
+        public static NativeToolbar? TryCreate(nint window)
+        {
+            // 'new' returns an owned reference. NSWindow also retains the toolbar while attached.
+            nint toolbar = Send(objc_getClass("NSToolbar"), sel_registerName("new"));
+            if (toolbar == 0)
+                return null;
+
+            SendBool(toolbar, sel_registerName("setShowsBaselineSeparator:"), false);
+            return new NativeToolbar(window, toolbar);
+        }
+
+        public void Update(bool fullScreen)
+        {
+            // An attached toolbar creates an opaque strip in fullscreen, so remove it there
+            // and reuse it on exit. Keep AppKit's standard fullscreen button auto-hiding.
+            SendPointer(_window, sel_registerName("setToolbar:"), fullScreen ? 0 : _toolbar);
+            SendBool(_window, sel_registerName("setTitlebarAppearsTransparent:"), true);
+            SendPointer(_window, sel_registerName("setTitleVisibility:"), 1); // NSWindowTitleHidden
+        }
+
+        public void Dispose()
+        {
+            // Closed may run after NSWindow was destroyed: only release our owned toolbar.
+            // Never send a message to the cached NSWindow pointer during teardown.
+            if (_toolbar != 0)
+            {
+                SendVoid(_toolbar, sel_registerName("release"));
+                _toolbar = 0;
+            }
+        }
+
+        [LibraryImport(LibObjC, StringMarshalling = StringMarshalling.Utf8)]
+        private static partial nint objc_getClass(string name);
+
+        [LibraryImport(LibObjC, StringMarshalling = StringMarshalling.Utf8)]
+        private static partial nint sel_registerName(string name);
+
+        [LibraryImport(LibObjC, EntryPoint = "objc_msgSend")]
+        private static partial nint Send(nint receiver, nint selector);
+
+        [LibraryImport(LibObjC, EntryPoint = "objc_msgSend")]
+        private static partial void SendVoid(nint receiver, nint selector);
+
+        [LibraryImport(LibObjC, EntryPoint = "objc_msgSend")]
+        private static partial void SendPointer(nint receiver, nint selector, nint value);
+
+        [LibraryImport(LibObjC, EntryPoint = "objc_msgSend")]
+        private static partial void SendBool(nint receiver, nint selector, [MarshalAs(UnmanagedType.I1)] bool value);
+    }
+}

--- a/src/Beutl/Pages/ExtensionsPage.axaml
+++ b/src/Beutl/Pages/ExtensionsPage.axaml
@@ -31,7 +31,7 @@
                          Margin="8,0"
                          HorizontalAlignment="Right"
                          VerticalAlignment="Center"
-                         Watermark="{x:Static lang:Strings.Search}">
+                         PlaceholderText="{x:Static lang:Strings.Search}">
                     <TextBox.InnerRightContent>
                         <Button Click="Search_Click" Theme="{StaticResource TransparentButton}">
                             <icons:FluentIcon Icon="Search" />

--- a/src/Beutl/Pages/ExtensionsPage.axaml
+++ b/src/Beutl/Pages/ExtensionsPage.axaml
@@ -15,17 +15,17 @@
         d:DesignWidth="800"
         mc:Ignorable="d">
     <Panel>
-        <ui:NavigationView x:Name="nav"
+        <ui:FANavigationView x:Name="nav"
                            IsBackButtonVisible="True"
                            IsBackEnabled="{Binding #frame.CanGoBack}"
                            IsSettingsVisible="False"
                            PaneDisplayMode="Top">
-            <ui:NavigationView.Resources>
+            <ui:FANavigationView.Resources>
                 <SolidColorBrush x:Key="NavigationViewContentBackground" Color="Transparent" />
                 <SolidColorBrush x:Key="NavigationViewContentGridBorderBrush" Color="Transparent" />
                 <Thickness x:Key="NavigationViewContentGridBorderThickness">0</Thickness>
-            </ui:NavigationView.Resources>
-            <ui:NavigationView.PaneCustomContent>
+            </ui:FANavigationView.Resources>
+            <ui:FANavigationView.PaneCustomContent>
                 <TextBox x:Name="searchTextBox"
                          MinWidth="250"
                          Margin="8,0"
@@ -38,10 +38,10 @@
                         </Button>
                     </TextBox.InnerRightContent>
                 </TextBox>
-            </ui:NavigationView.PaneCustomContent>
+            </ui:FANavigationView.PaneCustomContent>
 
             <!--  InvalidCastException対策に{x:Null}を指定  -->
-            <ui:Frame x:Name="frame" DataContext="{x:Null}" />
-        </ui:NavigationView>
+            <ui:FAFrame x:Name="frame" DataContext="{x:Null}" />
+        </ui:FANavigationView>
     </Panel>
 </Window>

--- a/src/Beutl/Pages/ExtensionsPage.axaml.cs
+++ b/src/Beutl/Pages/ExtensionsPage.axaml.cs
@@ -24,9 +24,9 @@ public sealed partial class ExtensionsPage : Window
     {
         InitializeComponent();
 
-        List<NavigationViewItem> items = GetItems();
+        List<FANavigationViewItem> items = GetItems();
         nav.MenuItemsSource = items;
-        NavigationViewItem selected = items[0];
+        FANavigationViewItem selected = items[0];
 
         frame.Navigated += Frame_Navigated;
         frame.Navigating += Frame_Navigating;
@@ -41,7 +41,7 @@ public sealed partial class ExtensionsPage : Window
     private void OnFirstLoaded(object? sender, RoutedEventArgs e)
     {
         Loaded -= OnFirstLoaded;
-        if (nav.SelectedItem is NavigationViewItem selected)
+        if (nav.SelectedItem is FANavigationViewItem selected)
         {
             OnItemInvoked(selected);
         }
@@ -58,11 +58,11 @@ public sealed partial class ExtensionsPage : Window
         frame.Navigate(typeof(SearchPage), searchTextBox.Text);
     }
 
-    private static List<NavigationViewItem> GetItems()
+    private static List<FANavigationViewItem> GetItems()
     {
         return
         [
-            new NavigationViewItem()
+            new FANavigationViewItem()
             {
                 Content = "Home",
                 Tag = typeof(DiscoverPage),
@@ -71,7 +71,7 @@ public sealed partial class ExtensionsPage : Window
                     Icon = FluentIcons.Common.Icon.Home
                 }
             },
-            new NavigationViewItem()
+            new FANavigationViewItem()
             {
                 Content = "Library",
                 Tag = typeof(LibraryPage),
@@ -83,25 +83,25 @@ public sealed partial class ExtensionsPage : Window
         ];
     }
 
-    private void Nav_BackRequested(object? sender, NavigationViewBackRequestedEventArgs e)
+    private void Nav_BackRequested(object? sender, FANavigationViewBackRequestedEventArgs e)
     {
         frame.GoBack();
     }
 
-    private void Nav_ItemInvoked(object? sender, NavigationViewItemInvokedEventArgs e)
+    private void Nav_ItemInvoked(object? sender, FANavigationViewItemInvokedEventArgs e)
     {
-        if (e.InvokedItemContainer is NavigationViewItem nvi)
+        if (e.InvokedItemContainer is FANavigationViewItem nvi)
         {
             OnItemInvoked(nvi);
         }
     }
 
-    private void OnItemInvoked(NavigationViewItem nvi)
+    private void OnItemInvoked(FANavigationViewItem nvi)
     {
         if (nvi.Tag is Type typ
             && DataContext is ExtensionsPageViewModel viewModel)
         {
-            NavigationTransitionInfo transitionInfo = SharedNavigationTransitionInfo.Instance;
+            FANavigationTransitionInfo transitionInfo = SharedNavigationTransitionInfo.Instance;
             if (typ == typeof(LibraryPage))
             {
                 frame.Navigate(typ, viewModel.Library, transitionInfo);
@@ -113,7 +113,7 @@ public sealed partial class ExtensionsPage : Window
         }
     }
 
-    private void Frame_Navigating(object sender, NavigatingCancelEventArgs e)
+    private void Frame_Navigating(object sender, FANavigatingCancelEventArgs e)
     {
         _logger.LogInformation("Navigate to '{PageName}'.", e.SourcePageType.Name);
         Type type1 = frame.CurrentSourcePageType;
@@ -126,13 +126,13 @@ public sealed partial class ExtensionsPage : Window
             refreshCommand.Execute();
         }
 
-        if (e.NavigationTransitionInfo is EntranceNavigationTransitionInfo entrance)
+        if (e.NavigationTransitionInfo is FAEntranceNavigationTransitionInfo entrance)
         {
-            if (e.NavigationMode is NavigationMode.Back)
+            if (e.NavigationMode is FANavigationMode.Back)
             {
                 entrance.FromHorizontalOffset = -28;
             }
-            else if (e.NavigationMode is NavigationMode.Forward or NavigationMode.Refresh)
+            else if (e.NavigationMode is FANavigationMode.Forward or FANavigationMode.Refresh)
             {
                 entrance.FromHorizontalOffset = 28;
             }
@@ -153,9 +153,9 @@ public sealed partial class ExtensionsPage : Window
         }
     }
 
-    private void Frame_Navigated(object sender, NavigationEventArgs e)
+    private void Frame_Navigated(object sender, FANavigationEventArgs e)
     {
-        foreach (NavigationViewItem nvi in nav.MenuItems.OfType<NavigationViewItem>())
+        foreach (FANavigationViewItem nvi in nav.MenuItems.OfType<FANavigationViewItem>())
         {
             if (nvi.Tag is Type tag && tag == e.SourcePageType)
             {
@@ -164,7 +164,7 @@ public sealed partial class ExtensionsPage : Window
             }
         }
 
-        foreach (NavigationViewItem nvi in nav.MenuItems.OfType<NavigationViewItem>())
+        foreach (FANavigationViewItem nvi in nav.MenuItems.OfType<FANavigationViewItem>())
         {
             if (nvi.Tag is Type tag && e.SourcePageType.Namespace?.EndsWith($"{tag.Name}s") == true)
             {

--- a/src/Beutl/Pages/ExtensionsPages/DiscoverPage.axaml.cs
+++ b/src/Beutl/Pages/ExtensionsPages/DiscoverPage.axaml.cs
@@ -16,10 +16,10 @@ public sealed partial class DiscoverPage : UserControl
     public DiscoverPage()
     {
         InitializeComponent();
-        AddHandler(Frame.NavigatedToEvent, OnNavigatedTo, RoutingStrategies.Direct);
+        AddHandler(FAFrame.NavigatedToEvent, OnNavigatedTo, RoutingStrategies.Direct);
     }
 
-    private void OnNavigatedTo(object? sender, NavigationEventArgs e)
+    private void OnNavigatedTo(object? sender, FANavigationEventArgs e)
     {
         if (e.Parameter is DiscoverPageViewModel viewModel)
         {
@@ -30,7 +30,7 @@ public sealed partial class DiscoverPage : UserControl
     private void Package_Click(object? sender, RoutedEventArgs e)
     {
         if (sender is Button { DataContext: Package package }
-            && this.FindLogicalAncestorOfType<Frame>() is { } frame)
+            && this.FindLogicalAncestorOfType<FAFrame>() is { } frame)
         {
             frame.Navigate(typeof(PackageDetailsPage), package);
         }

--- a/src/Beutl/Pages/ExtensionsPages/DiscoverPages/PackageDetailsPage.axaml.cs
+++ b/src/Beutl/Pages/ExtensionsPages/DiscoverPages/PackageDetailsPage.axaml.cs
@@ -17,11 +17,11 @@ public partial class PackageDetailsPage : UserControl
     public PackageDetailsPage()
     {
         InitializeComponent();
-        AddHandler(Frame.NavigatedFromEvent, OnNavigatedFrom, RoutingStrategies.Direct);
-        AddHandler(Frame.NavigatedToEvent, OnNavigatedTo, RoutingStrategies.Direct);
+        AddHandler(FAFrame.NavigatedFromEvent, OnNavigatedFrom, RoutingStrategies.Direct);
+        AddHandler(FAFrame.NavigatedToEvent, OnNavigatedTo, RoutingStrategies.Direct);
     }
 
-    private void OnNavigatedTo(object? sender, NavigationEventArgs e)
+    private void OnNavigatedTo(object? sender, FANavigationEventArgs e)
     {
         if (e.Parameter is Package package)
         {
@@ -31,7 +31,7 @@ public partial class PackageDetailsPage : UserControl
         }
     }
 
-    private void OnNavigatedFrom(object? sender, NavigationEventArgs e)
+    private void OnNavigatedFrom(object? sender, FANavigationEventArgs e)
     {
         DestoryDataContext();
     }
@@ -56,7 +56,7 @@ public partial class PackageDetailsPage : UserControl
         if (DataContext is PackageDetailsPageViewModel viewModel
             && viewModel.Package.WebSite.Value is string url)
         {
-            var dialog = new ContentDialog()
+            var dialog = new FAContentDialog()
             {
                 Title = ExtensionsStrings.OpenUrl_Title,
                 Content = new SelectableTextBlock()
@@ -67,7 +67,7 @@ public partial class PackageDetailsPage : UserControl
                 CloseButtonText = Strings.Cancel
             };
 
-            if (await dialog.ShowAsync() is ContentDialogResult.Primary)
+            if (await dialog.ShowAsync() is FAContentDialogResult.Primary)
             {
                 Process.Start(new ProcessStartInfo(url) { UseShellExecute = true, Verb = "open" });
             }
@@ -77,7 +77,7 @@ public partial class PackageDetailsPage : UserControl
     private void OpenPublisherPage_Click(object? sender, RoutedEventArgs e)
     {
         if (DataContext is PackageDetailsPageViewModel viewModel
-            && this.FindLogicalAncestorOfType<Frame>() is { } frame)
+            && this.FindLogicalAncestorOfType<FAFrame>() is { } frame)
         {
             frame.Navigate(typeof(UserProfilePage), viewModel.Package.Owner);
         }

--- a/src/Beutl/Pages/ExtensionsPages/DiscoverPages/SearchPage.axaml
+++ b/src/Beutl/Pages/ExtensionsPages/DiscoverPages/SearchPage.axaml
@@ -3,12 +3,12 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:api="using:Beutl.Api.Objects"
              xmlns:asyncImageLoader="using:AsyncImageLoader"
+             xmlns:controls="using:Beutl.Controls"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:extensionsPage="using:Beutl.ViewModels.ExtensionsPages"
              xmlns:icons="using:FluentIcons.Avalonia.Fluent"
              xmlns:lang="using:Beutl.Language"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:panelx="using:PanelExtension"
              xmlns:ui="using:FluentAvalonia.UI.Controls"
              xmlns:viewModel="using:Beutl.ViewModels.ExtensionsPages.DiscoverPages"
              d:DesignHeight="450"
@@ -52,9 +52,9 @@
 
                 <ItemsRepeater ItemsSource="{Binding Packages}">
                     <ItemsRepeater.Layout>
-                        <panelx:HorizontalGridLayout ColumnSpacing="16"
-                                                     MinItemWidth="345"
-                                                     RowSpacing="16" />
+                        <controls:HorizontalGridLayout ColumnSpacing="16"
+                                                       MinItemWidth="345"
+                                                       RowSpacing="16" />
                     </ItemsRepeater.Layout>
                     <ItemsRepeater.ItemTemplate>
                         <DataTemplate>

--- a/src/Beutl/Pages/ExtensionsPages/DiscoverPages/SearchPage.axaml.cs
+++ b/src/Beutl/Pages/ExtensionsPages/DiscoverPages/SearchPage.axaml.cs
@@ -17,11 +17,11 @@ public partial class SearchPage : UserControl
     public SearchPage()
     {
         InitializeComponent();
-        AddHandler(Frame.NavigatedFromEvent, OnNavigatedFrom, RoutingStrategies.Direct);
-        AddHandler(Frame.NavigatedToEvent, OnNavigatedTo, RoutingStrategies.Direct);
+        AddHandler(FAFrame.NavigatedFromEvent, OnNavigatedFrom, RoutingStrategies.Direct);
+        AddHandler(FAFrame.NavigatedToEvent, OnNavigatedTo, RoutingStrategies.Direct);
     }
 
-    private void OnNavigatedTo(object? sender, NavigationEventArgs e)
+    private void OnNavigatedTo(object? sender, FANavigationEventArgs e)
     {
         if (e.Parameter is string keyword)
         {
@@ -31,7 +31,7 @@ public partial class SearchPage : UserControl
         }
     }
 
-    private void OnNavigatedFrom(object? sender, NavigationEventArgs e)
+    private void OnNavigatedFrom(object? sender, FANavigationEventArgs e)
     {
         DestoryDataContext();
     }
@@ -54,7 +54,7 @@ public partial class SearchPage : UserControl
     private void Package_Click(object? sender, RoutedEventArgs e)
     {
         if (sender is Button { DataContext: Package package }
-            && this.FindLogicalAncestorOfType<Frame>() is { } frame)
+            && this.FindLogicalAncestorOfType<FAFrame>() is { } frame)
         {
             frame.Navigate(typeof(PackageDetailsPage), package);
         }

--- a/src/Beutl/Pages/ExtensionsPages/DiscoverPages/UserProfilePage.axaml
+++ b/src/Beutl/Pages/ExtensionsPages/DiscoverPages/UserProfilePage.axaml
@@ -3,12 +3,12 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:api="using:Beutl.Api.Objects"
              xmlns:asyncImageLoader="using:AsyncImageLoader"
+             xmlns:controls="using:Beutl.Controls"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:extensionsPage="using:Beutl.ViewModels.ExtensionsPages"
              xmlns:icons="using:FluentIcons.Avalonia.Fluent"
              xmlns:lang="using:Beutl.Language"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:panelx="using:PanelExtension"
              xmlns:ui="using:FluentAvalonia.UI.Controls"
              xmlns:viewModel="using:Beutl.ViewModels.ExtensionsPages.DiscoverPages"
              d:DesignHeight="450"
@@ -84,9 +84,9 @@
                                Margin="0,16,0,0"
                                ItemsSource="{Binding Packages}">
                     <ItemsRepeater.Layout>
-                        <panelx:HorizontalGridLayout ColumnSpacing="16"
-                                                     MinItemWidth="345"
-                                                     RowSpacing="16" />
+                        <controls:HorizontalGridLayout ColumnSpacing="16"
+                                                       MinItemWidth="345"
+                                                       RowSpacing="16" />
                     </ItemsRepeater.Layout>
                     <ItemsRepeater.ItemTemplate>
                         <DataTemplate>

--- a/src/Beutl/Pages/ExtensionsPages/DiscoverPages/UserProfilePage.axaml.cs
+++ b/src/Beutl/Pages/ExtensionsPages/DiscoverPages/UserProfilePage.axaml.cs
@@ -14,11 +14,11 @@ public partial class UserProfilePage : UserControl
     public UserProfilePage()
     {
         InitializeComponent();
-        AddHandler(Frame.NavigatedFromEvent, OnNavigatedFrom, RoutingStrategies.Direct);
-        AddHandler(Frame.NavigatedToEvent, OnNavigatedTo, RoutingStrategies.Direct);
+        AddHandler(FAFrame.NavigatedFromEvent, OnNavigatedFrom, RoutingStrategies.Direct);
+        AddHandler(FAFrame.NavigatedToEvent, OnNavigatedTo, RoutingStrategies.Direct);
     }
 
-    private void OnNavigatedTo(object? sender, NavigationEventArgs e)
+    private void OnNavigatedTo(object? sender, FANavigationEventArgs e)
     {
         if (e.Parameter is Profile user)
         {
@@ -27,7 +27,7 @@ public partial class UserProfilePage : UserControl
         }
     }
 
-    private void OnNavigatedFrom(object? sender, NavigationEventArgs e)
+    private void OnNavigatedFrom(object? sender, FANavigationEventArgs e)
     {
         DestoryDataContext();
     }
@@ -45,7 +45,7 @@ public partial class UserProfilePage : UserControl
     private void Package_Click(object? sender, RoutedEventArgs e)
     {
         if (sender is Button { DataContext: Package package }
-            && this.FindLogicalAncestorOfType<Frame>() is { } frame)
+            && this.FindLogicalAncestorOfType<FAFrame>() is { } frame)
         {
             frame.Navigate(typeof(PackageDetailsPage), package);
         }

--- a/src/Beutl/Pages/ExtensionsPages/FadeNavigationTransitionInfo.cs
+++ b/src/Beutl/Pages/ExtensionsPages/FadeNavigationTransitionInfo.cs
@@ -7,7 +7,7 @@ using FluentAvalonia.UI.Media.Animation;
 
 namespace Beutl.Pages.ExtensionsPages;
 
-public sealed class FadeNavigationTransitionInfo : NavigationTransitionInfo
+public sealed class FadeNavigationTransitionInfo : FANavigationTransitionInfo
 {
     public override async void RunAnimation(Animatable ctrl, CancellationToken ct)
     {

--- a/src/Beutl/Pages/ExtensionsPages/LibraryPage.axaml.cs
+++ b/src/Beutl/Pages/ExtensionsPages/LibraryPage.axaml.cs
@@ -15,10 +15,10 @@ public sealed partial class LibraryPage : UserControl
     public LibraryPage()
     {
         InitializeComponent();
-        AddHandler(Frame.NavigatedToEvent, OnNavigatedTo, RoutingStrategies.Direct);
+        AddHandler(FAFrame.NavigatedToEvent, OnNavigatedTo, RoutingStrategies.Direct);
     }
 
-    private void OnNavigatedTo(object? sender, NavigationEventArgs e)
+    private void OnNavigatedTo(object? sender, FANavigationEventArgs e)
     {
         if (e.Parameter is LibraryPageViewModel viewModel)
         {
@@ -28,7 +28,7 @@ public sealed partial class LibraryPage : UserControl
 
     private void Package_Click(object? sender, RoutedEventArgs e)
     {
-        if (this.FindLogicalAncestorOfType<Frame>() is { } frame
+        if (this.FindLogicalAncestorOfType<FAFrame>() is { } frame
             && DataContext is LibraryPageViewModel viewModel
             && sender is Button button)
         {
@@ -47,7 +47,7 @@ public sealed partial class LibraryPage : UserControl
         Button button,
         LocalUserPackageViewModel localPackage,
         LibraryPageViewModel viewModel,
-        Frame frame)
+        FAFrame frame)
     {
         button.IsEnabled = false;
         try
@@ -60,7 +60,7 @@ public sealed partial class LibraryPage : UserControl
             }
             else
             {
-                var dialog = new ContentDialog
+                var dialog = new FAContentDialog
                 {
                     Title = ExtensionsStrings.LocalPackage,
                     Content = $"{string.Format(ExtensionsStrings.Could_not_find_a_package_from_remote, localPackage.Name)}\n" +

--- a/src/Beutl/Pages/SettingsDialog.axaml
+++ b/src/Beutl/Pages/SettingsDialog.axaml
@@ -7,20 +7,20 @@
              d:DesignHeight="450"
              d:DesignWidth="800"
              mc:Ignorable="d">
-    <ui:NavigationView x:Name="nav"
+    <ui:FANavigationView x:Name="nav"
                        IsBackButtonVisible="True"
                        IsBackEnabled="{Binding #frame.CanGoBack}"
                        IsSettingsVisible="False">
-        <ui:NavigationView.Styles>
-            <Style Selector="ui|NavigationView /template/ SplitView Border#ContentGridBorder">
+        <ui:FANavigationView.Styles>
+            <Style Selector="ui|FANavigationView /template/ SplitView Border#ContentGridBorder">
                 <Setter Property="Background" Value="Transparent" />
                 <Setter Property="BorderBrush" Value="Transparent" />
                 <Setter Property="BorderThickness" Value="0" />
                 <Setter Property="Margin" Value="{DynamicResource NavigationViewContentMargin}" />
                 <Setter Property="CornerRadius" Value="{DynamicResource NavigationViewContentGridCornerRadius}" />
             </Style>
-        </ui:NavigationView.Styles>
+        </ui:FANavigationView.Styles>
         <!--  InvalidCastException対策に{x:Null}を指定  -->
-        <ui:Frame x:Name="frame" DataContext="{x:Null}" />
-    </ui:NavigationView>
+        <ui:FAFrame x:Name="frame" DataContext="{x:Null}" />
+    </ui:FANavigationView>
 </UserControl>

--- a/src/Beutl/Pages/SettingsDialog.axaml.cs
+++ b/src/Beutl/Pages/SettingsDialog.axaml.cs
@@ -13,7 +13,7 @@ using FluentIconSource = FluentIcons.Avalonia.Fluent.FluentIconSource;
 
 namespace Beutl.Pages;
 
-public sealed partial class SettingsDialog : AppWindow
+public sealed partial class SettingsDialog : FAAppWindow
 {
     private readonly PageResolver _pageResolver;
     private readonly ILogger _logger = Log.CreateLogger<SettingsDialog>();
@@ -30,30 +30,26 @@ public sealed partial class SettingsDialog : AppWindow
         {
             nav.Margin = new Thickness(0, 22, 0, 0);
             ExtendClientAreaToDecorationsHint = true;
-            ExtendClientAreaChromeHints = ExtendClientAreaChromeHints.PreferSystemChrome;
         }
 
         _pageResolver = new PageResolver();
         _ = new NavigationProvider(frame, _pageResolver);
 
-        List<NavigationViewItem> items = GetItems();
+        List<FANavigationViewItem> items = GetItems();
         nav.MenuItemsSource = items;
-        NavigationViewItem selected = items[0];
+        FANavigationViewItem selected = items[0];
 
         frame.Navigated += Frame_Navigated;
         nav.ItemInvoked += Nav_ItemInvoked;
         nav.BackRequested += Nav_BackRequested;
 
         nav.SelectedItem = selected;
-#if DEBUG
-        this.AttachDevTools();
-#endif
     }
 
     protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
     {
         base.OnAttachedToVisualTree(e);
-        if (nav.SelectedItem is NavigationViewItem selected)
+        if (nav.SelectedItem is FANavigationViewItem selected)
         {
             OnItemInvoked(selected);
         }
@@ -78,45 +74,45 @@ public sealed partial class SettingsDialog : AppWindow
     {
         Type pageType = _pageResolver.GetPageType(obj.GetType());
 
-        NavigationTransitionInfo transitionInfo = SharedNavigationTransitionInfo.Instance;
+        FANavigationTransitionInfo transitionInfo = SharedNavigationTransitionInfo.Instance;
         frame.Navigate(pageType, obj, transitionInfo);
     }
 
-    private static List<NavigationViewItem> GetItems()
+    private static List<FANavigationViewItem> GetItems()
     {
         return
         [
-            new NavigationViewItem()
+            new FANavigationViewItem()
             {
                 Content = SettingsStrings.Account,
                 Tag = typeof(AccountSettingsPage),
                 IconSource = new FluentIconSource { Icon = FluentIcons.Common.Icon.People }
             },
-            new NavigationViewItem()
+            new FANavigationViewItem()
             {
                 Content = Strings.View,
                 Tag = typeof(ViewSettingsPage),
                 IconSource = new FluentIconSource { Icon = FluentIcons.Common.Icon.Eye }
             },
-            new NavigationViewItem()
+            new FANavigationViewItem()
             {
                 Content = Strings.Editor,
                 Tag = typeof(EditorSettingsPage),
                 IconSource = new FluentIconSource { Icon = FluentIcons.Common.Icon.Edit }
             },
-            new NavigationViewItem()
+            new FANavigationViewItem()
             {
                 Content = SettingsStrings.Keymap,
                 Tag = typeof(KeyMapSettingsPage),
                 IconSource = new FluentIconSource { Icon = FluentIcons.Common.Icon.Keyboard }
             },
-            new NavigationViewItem()
+            new FANavigationViewItem()
             {
                 Content = SettingsStrings.Font,
                 Tag = typeof(FontSettingsPage),
                 IconSource = new FluentIconSource { Icon = FluentIcons.Common.Icon.TextFont }
             },
-            new NavigationViewItem()
+            new FANavigationViewItem()
             {
                 Content = Strings.Extensions,
                 Tag = typeof(ExtensionsSettingsPage),
@@ -125,7 +121,7 @@ public sealed partial class SettingsDialog : AppWindow
                     Icon = FluentIcons.Common.Icon.PuzzlePiece
                 }
             },
-            new NavigationViewItem()
+            new FANavigationViewItem()
             {
                 Content = SettingsStrings.AiAgents,
                 Tag = typeof(AiAgentSettingsPage),
@@ -134,7 +130,7 @@ public sealed partial class SettingsDialog : AppWindow
                     Symbol = FluentIcons.Common.Symbol.Chat
                 }
             },
-            new NavigationViewItem()
+            new FANavigationViewItem()
             {
                 Content = Strings.Info,
                 Tag = typeof(InformationPage),
@@ -146,25 +142,25 @@ public sealed partial class SettingsDialog : AppWindow
         ];
     }
 
-    private void Nav_BackRequested(object? sender, NavigationViewBackRequestedEventArgs e)
+    private void Nav_BackRequested(object? sender, FANavigationViewBackRequestedEventArgs e)
     {
         frame.GoBack();
     }
 
-    private void Nav_ItemInvoked(object? sender, NavigationViewItemInvokedEventArgs e)
+    private void Nav_ItemInvoked(object? sender, FANavigationViewItemInvokedEventArgs e)
     {
-        if (e.InvokedItemContainer is NavigationViewItem nvi)
+        if (e.InvokedItemContainer is FANavigationViewItem nvi)
         {
             OnItemInvoked(nvi);
         }
     }
 
-    private void OnItemInvoked(NavigationViewItem nvi)
+    private void OnItemInvoked(FANavigationViewItem nvi)
     {
         if (nvi.Tag is Type typ
             && DataContext is SettingsDialogViewModel settingsPage)
         {
-            NavigationTransitionInfo transitionInfo = SharedNavigationTransitionInfo.Instance;
+            FANavigationTransitionInfo transitionInfo = SharedNavigationTransitionInfo.Instance;
             object? parameter = typ.Name switch
             {
                 "AccountSettingsPage" => settingsPage.Account,
@@ -182,11 +178,11 @@ public sealed partial class SettingsDialog : AppWindow
         }
     }
 
-    private void Frame_Navigated(object sender, NavigationEventArgs e)
+    private void Frame_Navigated(object sender, FANavigationEventArgs e)
     {
         _logger.LogInformation("Navigate to '{PageName}'.", e.SourcePageType.Name);
 
-        foreach (NavigationViewItem nvi in nav.MenuItemsSource)
+        foreach (FANavigationViewItem nvi in nav.MenuItemsSource)
         {
             if (nvi.Tag is Type tag)
             {

--- a/src/Beutl/Pages/SettingsDialog.axaml.cs
+++ b/src/Beutl/Pages/SettingsDialog.axaml.cs
@@ -1,5 +1,5 @@
 ﻿using Avalonia;
-using Avalonia.Platform;
+using Avalonia.Interactivity;
 using Beutl.Controls.Navigation;
 using Beutl.Logging;
 using Beutl.Pages.SettingsPages;
@@ -17,6 +17,7 @@ public sealed partial class SettingsDialog : FAAppWindow
 {
     private readonly PageResolver _pageResolver;
     private readonly ILogger _logger = Log.CreateLogger<SettingsDialog>();
+    private object? _pendingNavigation;
 
     public SettingsDialog()
     {
@@ -44,20 +45,29 @@ public sealed partial class SettingsDialog : FAAppWindow
         nav.BackRequested += Nav_BackRequested;
 
         nav.SelectedItem = selected;
+        frame.Loaded += OnFrameLoaded;
+        Closed += OnClosed;
     }
 
-    protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+    private void OnFrameLoaded(object? sender, RoutedEventArgs e)
     {
-        base.OnAttachedToVisualTree(e);
-        if (nav.SelectedItem is FANavigationViewItem selected)
+        // Avalonia 12 attaches the window from its base constructor, before InitializeComponent.
+        // Navigation also needs the frame's template, so wait for the frame to finish loading.
+        if (_pendingNavigation is { } parameter)
+        {
+            _pendingNavigation = null;
+            OnNavigateRequested(parameter);
+        }
+        else if (frame.Content is null && nav.SelectedItem is FANavigationViewItem selected)
         {
             OnItemInvoked(selected);
         }
     }
 
-    protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+    private void OnClosed(object? sender, EventArgs e)
     {
-        base.OnDetachedFromVisualTree(e);
+        frame.Loaded -= OnFrameLoaded;
+        _pendingNavigation = null;
         frame.SetNavigationState("|\n0\n0");
     }
 
@@ -72,6 +82,14 @@ public sealed partial class SettingsDialog : FAAppWindow
 
     private void OnNavigateRequested(object obj)
     {
+        // App requests the initial page before calling ShowDialog. Keep the latest request
+        // without creating an invisible page or an extra entry in the back stack.
+        if (!frame.IsLoaded)
+        {
+            _pendingNavigation = obj;
+            return;
+        }
+
         Type pageType = _pageResolver.GetPageType(obj.GetType());
 
         FANavigationTransitionInfo transitionInfo = SharedNavigationTransitionInfo.Instance;

--- a/src/Beutl/Pages/SettingsPages/AiAgentSettingsPage.axaml
+++ b/src/Beutl/Pages/SettingsPages/AiAgentSettingsPage.axaml
@@ -157,17 +157,17 @@
                     </ctrls:OptionsDisplayItem.ActionButton>
                 </ctrls:OptionsDisplayItem>
 
-                <ui:InfoBar IsClosable="False"
+                <ui:FAInfoBar IsClosable="False"
                             IsOpen="{Binding !CanInstallMcp.Value}"
                             Message="{x:Static lang:SettingsStrings.AiAgents_McpManual}"
                             Severity="Informational" />
 
-                <ui:InfoBar IsClosable="False"
+                <ui:FAInfoBar IsClosable="False"
                             IsOpen="{Binding IsStdioCommandMissing.Value}"
                             Message="{x:Static lang:SettingsStrings.AiAgents_StdioMissing}"
                             Severity="Warning" />
 
-                <ui:InfoBar IsClosable="False"
+                <ui:FAInfoBar IsClosable="False"
                             IsOpen="{Binding !IsLiveMcpAvailable.Value}"
                             Message="{x:Static lang:SettingsStrings.AiAgents_LiveMcp_NotRunning}"
                             Severity="Warning" />
@@ -276,7 +276,7 @@
                             HorizontalAlignment="Right"
                             Orientation="Horizontal"
                             Spacing="8">
-                    <ui:ProgressRing Width="24"
+                    <ui:FAProgressRing Width="24"
                                      Height="24"
                                      IsVisible="{Binding IsInstalling.Value}" />
                     <Button MinWidth="120"

--- a/src/Beutl/Pages/SettingsPages/AiAgentSettingsPage.axaml.cs
+++ b/src/Beutl/Pages/SettingsPages/AiAgentSettingsPage.axaml.cs
@@ -1,4 +1,5 @@
 ﻿using Avalonia.Controls;
+using Avalonia.Input.Platform;
 using Avalonia.Interactivity;
 using Avalonia.Platform.Storage;
 using Beutl.Language;

--- a/src/Beutl/Pages/SettingsPages/EditorExtensionPriorityPage.axaml
+++ b/src/Beutl/Pages/SettingsPages/EditorExtensionPriorityPage.axaml
@@ -27,26 +27,26 @@
                         Orientation="Vertical"
                         Spacing="4">
                 <Grid RowDefinitions="Auto,Auto,Auto,Auto">
-                    <ui:CommandBar DefaultLabelPosition="Right">
-                        <ui:CommandBar.PrimaryCommands>
-                            <ui:CommandBarElementContainer VerticalContentAlignment="Center">
+                    <ui:FACommandBar DefaultLabelPosition="Right">
+                        <ui:FACommandBar.PrimaryCommands>
+                            <ui:FACommandBarElementContainer VerticalContentAlignment="Center">
                                 <ComboBox Height="36"
                                           MinWidth="250"
                                           Background="Transparent"
                                           BorderThickness="0"
                                           ItemsSource="{CompiledBinding FileExtensions}"
                                           SelectedItem="{CompiledBinding SelectedFileExtension.Value}" />
-                            </ui:CommandBarElementContainer>
-                            <ui:CommandBarButton Click="Add_FileExtension"
+                            </ui:FACommandBarElementContainer>
+                            <ui:FACommandBarButton Click="Add_FileExtension"
                                                  IconSource="Add"
                                                  Label="{x:Static lang:Strings.Add}" />
-                        </ui:CommandBar.PrimaryCommands>
-                        <ui:CommandBar.SecondaryCommands>
-                            <ui:CommandBarButton Command="{CompiledBinding RemoveFileExtension}"
+                        </ui:FACommandBar.PrimaryCommands>
+                        <ui:FACommandBar.SecondaryCommands>
+                            <ui:FACommandBarButton Command="{CompiledBinding RemoveFileExtension}"
                                                  IconSource="Delete"
                                                  Label="{x:Static lang:Strings.Remove}" />
-                        </ui:CommandBar.SecondaryCommands>
-                    </ui:CommandBar>
+                        </ui:FACommandBar.SecondaryCommands>
+                    </ui:FACommandBar>
 
                     <ListBox Grid.Row="1" ItemsSource="{CompiledBinding EditorExtensions1}">
                         <ListBox.ItemTemplate>
@@ -64,21 +64,21 @@
                                         <TextBlock Classes="CaptionTextBlockStyle" Text="{Binding TypeName}" />
                                     </StackPanel>
 
-                                    <ui:CommandBarButton Grid.Column="1"
+                                    <ui:FACommandBarButton Grid.Column="1"
                                                          Command="{Binding #root.DataContext.HighPriority}"
                                                          CommandParameter="{Binding}"
                                                          IconSource="ChevronUp"
                                                          IsVisible="{Binding $parent[ListBoxItem].IsPointerOver}"
                                                          Label="{x:Static lang:SettingsStrings.Higher}" />
 
-                                    <ui:CommandBarButton Grid.Column="2"
+                                    <ui:FACommandBarButton Grid.Column="2"
                                                          Command="{Binding #root.DataContext.LowPriority}"
                                                          CommandParameter="{Binding}"
                                                          IconSource="ChevronDown"
                                                          IsVisible="{Binding $parent[ListBoxItem].IsPointerOver}"
                                                          Label="{x:Static lang:SettingsStrings.Lower}" />
 
-                                    <ui:CommandBarButton Grid.Column="3"
+                                    <ui:FACommandBarButton Grid.Column="3"
                                                          Command="{Binding #root.DataContext.RemoveExt}"
                                                          CommandParameter="{Binding}"
                                                          IconSource="Clear"
@@ -107,7 +107,7 @@
                                         <TextBlock Classes="CaptionTextBlockStyle" Text="{Binding TypeName}" />
                                     </StackPanel>
 
-                                    <ui:CommandBarButton Grid.Column="1"
+                                    <ui:FACommandBarButton Grid.Column="1"
                                                          Command="{Binding #root.DataContext.AddExt}"
                                                          CommandParameter="{Binding}"
                                                          IconSource="Add"

--- a/src/Beutl/Pages/SettingsPages/EditorExtensionPriorityPage.axaml.cs
+++ b/src/Beutl/Pages/SettingsPages/EditorExtensionPriorityPage.axaml.cs
@@ -19,17 +19,17 @@ public sealed partial class EditorExtensionPriorityPage : UserControl
     {
         if (DataContext is EditorExtensionPriorityPageViewModel viewModel)
         {
-            var dialog = new ContentDialog
+            var dialog = new FAContentDialog
             {
                 DataContext = viewModel,
                 Title = SettingsStrings.Add_file_extension,
                 PrimaryButtonText = Strings.Add,
-                [!ContentDialog.IsPrimaryButtonEnabledProperty] = new Binding("CanAddFileExtension.Value"),
+                [!FAContentDialog.IsPrimaryButtonEnabledProperty] = new ReflectionBinding("CanAddFileExtension.Value"),
                 PrimaryButtonCommand = viewModel.AddFileExtension,
                 CloseButtonText = Strings.Cancel,
                 Content = new TextBox
                 {
-                    [!TextBox.TextProperty] = new Binding("FileExtensionInput.Value", BindingMode.TwoWay)
+                    [!TextBox.TextProperty] = new ReflectionBinding("FileExtensionInput.Value") { Mode = BindingMode.TwoWay }
                 }
             };
             await dialog.ShowAsync();

--- a/src/Beutl/Pages/SettingsPages/EditorSettingsPage.axaml
+++ b/src/Beutl/Pages/SettingsPages/EditorSettingsPage.axaml
@@ -268,7 +268,7 @@
                     </ctrls:OptionsDisplayItem.ActionButton>
                 </ctrls:OptionsDisplayItem>
 
-                <ui:InfoBar IsClosable="False"
+                <ui:FAInfoBar IsClosable="False"
                             IsOpen="{CompiledBinding IsNodeCacheEnabled.Value}"
                             Message="{x:Static lang:SettingsStrings.NodeCacheWarning}"
                             Severity="Warning" />

--- a/src/Beutl/Pages/SettingsPages/EditorSettingsPage.axaml
+++ b/src/Beutl/Pages/SettingsPages/EditorSettingsPage.axaml
@@ -133,7 +133,7 @@
                     <ctrls:OptionsDisplayItem.ActionButton>
                         <TextBox MinWidth="250"
                                  VerticalAlignment="Center"
-                                 Watermark="{x:Static lang:SettingsStrings.VersionControl_GitExecutablePath_Automatic}"
+                                 PlaceholderText="{x:Static lang:SettingsStrings.VersionControl_GitExecutablePath_Automatic}"
                                  Text="{CompiledBinding GitExecutablePath.Value, Mode=TwoWay}" />
                     </ctrls:OptionsDisplayItem.ActionButton>
                 </ctrls:OptionsDisplayItem>

--- a/src/Beutl/Pages/SettingsPages/FontSettingsPage.axaml
+++ b/src/Beutl/Pages/SettingsPages/FontSettingsPage.axaml
@@ -12,13 +12,13 @@
              x:DataType="vm:FontSettingsPageViewModel"
              mc:Ignorable="d">
     <StackPanel Margin="10,0">
-        <ui:CommandBar DefaultLabelPosition="Right">
-            <ui:CommandBar.PrimaryCommands>
-                <ui:CommandBarButton Click="AddClick"
+        <ui:FACommandBar DefaultLabelPosition="Right">
+            <ui:FACommandBar.PrimaryCommands>
+                <ui:FACommandBarButton Click="AddClick"
                                      IconSource="Add"
                                      Label="{x:Static lang:Strings.Add}" />
-            </ui:CommandBar.PrimaryCommands>
-        </ui:CommandBar>
+            </ui:FACommandBar.PrimaryCommands>
+        </ui:FACommandBar>
 
         <ListBox ItemsSource="{CompiledBinding FontDirectories}" SelectedItem="{CompiledBinding SelectFont.Value, Mode=TwoWay}">
             <ListBox.ItemTemplate>
@@ -26,7 +26,7 @@
                     <Panel>
                         <TextBlock VerticalAlignment="Center" Text="{Binding}" />
 
-                        <ui:CommandBarButton HorizontalAlignment="Right"
+                        <ui:FACommandBarButton HorizontalAlignment="Right"
                                              Command="{Binding #root.DataContext.Remove, Mode=OneTime}"
                                              CommandParameter="{Binding $self.DataContext}"
                                              IconSource="Delete"

--- a/src/Beutl/Pages/SettingsPages/FontSettingsPage.axaml.cs
+++ b/src/Beutl/Pages/SettingsPages/FontSettingsPage.axaml.cs
@@ -15,7 +15,7 @@ public sealed partial class FontSettingsPage : UserControl
 
     public async void AddClick(object? sender, RoutedEventArgs e)
     {
-        if (VisualRoot is Window window && DataContext is FontSettingsPageViewModel vm)
+        if (TopLevel.GetTopLevel(this) is Window window && DataContext is FontSettingsPageViewModel vm)
         {
             var options = new FolderPickerOpenOptions
             {

--- a/src/Beutl/Pages/SettingsPages/InformationPage.axaml.cs
+++ b/src/Beutl/Pages/SettingsPages/InformationPage.axaml.cs
@@ -1,6 +1,7 @@
 ﻿#pragma warning disable CS0436
 
 using Avalonia.Controls;
+using Avalonia.Input.Platform;
 using Avalonia.Interactivity;
 using Beutl.ViewModels.SettingsPages;
 

--- a/src/Beutl/Pages/SettingsPages/KeyMapSettingsPage.axaml.cs
+++ b/src/Beutl/Pages/SettingsPages/KeyMapSettingsPage.axaml.cs
@@ -48,7 +48,7 @@ public partial class KeyMapSettingsPage : UserControl
     }
 }
 
-public sealed class KeyMapFlyout : PickerFlyoutBase
+public sealed class KeyMapFlyout : FAPickerFlyoutBase
 {
     public static readonly StyledProperty<KeyGesture?> GestureProperty =
         AvaloniaProperty.Register<KeyMapFlyout, KeyGesture?>(nameof(Gesture));
@@ -63,7 +63,7 @@ public sealed class KeyMapFlyout : PickerFlyoutBase
 
     protected override Control CreatePresenter()
     {
-        var pfp = new PickerFlyoutPresenter();
+        var pfp = new FAPickerFlyoutPresenter();
         pfp.Padding = new Thickness(8);
         var textBox = new TextBox();
         textBox.Bind(TextBox.TextProperty, this.GetObservable(GestureProperty)
@@ -115,7 +115,7 @@ public sealed class KeyMapFlyout : PickerFlyoutBase
         Hide();
     }
 
-    private void OnFlyoutConfirmed(PickerFlyoutPresenter sender, object args)
+    private void OnFlyoutConfirmed(FAPickerFlyoutPresenter sender, object args)
     {
         OnConfirmed();
     }

--- a/src/Beutl/Pages/SharedNavigationTransitionInfo.cs
+++ b/src/Beutl/Pages/SharedNavigationTransitionInfo.cs
@@ -4,5 +4,5 @@ namespace Beutl.Pages;
 
 public static class SharedNavigationTransitionInfo
 {
-    public static readonly NavigationTransitionInfo Instance = new EntranceNavigationTransitionInfo();
+    public static readonly FANavigationTransitionInfo Instance = new FAEntranceNavigationTransitionInfo();
 }

--- a/src/Beutl/Services/NotificationService.cs
+++ b/src/Beutl/Services/NotificationService.cs
@@ -40,7 +40,7 @@ public sealed class NotificationServiceHandler : INotificationServiceHandler
         return null;
     }
 
-    private static void Close(InfoBar infoBar)
+    private static void Close(FAInfoBar infoBar)
     {
         // ShowCoreAsync 側の Expiration 待機が後から `if (!infoBar.IsOpen) return;` を
         // 通過して HiddenNotificationPanel に積み直さないように、ここで明示的に閉じる
@@ -80,7 +80,7 @@ public sealed class NotificationServiceHandler : INotificationServiceHandler
                     }
 
                     var dismissed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-                    InfoBar infoBar = BuildInfoBar(notification, dismissed, closeNotification);
+                    FAInfoBar infoBar = BuildInfoBar(notification, dismissed, closeNotification);
                     mainView.NotificationPanel.Children.Add(infoBar);
                     shown = true;
 
@@ -95,7 +95,7 @@ public sealed class NotificationServiceHandler : INotificationServiceHandler
                         return;
 
                     infoBar.IsOpen = false;
-                    // FluentAvalonia の InfoBar クローズアニメーション完了待ち (≈167ms)
+                    // FluentAvalonia の FAInfoBar クローズアニメーション完了待ち (≈167ms)
                     await Task.Delay(167);
 
                     if (GetMainView() is MainView mv)
@@ -132,12 +132,12 @@ public sealed class NotificationServiceHandler : INotificationServiceHandler
         }
     }
 
-    internal InfoBar BuildInfoBar(
+    internal FAInfoBar BuildInfoBar(
         Notification notification,
         TaskCompletionSource dismissed,
         Action closeNotification)
     {
-        var infoBar = new InfoBar
+        var infoBar = new FAInfoBar
         {
             [!TemplatedControl.BackgroundProperty] =
                 new DynamicResourceExtension("SolidBackgroundFillColorTertiaryBrush"),
@@ -149,16 +149,16 @@ public sealed class NotificationServiceHandler : INotificationServiceHandler
             Width = 350,
             Severity = notification.Type switch
             {
-                NotificationType.Success => InfoBarSeverity.Success,
-                NotificationType.Warning => InfoBarSeverity.Warning,
-                NotificationType.Error => InfoBarSeverity.Error,
-                NotificationType.Information or _ => InfoBarSeverity.Informational,
+                NotificationType.Success => FAInfoBarSeverity.Success,
+                NotificationType.Warning => FAInfoBarSeverity.Warning,
+                NotificationType.Error => FAInfoBarSeverity.Error,
+                NotificationType.Information or _ => FAInfoBarSeverity.Informational,
             }
         };
 
         infoBar.CloseButtonClick += (s, _) =>
         {
-            if (s is InfoBar { DataContext: Notification } closingBar)
+            if (s is FAInfoBar { DataContext: Notification } closingBar)
             {
                 closeNotification();
                 Close(closingBar);
@@ -238,7 +238,7 @@ public sealed class NotificationServiceHandler : INotificationServiceHandler
         }
     }
 
-    private static Task WaitPointerExitedAsync(InfoBar infoBar)
+    private static Task WaitPointerExitedAsync(FAInfoBar infoBar)
     {
         var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 

--- a/src/Beutl/Services/PrimitiveImpls/ExtensionsToolWindowExtension.cs
+++ b/src/Beutl/Services/PrimitiveImpls/ExtensionsToolWindowExtension.cs
@@ -20,7 +20,7 @@ public sealed class ExtensionsToolWindowExtension : ToolWindowExtension
 
     public override ToolWindowMode Mode => ToolWindowMode.Dialog;
 
-    public override IconSource? GetIcon()
+    public override FAIconSource? GetIcon()
         => new FluentIconSource() { Icon = Icon.PuzzlePiece };
 
     public override bool TryCreateContent([NotNullWhen(true)] out Window? window)

--- a/src/Beutl/Services/PrimitiveImpls/SceneEditorExtension.cs
+++ b/src/Beutl/Services/PrimitiveImpls/SceneEditorExtension.cs
@@ -133,7 +133,7 @@ public sealed class SceneEditorExtension : EditorExtension
         return false;
     }
 
-    public override IconSource? GetIcon()
+    public override FAIconSource? GetIcon()
     {
         return new FluentIconSource { Icon = Icon.Document };
     }

--- a/src/Beutl/Services/ProjectService.cs
+++ b/src/Beutl/Services/ProjectService.cs
@@ -446,7 +446,7 @@ public sealed class ProjectService
             if (minVersion > NuGetVersion.Parse(BeutlApplication.Version) &&
                 !Preferences.Default.Get("ProjectService.SkipVersionCheck", false))
             {
-                var dialog = new ContentDialog
+                var dialog = new FAContentDialog
                 {
                     Title = MessageStrings.ProjectVersionMismatch_Title,
                     Content = string.Format(MessageStrings.ProjectVersionMismatch_Content, minVersion),

--- a/src/Beutl/Services/StartupNotificationService.cs
+++ b/src/Beutl/Services/StartupNotificationService.cs
@@ -83,9 +83,9 @@ internal static class StartupNotificationService
         return completion.Task;
     }
 
-    internal static ContentDialog CreateSideloadDetailsDialog(IReadOnlyList<string> packageNames)
+    internal static FAContentDialog CreateSideloadDetailsDialog(IReadOnlyList<string> packageNames)
     {
-        return new ContentDialog
+        return new FAContentDialog
         {
             Title = MessageStrings.ConfirmLoadSideloadExtensions,
             Content = new ListBox
@@ -103,7 +103,7 @@ internal static class StartupNotificationService
                 })
             },
             CloseButtonText = Strings.Close,
-            DefaultButton = ContentDialogButton.Close
+            DefaultButton = FAContentDialogButton.Close
         };
     }
 

--- a/src/Beutl/Services/StartupTasks/CheckForPackageUpdatesTask.cs
+++ b/src/Beutl/Services/StartupTasks/CheckForPackageUpdatesTask.cs
@@ -83,7 +83,7 @@ public sealed class CheckForPackageUpdatesTask : StartupTask
                 window.DataContext = context;
                 if (window is Pages.ExtensionsPage page)
                 {
-                    page.nav.SelectedItem = page.nav.MenuItemsSource.Cast<NavigationViewItem>().ElementAtOrDefault(1);
+                    page.nav.SelectedItem = page.nav.MenuItemsSource.Cast<FANavigationViewItem>().ElementAtOrDefault(1);
                 }
 
                 try

--- a/src/Beutl/Services/StartupTasks/CheckForUpdatesTask.cs
+++ b/src/Beutl/Services/StartupTasks/CheckForUpdatesTask.cs
@@ -182,7 +182,7 @@ public sealed class CheckForUpdatesTask : StartupTask
         await App.WaitWindowOpened();
         await Dispatcher.UIThread.InvokeAsync(async () =>
         {
-            var dialog = new ContentDialog
+            var dialog = new FAContentDialog
             {
                 Title = MessageStrings.UpgradeRequired,
                 Content = MessageStrings.VersionDiscontinued,

--- a/src/Beutl/Services/StartupTasks/CrashRecoveryPromptTask.cs
+++ b/src/Beutl/Services/StartupTasks/CrashRecoveryPromptTask.cs
@@ -63,7 +63,7 @@ public sealed class CrashRecoveryPromptTask : StartupTask
 
                 stack.Children.Add(restrictedModeCheckBox);
 
-                var dialog = new ContentDialog
+                var dialog = new FAContentDialog
                 {
                     Title = MessageStrings.PreviousSessionErrorTitle,
                     Content = stack,

--- a/src/Beutl/Services/WindowCapture/WindowCaptureSession.cs
+++ b/src/Beutl/Services/WindowCapture/WindowCaptureSession.cs
@@ -114,7 +114,7 @@ internal sealed class WindowCaptureSession : IAsyncDisposable
 
         // If timer setup fails after ffmpeg/writer are running, leave _stopped=false
         // so the caller's DisposeAsync routes through StopAsync and reclaims them.
-        _timer = new DispatcherTimer(DispatcherPriority.Render)
+        _timer = new DispatcherTimer(DispatcherPriority.Render, _window.Dispatcher)
         {
             Interval = TimeSpan.FromSeconds(1.0 / _frameRate),
         };

--- a/src/Beutl/ViewModels/Dialogs/AiSubtitleDialogViewModel.Advanced.cs
+++ b/src/Beutl/ViewModels/Dialogs/AiSubtitleDialogViewModel.Advanced.cs
@@ -3214,24 +3214,24 @@ public sealed partial class AiSubtitleDialogViewModel
         CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
-        var dialog = new ContentDialog
+        var dialog = new FAContentDialog
         {
             Title = Strings.AiSubtitle_LossySrtExportTitle,
             Content = Strings.AiSubtitle_LossySrtExportMessage,
             PrimaryButtonText = Strings.AiSubtitle_Export,
             CloseButtonText = Strings.Cancel,
-            DefaultButton = ContentDialogButton.Close,
+            DefaultButton = FAContentDialogButton.Close,
         };
         var showDialog = dialog.ShowAsync();
         using CancellationTokenRegistration cancellationRegistration =
             cancellationToken.Register(static state =>
             {
-                var contentDialog = (ContentDialog)state!;
+                var contentDialog = (FAContentDialog)state!;
                 Dispatcher.UIThread.Post(contentDialog.Hide);
             }, dialog);
-        ContentDialogResult result = await showDialog;
+        FAContentDialogResult result = await showDialog;
         cancellationToken.ThrowIfCancellationRequested();
-        return result == ContentDialogResult.Primary;
+        return result == FAContentDialogResult.Primary;
     }
 
     private void DeleteCueCore()

--- a/src/Beutl/ViewModels/ExtensionsPages/PackageOperationHandler.cs
+++ b/src/Beutl/ViewModels/ExtensionsPages/PackageOperationHandler.cs
@@ -246,25 +246,25 @@ internal class PackageOperationHandler
         if (expectedProject is null)
             return true;
 
-        var dialog = new ContentDialog
+        var dialog = new FAContentDialog
         {
             Title = ExtensionsStrings.PackageInstaller,
             Content = ExtensionsStrings.PackageInstaller_CloseProjectConfirmation,
             PrimaryButtonText = Strings.OK,
             SecondaryButtonText = ExtensionsStrings.PackageInstaller_SaveAndClose,
             CloseButtonText = Strings.Cancel,
-            DefaultButton = ContentDialogButton.Secondary
+            DefaultButton = FAContentDialogButton.Secondary
         };
 
         return await HandleProjectCloseChoice(await dialog.ShowAsync(), expectedProject);
     }
 
     internal async Task<bool> HandleProjectCloseChoice(
-        ContentDialogResult result,
+        FAContentDialogResult result,
         Project expectedProject)
     {
         ArgumentNullException.ThrowIfNull(expectedProject);
-        if (result == ContentDialogResult.Secondary)
+        if (result == FAContentDialogResult.Secondary)
         {
             IProjectFileWriteLease? fileWrite = null;
             IDisposable? editorSuspension = null;
@@ -297,7 +297,7 @@ internal class PackageOperationHandler
             }
         }
 
-        if (result == ContentDialogResult.Primary)
+        if (result == FAContentDialogResult.Primary)
         {
             return await _projectService.TryCloseProjectAsync(
                 expectedProject,

--- a/src/Beutl/ViewModels/ExtensionsPages/RemoteUserPackageViewModel.cs
+++ b/src/Beutl/ViewModels/ExtensionsPages/RemoteUserPackageViewModel.cs
@@ -254,7 +254,7 @@ public sealed class RemoteUserPackageViewModel : BaseViewModel, IUserPackageView
                     if (!Package.Paid.Value && Package.FormattedPrice.Value != null)
                     {
                         string priceText = Package.FormattedPrice.Value;
-                        var dialog = new ContentDialog
+                        var dialog = new FAContentDialog
                         {
                             Title = ExtensionsStrings.RemoveFromLibrary_Title,
                             Content = new TextBlock
@@ -266,7 +266,7 @@ public sealed class RemoteUserPackageViewModel : BaseViewModel, IUserPackageView
                             CloseButtonText = Strings.Cancel
                         };
 
-                        if (await dialog.ShowAsync() is not ContentDialogResult.Primary)
+                        if (await dialog.ShowAsync() is not FAContentDialogResult.Primary)
                             return;
                     }
 

--- a/src/Beutl/ViewModels/SettingsPages/EditorSettingsPageViewModel.cs
+++ b/src/Beutl/ViewModels/SettingsPages/EditorSettingsPageViewModel.cs
@@ -213,7 +213,7 @@ public sealed class EditorSettingsPageViewModel : IDisposable
         GitExecutablePath = _versionControlConfig
             .GetObservable(VersionControlConfig.GitExecutablePathProperty)
             .Select(static value => value ?? string.Empty)
-            .ToReactiveProperty()
+            .ToReactiveProperty(initialValue: string.Empty)
             .DisposeWith(_disposables);
         GitExecutablePath.Subscribe(value =>
             {

--- a/src/Beutl/Views/CommandPaletteView.axaml
+++ b/src/Beutl/Views/CommandPaletteView.axaml
@@ -39,7 +39,7 @@
                          FontSize="16"
                          KeyDown="OnQueryKeyDown"
                          Text="{Binding Query.Value, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                         Watermark="{x:Static lang:Strings.CommandPalette_Placeholder}"
+                         PlaceholderText="{x:Static lang:Strings.CommandPalette_Placeholder}"
                          controls:TextBoxAttachment.EnterDownBehavior="None" />
 
                 <Border Grid.Row="1"

--- a/src/Beutl/Views/CommandPaletteView.axaml.cs
+++ b/src/Beutl/Views/CommandPaletteView.axaml.cs
@@ -86,7 +86,7 @@ public partial class CommandPaletteView : UserControl
                 if (captured is not null
                     && captured.TryGetTarget(out IInputElement? target)
                     && target is Visual { IsEffectivelyVisible: true } visual
-                    && visual.GetVisualRoot() is not null
+                    && TopLevel.GetTopLevel(visual) is not null
                     && target.Focus())
                 {
                     return;

--- a/src/Beutl/Views/Dialogs/AddOutputProfileDialog.axaml
+++ b/src/Beutl/Views/Dialogs/AddOutputProfileDialog.axaml
@@ -1,4 +1,4 @@
-<ui:ContentDialog x:Class="Beutl.Views.Dialogs.AddOutputProfileDialog"
+<ui:FAContentDialog x:Class="Beutl.Views.Dialogs.AddOutputProfileDialog"
                   xmlns="https://github.com/avaloniaui"
                   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                   xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -15,9 +15,9 @@
                   CloseButtonText="{x:Static lang:Strings.Close}"
                   PrimaryButtonText="{x:Static lang:Strings.Add}"
                   mc:Ignorable="d">
-    <ui:ContentDialog.Resources>
+    <ui:FAContentDialog.Resources>
         <StaticResource x:Key="ContentDialogMaxWidth" ResourceKey="ContentDialogMinWidth" />
-    </ui:ContentDialog.Resources>
+    </ui:FAContentDialog.Resources>
 
     <StackPanel Spacing="8">
         <TextBlock Text="{x:Static lang:Strings.Extensions}" />
@@ -37,4 +37,4 @@
             </ListBox.ItemTemplate>
         </ListBox>
     </StackPanel>
-</ui:ContentDialog>
+</ui:FAContentDialog>

--- a/src/Beutl/Views/Dialogs/AddOutputProfileDialog.axaml.cs
+++ b/src/Beutl/Views/Dialogs/AddOutputProfileDialog.axaml.cs
@@ -3,16 +3,16 @@ using FluentAvalonia.UI.Controls;
 
 namespace Beutl.Views.Dialogs;
 
-public partial class AddOutputProfileDialog : ContentDialog
+public partial class AddOutputProfileDialog : FAContentDialog
 {
     public AddOutputProfileDialog()
     {
         InitializeComponent();
     }
 
-    protected override Type StyleKeyOverride => typeof(ContentDialog);
+    protected override Type StyleKeyOverride => typeof(FAContentDialog);
 
-    protected override void OnPrimaryButtonClick(ContentDialogButtonClickEventArgs args)
+    protected override void OnPrimaryButtonClick(FAContentDialogButtonClickEventArgs args)
     {
         base.OnPrimaryButtonClick(args);
         if (DataContext is not AddOutputProfileViewModel vm) return;

--- a/src/Beutl/Views/Dialogs/CreateNewProject.axaml
+++ b/src/Beutl/Views/Dialogs/CreateNewProject.axaml
@@ -1,4 +1,4 @@
-<ui:ContentDialog x:Class="Beutl.Views.Dialogs.CreateNewProject"
+<ui:FAContentDialog x:Class="Beutl.Views.Dialogs.CreateNewProject"
                   xmlns="https://github.com/avaloniaui"
                   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                   xmlns:converters="clr-namespace:Beutl.Converters;assembly=Beutl"
@@ -73,4 +73,4 @@
             </StackPanel>
         </Carousel.Items>
     </Carousel>
-</ui:ContentDialog>
+</ui:FAContentDialog>

--- a/src/Beutl/Views/Dialogs/CreateNewProject.axaml.cs
+++ b/src/Beutl/Views/Dialogs/CreateNewProject.axaml.cs
@@ -8,7 +8,7 @@ using FluentAvalonia.UI.Controls;
 
 namespace Beutl.Views.Dialogs;
 
-public sealed partial class CreateNewProject : ContentDialog
+public sealed partial class CreateNewProject : FAContentDialog
 {
     private IDisposable? _sBtnBinding;
 
@@ -17,10 +17,10 @@ public sealed partial class CreateNewProject : ContentDialog
         InitializeComponent();
     }
 
-    protected override Type StyleKeyOverride => typeof(ContentDialog);
+    protected override Type StyleKeyOverride => typeof(FAContentDialog);
 
     // 戻る
-    protected override void OnPrimaryButtonClick(ContentDialogButtonClickEventArgs args)
+    protected override void OnPrimaryButtonClick(FAContentDialogButtonClickEventArgs args)
     {
         base.OnPrimaryButtonClick(args);
         if (carousel.SelectedIndex == 1)
@@ -39,7 +39,7 @@ public sealed partial class CreateNewProject : ContentDialog
     }
 
     // '次へ' or '新規作成'
-    protected override void OnSecondaryButtonClick(ContentDialogButtonClickEventArgs args)
+    protected override void OnSecondaryButtonClick(FAContentDialogButtonClickEventArgs args)
     {
         base.OnSecondaryButtonClick(args);
         if (DataContext is not CreateNewProjectViewModel vm) return;

--- a/src/Beutl/Views/Dialogs/CreateNewProject.axaml.cs
+++ b/src/Beutl/Views/Dialogs/CreateNewProject.axaml.cs
@@ -65,7 +65,7 @@ public sealed partial class CreateNewProject : FAContentDialog
     // 場所を選択
     private async void PickLocation(object? sender, RoutedEventArgs e)
     {
-        if (DataContext is CreateNewProjectViewModel vm && VisualRoot is Window parent)
+        if (DataContext is CreateNewProjectViewModel vm && TopLevel.GetTopLevel(this) is Window parent)
         {
             var options = new FolderPickerOpenOptions();
             IReadOnlyList<IStorageFolder> result = await parent.StorageProvider.OpenFolderPickerAsync(options);

--- a/src/Beutl/Views/Dialogs/CreateNewScene.axaml
+++ b/src/Beutl/Views/Dialogs/CreateNewScene.axaml
@@ -1,4 +1,4 @@
-<ui:ContentDialog x:Class="Beutl.Views.Dialogs.CreateNewScene"
+<ui:FAContentDialog x:Class="Beutl.Views.Dialogs.CreateNewScene"
                   xmlns="https://github.com/avaloniaui"
                   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                   xmlns:converters="clr-namespace:Beutl.Converters;assembly=Beutl"
@@ -37,4 +37,4 @@
         <TextBlock Margin="0,8,0,0" Text="{x:Static lang:Strings.Size}" />
         <TextBox Text="{CompiledBinding Size.Value, Mode=TwoWay, Converter={x:Static converters:AvaloniaPixelSizeConverter.Instance}}" />
     </StackPanel>
-</ui:ContentDialog>
+</ui:FAContentDialog>

--- a/src/Beutl/Views/Dialogs/CreateNewScene.axaml.cs
+++ b/src/Beutl/Views/Dialogs/CreateNewScene.axaml.cs
@@ -8,14 +8,14 @@ using FluentAvalonia.UI.Controls;
 
 namespace Beutl.Views.Dialogs;
 
-public sealed partial class CreateNewScene : ContentDialog
+public sealed partial class CreateNewScene : FAContentDialog
 {
     public CreateNewScene()
     {
         InitializeComponent();
     }
 
-    protected override Type StyleKeyOverride => typeof(ContentDialog);
+    protected override Type StyleKeyOverride => typeof(FAContentDialog);
 
     // 場所を選択
     private async void PickLocation(object? sender, RoutedEventArgs e)

--- a/src/Beutl/Views/Dialogs/CreateNewScene.axaml.cs
+++ b/src/Beutl/Views/Dialogs/CreateNewScene.axaml.cs
@@ -20,7 +20,7 @@ public sealed partial class CreateNewScene : FAContentDialog
     // 場所を選択
     private async void PickLocation(object? sender, RoutedEventArgs e)
     {
-        if (DataContext is CreateNewSceneViewModel vm && VisualRoot is Window parent)
+        if (DataContext is CreateNewSceneViewModel vm && TopLevel.GetTopLevel(this) is Window parent)
         {
             var options = new FolderPickerOpenOptions();
             IReadOnlyList<IStorageFolder> result = await parent.StorageProvider.OpenFolderPickerAsync(options);

--- a/src/Beutl/Views/Dialogs/OutputProgressDialog.axaml
+++ b/src/Beutl/Views/Dialogs/OutputProgressDialog.axaml
@@ -1,4 +1,4 @@
-<ui:ContentDialog x:Class="Beutl.Views.Dialogs.OutputProgressDialog"
+<ui:FAContentDialog x:Class="Beutl.Views.Dialogs.OutputProgressDialog"
                   xmlns="https://github.com/avaloniaui"
                   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                   xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -13,9 +13,9 @@
                   x:DataType="tools:OutputViewModel"
                   CloseButtonClick="OnCloseButtonClick"
                   mc:Ignorable="d">
-    <ui:ContentDialog.Resources>
+    <ui:FAContentDialog.Resources>
         <StaticResource x:Key="ContentDialogMaxWidth" ResourceKey="ContentDialogMinWidth" />
-    </ui:ContentDialog.Resources>
+    </ui:FAContentDialog.Resources>
 
     <StackPanel Spacing="12">
         <TextBlock FontWeight="SemiBold"
@@ -68,4 +68,4 @@
             </StackPanel>
         </Grid>
     </StackPanel>
-</ui:ContentDialog>
+</ui:FAContentDialog>

--- a/src/Beutl/Views/Dialogs/OutputProgressDialog.axaml.cs
+++ b/src/Beutl/Views/Dialogs/OutputProgressDialog.axaml.cs
@@ -5,7 +5,7 @@ using FluentAvalonia.UI.Controls;
 
 namespace Beutl.Views.Dialogs;
 
-public partial class OutputProgressDialog : ContentDialog
+public partial class OutputProgressDialog : FAContentDialog
 {
     private readonly IOutputExecutionController? _execution;
     private IDisposable? _runningSubscription;
@@ -29,9 +29,9 @@ public partial class OutputProgressDialog : ContentDialog
         };
     }
 
-    protected override Type StyleKeyOverride => typeof(ContentDialog);
+    protected override Type StyleKeyOverride => typeof(FAContentDialog);
 
-    private void OnCloseButtonClick(ContentDialog sender, ContentDialogButtonClickEventArgs args)
+    private void OnCloseButtonClick(FAContentDialog sender, FAContentDialogButtonClickEventArgs args)
     {
         if (_execution?.IsRunning.Value == true)
         {

--- a/src/Beutl/Views/Dialogs/SaveFrameDialog.axaml
+++ b/src/Beutl/Views/Dialogs/SaveFrameDialog.axaml
@@ -1,4 +1,4 @@
-<ui:ContentDialog x:Class="Beutl.Views.Dialogs.SaveFrameDialog"
+<ui:FAContentDialog x:Class="Beutl.Views.Dialogs.SaveFrameDialog"
                   xmlns="https://github.com/avaloniaui"
                   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                   xmlns:converters="using:Beutl.Converters"
@@ -16,9 +16,9 @@
                   IsPrimaryButtonEnabled="{CompiledBinding CanSave.Value}"
                   PrimaryButtonText="{x:Static lang:Strings.Save}"
                   mc:Ignorable="d">
-    <ui:ContentDialog.Resources>
+    <ui:FAContentDialog.Resources>
         <StaticResource x:Key="ContentDialogMaxWidth" ResourceKey="ContentDialogMinWidth" />
-    </ui:ContentDialog.Resources>
+    </ui:FAContentDialog.Resources>
 
     <StackPanel Spacing="12">
         <StackPanel Spacing="4">
@@ -45,4 +45,4 @@
                    Text="{CompiledBinding Warning.Value}"
                    TextWrapping="Wrap" />
     </StackPanel>
-</ui:ContentDialog>
+</ui:FAContentDialog>

--- a/src/Beutl/Views/Dialogs/SaveFrameDialog.axaml.cs
+++ b/src/Beutl/Views/Dialogs/SaveFrameDialog.axaml.cs
@@ -2,12 +2,12 @@
 
 namespace Beutl.Views.Dialogs;
 
-public partial class SaveFrameDialog : ContentDialog
+public partial class SaveFrameDialog : FAContentDialog
 {
     public SaveFrameDialog()
     {
         InitializeComponent();
     }
 
-    protected override Type StyleKeyOverride => typeof(ContentDialog);
+    protected override Type StyleKeyOverride => typeof(FAContentDialog);
 }

--- a/src/Beutl/Views/Dialogs/UpdateDialog.axaml
+++ b/src/Beutl/Views/Dialogs/UpdateDialog.axaml
@@ -1,4 +1,4 @@
-<ui:ContentDialog x:Class="Beutl.Views.Dialogs.UpdateDialog"
+<ui:FAContentDialog x:Class="Beutl.Views.Dialogs.UpdateDialog"
                   xmlns="https://github.com/avaloniaui"
                   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                   xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -16,9 +16,9 @@
                   PrimaryButtonCommand="{Binding HandlePrimaryButtonClick}"
                   PrimaryButtonText="{x:Static lang:Strings.Next}"
                   mc:Ignorable="d">
-    <ui:ContentDialog.Resources>
+    <ui:FAContentDialog.Resources>
         <StaticResource x:Key="ContentDialogMaxWidth" ResourceKey="ContentDialogMinWidth" />
-    </ui:ContentDialog.Resources>
+    </ui:FAContentDialog.Resources>
 
     <StackPanel Spacing="8">
         <TextBlock Text="{Binding ProgressText.Value}" />
@@ -26,4 +26,4 @@
                      Maximum="{Binding ProgressMax.Value}"
                      Value="{Binding ProgressValue.Value}" />
     </StackPanel>
-</ui:ContentDialog>
+</ui:FAContentDialog>

--- a/src/Beutl/Views/Dialogs/UpdateDialog.axaml.cs
+++ b/src/Beutl/Views/Dialogs/UpdateDialog.axaml.cs
@@ -3,16 +3,16 @@ using FluentAvalonia.UI.Controls;
 
 namespace Beutl.Views.Dialogs;
 
-public partial class UpdateDialog : ContentDialog
+public partial class UpdateDialog : FAContentDialog
 {
     public UpdateDialog()
     {
         InitializeComponent();
     }
 
-    protected override Type StyleKeyOverride => typeof(ContentDialog);
+    protected override Type StyleKeyOverride => typeof(FAContentDialog);
 
-    protected override void OnCloseButtonClick(ContentDialogButtonClickEventArgs args)
+    protected override void OnCloseButtonClick(FAContentDialogButtonClickEventArgs args)
     {
         base.OnCloseButtonClick(args);
         if (DataContext is not UpdateDialogViewModel vm) return;

--- a/src/Beutl/Views/Dialogs/WindowCaptureDialog.axaml
+++ b/src/Beutl/Views/Dialogs/WindowCaptureDialog.axaml
@@ -48,7 +48,7 @@
                 <TextBox Grid.Column="0"
                          IsReadOnly="True"
                          Text="{Binding OutputPath.Value}"
-                         Watermark="{x:Static lang:Strings.ClickBrowse}" />
+                         PlaceholderText="{x:Static lang:Strings.ClickBrowse}" />
                 <Button Grid.Column="2"
                         Click="OnBrowseClick"
                         Content="{x:Static lang:Strings.Browse}" />

--- a/src/Beutl/Views/Dialogs/WindowCaptureDialog.axaml
+++ b/src/Beutl/Views/Dialogs/WindowCaptureDialog.axaml
@@ -1,4 +1,4 @@
-<ui:ContentDialog x:Class="Beutl.Views.Dialogs.WindowCaptureDialog"
+<ui:FAContentDialog x:Class="Beutl.Views.Dialogs.WindowCaptureDialog"
                   xmlns="https://github.com/avaloniaui"
                   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                   xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -16,9 +16,9 @@
                   IsPrimaryButtonEnabled="{Binding CanStart.Value}"
                   PrimaryButtonText="{x:Static lang:Strings.Start}"
                   mc:Ignorable="d">
-    <ui:ContentDialog.Resources>
+    <ui:FAContentDialog.Resources>
         <StaticResource x:Key="ContentDialogMaxWidth" ResourceKey="ContentDialogMinWidth" />
-    </ui:ContentDialog.Resources>
+    </ui:FAContentDialog.Resources>
 
     <StackPanel Spacing="12">
         <StackPanel Spacing="4">
@@ -55,4 +55,4 @@
             </Grid>
         </StackPanel>
     </StackPanel>
-</ui:ContentDialog>
+</ui:FAContentDialog>

--- a/src/Beutl/Views/Dialogs/WindowCaptureDialog.axaml.cs
+++ b/src/Beutl/Views/Dialogs/WindowCaptureDialog.axaml.cs
@@ -6,14 +6,14 @@ using FluentAvalonia.UI.Controls;
 
 namespace Beutl.Views.Dialogs;
 
-public partial class WindowCaptureDialog : ContentDialog
+public partial class WindowCaptureDialog : FAContentDialog
 {
     public WindowCaptureDialog()
     {
         InitializeComponent();
     }
 
-    protected override Type StyleKeyOverride => typeof(ContentDialog);
+    protected override Type StyleKeyOverride => typeof(FAContentDialog);
 
     private async void OnBrowseClick(object? sender, RoutedEventArgs e)
     {

--- a/src/Beutl/Views/Dock/DockStyles.axaml
+++ b/src/Beutl/Views/Dock/DockStyles.axaml
@@ -165,7 +165,7 @@
     </Style>
 
     <Style Selector="HostWindow">
-        <Setter Property="SystemDecorations" Value="BorderOnly" />
+        <Setter Property="WindowDecorations" Value="BorderOnly" />
         <Setter Property="Background" Value="{DynamicResource DockSurfaceWorkbenchBrush}" />
         <Setter Property="Topmost" Value="True" />
     </Style>

--- a/src/Beutl/Views/Editors/AudioEffectEditor.axaml
+++ b/src/Beutl/Views/Editors/AudioEffectEditor.axaml
@@ -22,10 +22,10 @@
                       ToolTip.Tip="{Binding Description.Value}">
             <ToggleButton.ContextFlyout>
                 <ui:FAMenuFlyout>
-                    <ui:MenuFlyoutItem Click="ChangeEffectTypeClick"
+                    <ui:FAMenuFlyoutItem Click="ChangeEffectTypeClick"
                                        IconSource="New"
                                        Text="{x:Static lang:Strings.Change}" />
-                    <ui:MenuFlyoutItem Click="SetNullClick" Text="{x:Static lang:Strings.Null}" />
+                    <ui:FAMenuFlyoutItem Click="SetNullClick" Text="{x:Static lang:Strings.Null}" />
                 </ui:FAMenuFlyout>
             </ToggleButton.ContextFlyout>
             <ToggleButton.Tag>

--- a/src/Beutl/Views/Editors/BrushEditor.axaml
+++ b/src/Beutl/Views/Editors/BrushEditor.axaml
@@ -55,35 +55,35 @@
                             Theme="{StaticResource TransparentButton}">
                         <Button.ContextFlyout>
                             <ui:FAMenuFlyout Placement="Pointer">
-                                <ui:RadioMenuFlyoutItem Click="ChangeBrushType"
+                                <ui:FARadioMenuFlyoutItem Click="ChangeBrushType"
                                                         IsChecked="{Binding IsSolid.Value, Mode=OneWay}"
                                                         Tag="Solid"
                                                         Text="{x:Static lang:GraphicsStrings.SolidColorBrush}" />
-                                <ui:RadioMenuFlyoutItem Click="ChangeBrushType"
+                                <ui:FARadioMenuFlyoutItem Click="ChangeBrushType"
                                                         IsChecked="{Binding IsLinearGradient.Value, Mode=OneWay}"
                                                         Tag="LinearGradient"
                                                         Text="{x:Static lang:GraphicsStrings.LinearGradientBrush}" />
-                                <ui:RadioMenuFlyoutItem Click="ChangeBrushType"
+                                <ui:FARadioMenuFlyoutItem Click="ChangeBrushType"
                                                         IsChecked="{Binding IsConicGradient.Value, Mode=OneWay}"
                                                         Tag="ConicGradient"
                                                         Text="{x:Static lang:GraphicsStrings.ConicGradientBrush}" />
-                                <ui:RadioMenuFlyoutItem Click="ChangeBrushType"
+                                <ui:FARadioMenuFlyoutItem Click="ChangeBrushType"
                                                         IsChecked="{Binding IsRadialGradient.Value, Mode=OneWay}"
                                                         Tag="RadialGradient"
                                                         Text="{x:Static lang:GraphicsStrings.RadialGradientBrush}" />
-                                <ui:RadioMenuFlyoutItem Click="ChangeBrushType"
+                                <ui:FARadioMenuFlyoutItem Click="ChangeBrushType"
                                                         IsChecked="{Binding IsPerlinNoise.Value, Mode=OneWay}"
                                                         Tag="PerlinNoise"
                                                         Text="{x:Static lang:GraphicsStrings.PerlinNoiseBrush}" />
-                                <ui:RadioMenuFlyoutItem Click="ChangeBrushType"
+                                <ui:FARadioMenuFlyoutItem Click="ChangeBrushType"
                                                         IsChecked="{Binding IsDrawable.Value, Mode=OneWay}"
                                                         Tag="Drawable"
                                                         Text="{x:Static lang:GraphicsStrings.Drawable}" />
-                                <ui:RadioMenuFlyoutItem Click="ChangeBrushType"
+                                <ui:FARadioMenuFlyoutItem Click="ChangeBrushType"
                                                         IsChecked="{Binding IsPresenter.Value, Mode=OneWay}"
                                                         Tag="Presenter"
                                                         Text="{x:Static lang:GraphicsStrings.Presenter}" />
-                                <ui:RadioMenuFlyoutItem Click="ChangeBrushType"
+                                <ui:FARadioMenuFlyoutItem Click="ChangeBrushType"
                                                         IsChecked="{Binding !Value.Value, Mode=OneWay}"
                                                         Tag="Null"
                                                         Text="{x:Static lang:Strings.Null}" />
@@ -108,35 +108,35 @@
                         Theme="{StaticResource TransparentButton}">
                     <Button.Flyout>
                         <ui:FAMenuFlyout Placement="Pointer">
-                            <ui:RadioMenuFlyoutItem Click="ChangeBrushType"
+                            <ui:FARadioMenuFlyoutItem Click="ChangeBrushType"
                                                     IsChecked="{Binding IsSolid.Value, Mode=OneWay}"
                                                     Tag="Solid"
                                                     Text="{x:Static lang:GraphicsStrings.SolidColorBrush}" />
-                            <ui:RadioMenuFlyoutItem Click="ChangeBrushType"
+                            <ui:FARadioMenuFlyoutItem Click="ChangeBrushType"
                                                     IsChecked="{Binding IsLinearGradient.Value, Mode=OneWay}"
                                                     Tag="LinearGradient"
                                                     Text="{x:Static lang:GraphicsStrings.LinearGradientBrush}" />
-                            <ui:RadioMenuFlyoutItem Click="ChangeBrushType"
+                            <ui:FARadioMenuFlyoutItem Click="ChangeBrushType"
                                                     IsChecked="{Binding IsConicGradient.Value, Mode=OneWay}"
                                                     Tag="ConicGradient"
                                                     Text="{x:Static lang:GraphicsStrings.ConicGradientBrush}" />
-                            <ui:RadioMenuFlyoutItem Click="ChangeBrushType"
+                            <ui:FARadioMenuFlyoutItem Click="ChangeBrushType"
                                                     IsChecked="{Binding IsRadialGradient.Value, Mode=OneWay}"
                                                     Tag="RadialGradient"
                                                     Text="{x:Static lang:GraphicsStrings.RadialGradientBrush}" />
-                            <ui:RadioMenuFlyoutItem Click="ChangeBrushType"
+                            <ui:FARadioMenuFlyoutItem Click="ChangeBrushType"
                                                     IsChecked="{Binding IsPerlinNoise.Value, Mode=OneWay}"
                                                     Tag="PerlinNoise"
                                                     Text="{x:Static lang:GraphicsStrings.PerlinNoiseBrush}" />
-                            <ui:RadioMenuFlyoutItem Click="ChangeBrushType"
+                            <ui:FARadioMenuFlyoutItem Click="ChangeBrushType"
                                                     IsChecked="{Binding IsDrawable.Value, Mode=OneWay}"
                                                     Tag="Drawable"
                                                     Text="{x:Static lang:GraphicsStrings.Drawable}" />
-                            <ui:RadioMenuFlyoutItem Click="ChangeBrushType"
+                            <ui:FARadioMenuFlyoutItem Click="ChangeBrushType"
                                                     IsChecked="{Binding IsPresenter.Value, Mode=OneWay}"
                                                     Tag="Presenter"
                                                     Text="{x:Static lang:GraphicsStrings.Presenter}" />
-                            <ui:RadioMenuFlyoutItem Click="ChangeBrushType"
+                            <ui:FARadioMenuFlyoutItem Click="ChangeBrushType"
                                                     IsChecked="{Binding !Value.Value, Mode=OneWay}"
                                                     Tag="Null"
                                                     Text="{x:Static lang:Strings.Null}" />

--- a/src/Beutl/Views/Editors/BrushEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/BrushEditor.axaml.cs
@@ -353,7 +353,7 @@ public sealed partial class BrushEditor : UserControl
     private void ChangeBrushType(object? sender, RoutedEventArgs e)
     {
         if (DataContext is not BrushEditorViewModel { IsDisposed: false } viewModel) return;
-        if (sender is not RadioMenuFlyoutItem { Tag: string tag }) return;
+        if (sender is not FARadioMenuFlyoutItem { Tag: string tag }) return;
 
         if (tag is "PerlinNoise")
         {

--- a/src/Beutl/Views/Editors/CopyPasteMenuHelper.cs
+++ b/src/Beutl/Views/Editors/CopyPasteMenuHelper.cs
@@ -13,7 +13,7 @@ public static class CopyPasteMenuHelper
     {
         var dataContext = control.GetObservable(StyledElement.DataContextProperty)
             .Select(obj => obj as BaseEditorViewModel);
-        var copyMenu = new MenuFlyoutItem { Text = Strings.Copy };
+        var copyMenu = new FAMenuFlyoutItem { Text = Strings.Copy };
         copyMenu.Bind(
             InputElement.IsEnabledProperty,
             dataContext.Select(d => d?.CanCopy ?? Observable.ReturnThenNever(false)).Switch());
@@ -29,7 +29,7 @@ public static class CopyPasteMenuHelper
                 NotificationService.ShowError(Strings.Error, ex.Message);
             }
         };
-        var pasteMenu = new MenuFlyoutItem { Text = Strings.Paste };
+        var pasteMenu = new FAMenuFlyoutItem { Text = Strings.Paste };
         pasteMenu.Bind(
             InputElement.IsEnabledProperty,
             dataContext.Select(d => d?.CanPaste ?? Observable.ReturnThenNever(false)).Switch());
@@ -59,7 +59,7 @@ public static class CopyPasteMenuHelper
 
         if (menuFlyout.Items.Count > 0)
         {
-            var separator = new MenuFlyoutSeparator();
+            var separator = new FAMenuFlyoutSeparator();
             separator.Bind(
                 Visual.IsVisibleProperty,
                 dataContext

--- a/src/Beutl/Views/Editors/CoreObjectEditor.axaml
+++ b/src/Beutl/Views/Editors/CoreObjectEditor.axaml
@@ -23,11 +23,11 @@
                       ToolTip.Tip="{Binding Description.Value}">
             <ToggleButton.ContextFlyout>
                 <ui:FAMenuFlyout>
-                    <ui:MenuFlyoutItem Click="NewClick"
+                    <ui:FAMenuFlyoutItem Click="NewClick"
                                        IconSource="New"
                                        Text="{x:Static lang:Strings.Change}" />
-                    <ui:MenuFlyoutItem Click="SetNullClick" Text="{x:Static lang:Strings.Null}" />
-                    <ui:MenuFlyoutItem Click="Navigate_Click" Text="{x:Static lang:Strings.OpenInTab}" />
+                    <ui:FAMenuFlyoutItem Click="SetNullClick" Text="{x:Static lang:Strings.Null}" />
+                    <ui:FAMenuFlyoutItem Click="Navigate_Click" Text="{x:Static lang:Strings.OpenInTab}" />
                 </ui:FAMenuFlyout>
             </ToggleButton.ContextFlyout>
             <ToggleButton.Tag>
@@ -56,10 +56,10 @@
                         Theme="{StaticResource TransparentButton}">
                     <Button.Flyout>
                         <ui:FAMenuFlyout>
-                            <ui:MenuFlyoutItem Click="NewClick"
+                            <ui:FAMenuFlyoutItem Click="NewClick"
                                                IconSource="New"
                                                Text="{x:Static lang:Strings.Change}" />
-                            <ui:MenuFlyoutItem Click="SetNullClick" Text="{x:Static lang:Strings.Null}" />
+                            <ui:FAMenuFlyoutItem Click="SetNullClick" Text="{x:Static lang:Strings.Null}" />
                         </ui:FAMenuFlyout>
                     </Button.Flyout>
                     <icons:FluentIcon Icon="MoreVertical" />

--- a/src/Beutl/Views/Editors/DisplacementMapTransformEditor.axaml
+++ b/src/Beutl/Views/Editors/DisplacementMapTransformEditor.axaml
@@ -22,31 +22,31 @@
                       ToolTip.Tip="{Binding Description.Value}">
             <ToggleButton.ContextFlyout>
                 <ui:FAMenuFlyout>
-                    <ui:RadioMenuFlyoutItem Click="TransformTypeClicked"
+                    <ui:FARadioMenuFlyoutItem Click="TransformTypeClicked"
                                             IsChecked="{Binding IsTranslate.Value, Mode=OneWay}"
                                             Tag="Translate"
                                             Text="{x:Static lang:GraphicsStrings.TranslateTransform}">
-                        <ui:RadioMenuFlyoutItem.IconSource>
-                            <ui:PathIconSource Data="{StaticResource TranslateTransformIconData}" />
-                        </ui:RadioMenuFlyoutItem.IconSource>
-                    </ui:RadioMenuFlyoutItem>
-                    <ui:RadioMenuFlyoutItem Click="TransformTypeClicked"
+                        <ui:FARadioMenuFlyoutItem.IconSource>
+                            <ui:FAPathIconSource Data="{StaticResource TranslateTransformIconData}" />
+                        </ui:FARadioMenuFlyoutItem.IconSource>
+                    </ui:FARadioMenuFlyoutItem>
+                    <ui:FARadioMenuFlyoutItem Click="TransformTypeClicked"
                                             IsChecked="{Binding IsRotation.Value, Mode=OneWay}"
                                             Tag="Rotation"
                                             Text="{x:Static lang:GraphicsStrings.Rotation}">
-                        <ui:RadioMenuFlyoutItem.IconSource>
-                            <ui:PathIconSource Data="{StaticResource RotationTransformIconData}" />
-                        </ui:RadioMenuFlyoutItem.IconSource>
-                    </ui:RadioMenuFlyoutItem>
-                    <ui:RadioMenuFlyoutItem Click="TransformTypeClicked"
+                        <ui:FARadioMenuFlyoutItem.IconSource>
+                            <ui:FAPathIconSource Data="{StaticResource RotationTransformIconData}" />
+                        </ui:FARadioMenuFlyoutItem.IconSource>
+                    </ui:FARadioMenuFlyoutItem>
+                    <ui:FARadioMenuFlyoutItem Click="TransformTypeClicked"
                                             IsChecked="{Binding IsScale.Value, Mode=OneWay}"
                                             Tag="Scale"
                                             Text="{x:Static lang:GraphicsStrings.Scale}">
-                        <ui:RadioMenuFlyoutItem.IconSource>
-                            <ui:PathIconSource Data="{StaticResource ScaleTransformIconData}" />
-                        </ui:RadioMenuFlyoutItem.IconSource>
-                    </ui:RadioMenuFlyoutItem>
-                    <ui:RadioMenuFlyoutItem Click="TransformTypeClicked"
+                        <ui:FARadioMenuFlyoutItem.IconSource>
+                            <ui:FAPathIconSource Data="{StaticResource ScaleTransformIconData}" />
+                        </ui:FARadioMenuFlyoutItem.IconSource>
+                    </ui:FARadioMenuFlyoutItem>
+                    <ui:FARadioMenuFlyoutItem Click="TransformTypeClicked"
                                             IsChecked="{Binding !Value.Value, Mode=OneWay}"
                                             Tag="Null"
                                             Text="{x:Static lang:Strings.Null}" />

--- a/src/Beutl/Views/Editors/DisplacementMapTransformEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/DisplacementMapTransformEditor.axaml.cs
@@ -23,7 +23,7 @@ public partial class DisplacementMapTransformEditor : UserControl
 
     private void TransformTypeClicked(object? sender, RoutedEventArgs e)
     {
-        if (sender is not MenuFlyoutItem { Tag: string type }) return;
+        if (sender is not FAMenuFlyoutItem { Tag: string type }) return;
         if (DataContext is not DisplacementMapTransformEditorViewModel { IsDisposed: false } viewModel) return;
 
         viewModel.ChangeType(type switch

--- a/src/Beutl/Views/Editors/ExpressionEditorFlyout.cs
+++ b/src/Beutl/Views/Editors/ExpressionEditorFlyout.cs
@@ -7,7 +7,7 @@ using FluentAvalonia.UI.Controls.Primitives;
 
 namespace Beutl.Views.Editors;
 
-public sealed class ExpressionEditorFlyout : PickerFlyoutBase
+public sealed class ExpressionEditorFlyout : FAPickerFlyoutBase
 {
     private ExpressionEditorFlyoutPresenter? _presenter;
 

--- a/src/Beutl/Views/Editors/FilterEffectEditor.axaml
+++ b/src/Beutl/Views/Editors/FilterEffectEditor.axaml
@@ -25,10 +25,10 @@
                       ToolTip.Tip="{Binding Description.Value}">
             <ToggleButton.ContextFlyout>
                 <ui:FAMenuFlyout>
-                    <ui:MenuFlyoutItem Click="ChangeFilterTypeClick"
+                    <ui:FAMenuFlyoutItem Click="ChangeFilterTypeClick"
                                        IconSource="New"
                                        Text="{x:Static lang:Strings.Change}" />
-                    <ui:MenuFlyoutItem Click="SetNullClick" Text="{x:Static lang:Strings.Null}" />
+                    <ui:FAMenuFlyoutItem Click="SetNullClick" Text="{x:Static lang:Strings.Null}" />
                 </ui:FAMenuFlyout>
             </ToggleButton.ContextFlyout>
             <ToggleButton.Tag>
@@ -79,10 +79,10 @@
                         Theme="{StaticResource TransparentButton}">
                     <Button.Flyout>
                         <ui:FAMenuFlyout>
-                            <ui:MenuFlyoutItem Click="ChangeFilterTypeClick"
+                            <ui:FAMenuFlyoutItem Click="ChangeFilterTypeClick"
                                                IconSource="New"
                                                Text="{x:Static lang:Strings.Change}" />
-                            <ui:MenuFlyoutItem Click="SetNullClick" Text="{x:Static lang:Strings.Null}" />
+                            <ui:FAMenuFlyoutItem Click="SetNullClick" Text="{x:Static lang:Strings.Null}" />
                         </ui:FAMenuFlyout>
                     </Button.Flyout>
                     <icons:FluentIcon Icon="MoreVertical" />

--- a/src/Beutl/Views/Editors/GeometryEditor.axaml
+++ b/src/Beutl/Views/Editors/GeometryEditor.axaml
@@ -23,11 +23,11 @@
                       ToolTip.Tip="{Binding Description.Value}">
             <ToggleButton.ContextFlyout>
                 <ui:FAMenuFlyout>
-                    <ui:MenuFlyoutItem Click="SetNullClick"
+                    <ui:FAMenuFlyoutItem Click="SetNullClick"
                                        Text="{x:Static lang:Strings.Null}" />
-                    <ui:MenuFlyoutItem Click="InitializeClick"
+                    <ui:FAMenuFlyoutItem Click="InitializeClick"
                                        Text="{x:Static lang:Strings.Initialize}" />
-                    <ui:MenuFlyoutItem Click="ImportFromSvgPathClick"
+                    <ui:FAMenuFlyoutItem Click="ImportFromSvgPathClick"
                                        Text="{x:Static lang:Strings.ImportSvgPath}" />
                 </ui:FAMenuFlyout>
             </ToggleButton.ContextFlyout>

--- a/src/Beutl/Views/Editors/GeometryEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/GeometryEditor.axaml.cs
@@ -80,7 +80,7 @@ public partial class GeometryEditor : UserControl
         if (DataContext is not GeometryEditorViewModel { IsDisposed: false } viewModel) return;
 
         _logger.LogInformation("Importing from SVG path.");
-        var dialog = new ContentDialog()
+        var dialog = new FAContentDialog()
         {
             Title = Strings.ImportSvgPath,
             PrimaryButtonText = Strings.Import,
@@ -90,7 +90,7 @@ public partial class GeometryEditor : UserControl
         var description = new TextBlock() { Text = Strings.ImportSvgPath_Description };
         var textBox = new TextBox();
 
-        dialog[!ContentDialog.IsPrimaryButtonEnabledProperty] = textBox.GetObservable(TextBox.TextProperty)
+        dialog[!FAContentDialog.IsPrimaryButtonEnabledProperty] = textBox.GetObservable(TextBox.TextProperty)
             .Select(s => !string.IsNullOrWhiteSpace(s))
             .ToBinding();
 
@@ -98,7 +98,7 @@ public partial class GeometryEditor : UserControl
         stack.Children.Add(textBox);
         dialog.Content = stack;
 
-        if (await dialog.ShowAsync() == ContentDialogResult.Primary)
+        if (await dialog.ShowAsync() == FAContentDialogResult.Primary)
         {
             string? path = textBox.Text;
             if (string.IsNullOrWhiteSpace(path))

--- a/src/Beutl/Views/Editors/LibraryItemPickerFlyout.cs
+++ b/src/Beutl/Views/Editors/LibraryItemPickerFlyout.cs
@@ -10,7 +10,7 @@ using Reactive.Bindings.Extensions;
 
 namespace Beutl.Views.Editors;
 
-public sealed class LibraryItemPickerFlyout(SelectLibraryItemDialogViewModel viewModel) : PickerFlyoutBase
+public sealed class LibraryItemPickerFlyout(SelectLibraryItemDialogViewModel viewModel) : FAPickerFlyoutBase
 {
     public event TypedEventHandler<LibraryItemPickerFlyout, EventArgs>? Confirmed;
 

--- a/src/Beutl/Views/Editors/ListEditor.axaml
+++ b/src/Beutl/Views/Editors/ListEditor.axaml
@@ -28,8 +28,8 @@
                         Theme="{StaticResource TransparentButton}">
                     <Button.ContextFlyout>
                         <ui:FAMenuFlyout>
-                            <ui:MenuFlyoutItem Click="InitializeClick" Text="{x:Static lang:Strings.Initialize}" />
-                            <ui:MenuFlyoutItem Click="DeleteClick" Text="{x:Static lang:Strings.Remove}" />
+                            <ui:FAMenuFlyoutItem Click="InitializeClick" Text="{x:Static lang:Strings.Initialize}" />
+                            <ui:FAMenuFlyoutItem Click="DeleteClick" Text="{x:Static lang:Strings.Remove}" />
                         </ui:FAMenuFlyout>
                     </Button.ContextFlyout>
                     <icons:FluentIcon Classes.add="{Binding List.Value, Converter={x:Static ObjectConverters.IsNotNull}}">

--- a/src/Beutl/Views/Editors/NavigateButton.axaml.cs
+++ b/src/Beutl/Views/Editors/NavigateButton.axaml.cs
@@ -93,7 +93,7 @@ public sealed class NavigateButton<T> : NavigateButton
                     {
                         var combobox = new ComboBox { ItemsSource = types, SelectedIndex = 0 };
 
-                        var dialog = new ContentDialog
+                        var dialog = new FAContentDialog
                         {
                             Content = combobox,
                             Title = MessageStrings.MultipleTypesAvailable,
@@ -101,7 +101,7 @@ public sealed class NavigateButton<T> : NavigateButton
                             CloseButtonText = Strings.Cancel
                         };
 
-                        if (await dialog.ShowAsync() == ContentDialogResult.Primary)
+                        if (await dialog.ShowAsync() == FAContentDialogResult.Primary)
                         {
                             return combobox.SelectedItem as Type;
                         }

--- a/src/Beutl/Views/Editors/PathFigureListItemEditor.axaml
+++ b/src/Beutl/Views/Editors/PathFigureListItemEditor.axaml
@@ -49,11 +49,11 @@
                               Theme="{StaticResource TransparentToggleButton}">
                     <ToggleButton.ContextFlyout>
                         <ui:FAMenuFlyout>
-                            <ui:MenuFlyoutItem Click="EditInFrameClicked" Text="{x:Static lang:Strings.EditInFrame}" />
-                            <ui:MenuFlyoutItem Click="EditInTabClicked" Text="{x:Static lang:Strings.EditInTab}" />
+                            <ui:FAMenuFlyoutItem Click="EditInFrameClicked" Text="{x:Static lang:Strings.EditInFrame}" />
+                            <ui:FAMenuFlyoutItem Click="EditInTabClicked" Text="{x:Static lang:Strings.EditInTab}" />
                         </ui:FAMenuFlyout>
                     </ToggleButton.ContextFlyout>
-                    <ui:FontIcon FontFamily="{DynamicResource SymbolThemeFontFamily}" Glyph="&#xEDFB;" />
+                    <ui:FAFontIcon FontFamily="{DynamicResource SymbolThemeFontFamily}" Glyph="&#xEDFB;" />
                 </ToggleButton>
                 <Button Padding="0"
                         HorizontalContentAlignment="Center"
@@ -64,19 +64,19 @@
                     <icons:FluentIcon Icon="Add" />
                     <Button.ContextFlyout>
                         <ui:FAMenuFlyout>
-                            <ui:MenuFlyoutItem Click="AddClick"
+                            <ui:FAMenuFlyoutItem Click="AddClick"
                                                Tag="Cubic"
                                                Text="{x:Static lang:GraphicsStrings.CubicBezierSegment}" />
-                            <ui:MenuFlyoutItem Click="AddClick"
+                            <ui:FAMenuFlyoutItem Click="AddClick"
                                                Tag="Quad"
                                                Text="{x:Static lang:GraphicsStrings.QuadraticBezierSegment}" />
-                            <ui:MenuFlyoutItem Click="AddClick"
+                            <ui:FAMenuFlyoutItem Click="AddClick"
                                                Tag="Line"
                                                Text="{x:Static lang:GraphicsStrings.LineSegment}" />
-                            <ui:MenuFlyoutItem Click="AddClick"
+                            <ui:FAMenuFlyoutItem Click="AddClick"
                                                Tag="Arc"
                                                Text="{x:Static lang:GraphicsStrings.ArcSegment}" />
-                            <ui:MenuFlyoutItem Click="AddClick"
+                            <ui:FAMenuFlyoutItem Click="AddClick"
                                                Tag="Conic"
                                                Text="{x:Static lang:GraphicsStrings.ConicSegment}" />
                         </ui:FAMenuFlyout>

--- a/src/Beutl/Views/Editors/PathFigureListItemEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/PathFigureListItemEditor.axaml.cs
@@ -86,7 +86,7 @@ public partial class PathFigureListItemEditor : UserControl, IListItemEditor
     private void AddClick(object? sender, RoutedEventArgs e)
     {
         if (DataContext is PathFigureEditorViewModel { IsDisposed: false } viewModel
-            && sender is MenuFlyoutItem item)
+            && sender is FAMenuFlyoutItem item)
         {
             try
             {

--- a/src/Beutl/Views/Editors/PenEditor.axaml
+++ b/src/Beutl/Views/Editors/PenEditor.axaml
@@ -34,8 +34,8 @@
                         Theme="{StaticResource TransparentButton}">
                     <Button.ContextFlyout>
                         <ui:FAMenuFlyout>
-                            <ui:MenuFlyoutItem Click="InitializeClick" Text="{x:Static lang:Strings.Initialize}" />
-                            <ui:MenuFlyoutItem Click="DeleteClick" Text="{x:Static lang:Strings.Remove}" />
+                            <ui:FAMenuFlyoutItem Click="InitializeClick" Text="{x:Static lang:Strings.Initialize}" />
+                            <ui:FAMenuFlyoutItem Click="DeleteClick" Text="{x:Static lang:Strings.Remove}" />
                         </ui:FAMenuFlyout>
                     </Button.ContextFlyout>
                     <icons:FluentIcon Icon="Compose" />

--- a/src/Beutl/Views/Editors/PropertyEditorMenu.axaml
+++ b/src/Beutl/Views/Editors/PropertyEditorMenu.axaml
@@ -23,45 +23,45 @@
             Theme="{StaticResource TransparentButton}">
         <Button.ContextFlyout>
             <ui:FAMenuFlyout>
-                <ui:MenuFlyoutItem Command="{Binding Reset}"
+                <ui:FAMenuFlyoutItem Command="{Binding Reset}"
                                    IsEnabled="{Binding CanReset}"
                                    Text="{x:Static lang:Strings.Reset}" />
-                <ui:MenuFlyoutItem x:Name="editAnimationItem"
+                <ui:FAMenuFlyoutItem x:Name="editAnimationItem"
                                    Click="EditAnimation_Click"
                                    Text="{x:Static lang:Strings.EditAnimation}" />
-                <ui:MenuFlyoutItem x:Name="editInlineAnimationItem"
+                <ui:FAMenuFlyoutItem x:Name="editInlineAnimationItem"
                                    Click="EditInlineAnimation_Click"
                                    Text="{x:Static lang:Strings.EditAnimationInInlineView}" />
-                <ui:MenuFlyoutItem x:Name="removeAnimationItem"
+                <ui:FAMenuFlyoutItem x:Name="removeAnimationItem"
                                    Click="RemoveAnimation_Click"
                                    IsEnabled="{Binding HasAnimation.Value}"
                                    Text="{x:Static lang:Strings.RemoveAnimation}" />
-                <ui:ToggleMenuFlyoutItem x:Name="toggleLivePreview"
+                <ui:FAToggleMenuFlyoutItem x:Name="toggleLivePreview"
                                          IsChecked="{ReflectionBinding IsLivePreviewEnabled.Value,
                                                                        Mode=TwoWay}"
                                          IsVisible="False"
                                          Text="{x:Static lang:Strings.EnableLivePreview}" />
-                <ui:ToggleMenuFlyoutItem x:Name="uniformEditorToggle"
+                <ui:FAToggleMenuFlyoutItem x:Name="uniformEditorToggle"
                                          IsChecked="{ReflectionBinding IsUniformEditorEnabled.Value,
                                                                        Mode=TwoWay}"
                                          IsVisible="False"
                                          Text="{x:Static lang:Strings.UniformValue}" />
-                <ui:MenuFlyoutSeparator x:Name="expressionSeparator" IsVisible="False" />
-                <ui:MenuFlyoutItem x:Name="editExpressionItem"
+                <ui:FAMenuFlyoutSeparator x:Name="expressionSeparator" IsVisible="False" />
+                <ui:FAMenuFlyoutItem x:Name="editExpressionItem"
                                    Click="EditExpression_Click"
                                    IsVisible="False"
                                    Text="{x:Static lang:Strings.EditExpression}" />
-                <ui:MenuFlyoutItem x:Name="removeExpressionItem"
+                <ui:FAMenuFlyoutItem x:Name="removeExpressionItem"
                                    Click="RemoveExpression_Click"
                                    IsEnabled="{Binding HasExpression.Value}"
                                    IsVisible="False"
                                    Text="{x:Static lang:Strings.RemoveExpression}" />
-                <ui:MenuFlyoutSeparator x:Name="copyPropertyPathSeparator" IsVisible="False" />
-                <ui:MenuFlyoutItem x:Name="copyPropertyPathItem"
+                <ui:FAMenuFlyoutSeparator x:Name="copyPropertyPathSeparator" IsVisible="False" />
+                <ui:FAMenuFlyoutItem x:Name="copyPropertyPathItem"
                                    Click="CopyPropertyPath_Click"
                                    IsVisible="False"
                                    Text="{x:Static lang:Strings.CopyPropertyPath}" />
-                <ui:MenuFlyoutItem x:Name="copyGetPropertyCodeItem"
+                <ui:FAMenuFlyoutItem x:Name="copyGetPropertyCodeItem"
                                    Click="CopyGetPropertyCode_Click"
                                    IsVisible="False"
                                    Text="{x:Static lang:Strings.CopyGetPropertyCode}" />

--- a/src/Beutl/Views/Editors/PropertyEditorMenu.axaml.cs
+++ b/src/Beutl/Views/Editors/PropertyEditorMenu.axaml.cs
@@ -1,5 +1,6 @@
 ﻿using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Input.Platform;
 using Avalonia.Interactivity;
 using Beutl.Animation;
 using Beutl.Editor.Components.GraphEditorTab.ViewModels;

--- a/src/Beutl/Views/Editors/SceneEditor.axaml
+++ b/src/Beutl/Views/Editors/SceneEditor.axaml
@@ -19,7 +19,7 @@
                     Theme="{StaticResource TransparentButton}">
                 <Button.Flyout>
                     <ui:FAMenuFlyout>
-                        <ui:MenuFlyoutItem Click="SetNullClick" Text="{x:Static lang:Strings.Null}" />
+                        <ui:FAMenuFlyoutItem Click="SetNullClick" Text="{x:Static lang:Strings.Null}" />
                     </ui:FAMenuFlyout>
                 </Button.Flyout>
                 <icons:FluentIcon Icon="MoreVertical" />

--- a/src/Beutl/Views/Editors/TargetPickerFlyout.cs
+++ b/src/Beutl/Views/Editors/TargetPickerFlyout.cs
@@ -9,7 +9,7 @@ using FluentAvalonia.UI.Controls.Primitives;
 
 namespace Beutl.Views.Editors;
 
-public sealed class TargetPickerFlyout(TargetPickerFlyoutViewModel viewModel) : PickerFlyoutBase
+public sealed class TargetPickerFlyout(TargetPickerFlyoutViewModel viewModel) : FAPickerFlyoutBase
 {
     public event TypedEventHandler<TargetPickerFlyout, EventArgs>? Confirmed;
 

--- a/src/Beutl/Views/Editors/TemplateMenuHelper.cs
+++ b/src/Beutl/Views/Editors/TemplateMenuHelper.cs
@@ -15,7 +15,7 @@ public static class TemplateMenuHelper
         var dataContext = control.GetObservable(StyledElement.DataContextProperty)
             .Select(obj => obj as BaseEditorViewModel);
 
-        var saveMenu = new MenuFlyoutItem { Text = Strings.SaveAsTemplate };
+        var saveMenu = new FAMenuFlyoutItem { Text = Strings.SaveAsTemplate };
         saveMenu.Bind(
             InputElement.IsEnabledProperty,
             dataContext.Select(d => d?.CanSaveAsTemplate ?? Observable.ReturnThenNever(false)).Switch());
@@ -38,8 +38,8 @@ public static class TemplateMenuHelper
             flyout.ShowAt(control, true);
         };
 
-        var applySubMenu = new MenuFlyoutSubItem { Text = Strings.ApplyTemplate };
-        var addSubMenu = new MenuFlyoutSubItem { Text = Strings.AddFromTemplate };
+        var applySubMenu = new FAMenuFlyoutSubItem { Text = Strings.ApplyTemplate };
+        var addSubMenu = new FAMenuFlyoutSubItem { Text = Strings.AddFromTemplate };
 
         menuFlyout.Opening += (_, _) =>
         {
@@ -97,7 +97,7 @@ public static class TemplateMenuHelper
             addSubMenu.IsEnabled = addSubMenu.Items.Count > 0;
         };
 
-        var separator = new MenuFlyoutSeparator();
+        var separator = new FAMenuFlyoutSeparator();
         separator.Bind(
             Visual.IsVisibleProperty,
             dataContext
@@ -109,23 +109,23 @@ public static class TemplateMenuHelper
         menuFlyout.Items.Add(addSubMenu);
     }
 
-    private static MenuFlyoutItem CreateApplyMenuItem(ObjectTemplateItem template, BaseEditorViewModel vm)
+    private static FAMenuFlyoutItem CreateApplyMenuItem(ObjectTemplateItem template, BaseEditorViewModel vm)
     {
-        var mi = new MenuFlyoutItem { Text = template.Name.Value, Tag = template };
+        var mi = new FAMenuFlyoutItem { Text = template.Name.Value, Tag = template };
         mi.Click += (s, _) =>
         {
-            if (s is MenuFlyoutItem { Tag: ObjectTemplateItem item })
+            if (s is FAMenuFlyoutItem { Tag: ObjectTemplateItem item })
                 vm.ApplyTemplate(item);
         };
         return mi;
     }
 
-    private static MenuFlyoutItem CreateAddMenuItem(ObjectTemplateItem template, BaseEditorViewModel vm, bool useApplyTemplate)
+    private static FAMenuFlyoutItem CreateAddMenuItem(ObjectTemplateItem template, BaseEditorViewModel vm, bool useApplyTemplate)
     {
-        var mi = new MenuFlyoutItem { Text = template.Name.Value, Tag = template };
+        var mi = new FAMenuFlyoutItem { Text = template.Name.Value, Tag = template };
         mi.Click += (s, _) =>
         {
-            if (s is not MenuFlyoutItem { Tag: ObjectTemplateItem item }) return;
+            if (s is not FAMenuFlyoutItem { Tag: ObjectTemplateItem item }) return;
             if (useApplyTemplate)
                 vm.ApplyTemplate(item);
             else

--- a/src/Beutl/Views/Editors/TextureSourceEditor.axaml
+++ b/src/Beutl/Views/Editors/TextureSourceEditor.axaml
@@ -30,15 +30,15 @@
                         Theme="{StaticResource TransparentButton}">
                     <Button.ContextFlyout>
                         <ui:FAMenuFlyout>
-                            <ui:RadioMenuFlyoutItem Click="ChangeTextureSourceType"
+                            <ui:FARadioMenuFlyoutItem Click="ChangeTextureSourceType"
                                                     IsChecked="{Binding IsImageTextureSource.Value, Mode=OneWay}"
                                                     Tag="Image"
                                                     Text="{x:Static lang:GraphicsStrings.ImageTextureSource}" />
-                            <ui:RadioMenuFlyoutItem Click="ChangeTextureSourceType"
+                            <ui:FARadioMenuFlyoutItem Click="ChangeTextureSourceType"
                                                     IsChecked="{Binding IsDrawableTextureSource.Value, Mode=OneWay}"
                                                     Tag="Drawable"
                                                     Text="{x:Static lang:GraphicsStrings.DrawableTextureSource}" />
-                            <ui:RadioMenuFlyoutItem Click="ChangeTextureSourceType"
+                            <ui:FARadioMenuFlyoutItem Click="ChangeTextureSourceType"
                                                     IsChecked="{Binding !Value.Value, Mode=OneWay}"
                                                     Tag="Null"
                                                     Text="{x:Static lang:Strings.Null}" />

--- a/src/Beutl/Views/Editors/TextureSourceEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/TextureSourceEditor.axaml.cs
@@ -32,7 +32,7 @@ public partial class TextureSourceEditor : UserControl
     private void ChangeTextureSourceType(object? sender, RoutedEventArgs e)
     {
         if (DataContext is not TextureSourceEditorViewModel { IsDisposed: false } vm) return;
-        if (sender is not RadioMenuFlyoutItem { Tag: string tag }) return;
+        if (sender is not FARadioMenuFlyoutItem { Tag: string tag }) return;
 
         switch (tag)
         {

--- a/src/Beutl/Views/Editors/TransformEditor.axaml
+++ b/src/Beutl/Views/Editors/TransformEditor.axaml
@@ -24,10 +24,10 @@
                       ToolTip.Tip="{Binding Description.Value}">
             <ToggleButton.ContextFlyout>
                 <ui:FAMenuFlyout Placement="Pointer">
-                    <ui:MenuFlyoutSubItem x:Name="ChangeTypeMenu"
+                    <ui:FAMenuFlyoutSubItem x:Name="ChangeTypeMenu"
                                           IconSource="New"
                                           Text="{x:Static lang:Strings.Change}" />
-                    <ui:MenuFlyoutItem Click="SetNullClick" Text="{x:Static lang:Strings.Null}" />
+                    <ui:FAMenuFlyoutItem Click="SetNullClick" Text="{x:Static lang:Strings.Null}" />
                 </ui:FAMenuFlyout>
             </ToggleButton.ContextFlyout>
             <ToggleButton.Tag>
@@ -73,10 +73,10 @@
                         Theme="{StaticResource TransparentButton}">
                     <Button.Flyout>
                         <ui:FAMenuFlyout>
-                            <ui:MenuFlyoutSubItem x:Name="PresenterChangeTypeMenu"
+                            <ui:FAMenuFlyoutSubItem x:Name="PresenterChangeTypeMenu"
                                                   IconSource="New"
                                                   Text="{x:Static lang:Strings.Change}" />
-                            <ui:MenuFlyoutItem Click="SetNullClick" Text="{x:Static lang:Strings.Null}" />
+                            <ui:FAMenuFlyoutItem Click="SetNullClick" Text="{x:Static lang:Strings.Null}" />
                         </ui:FAMenuFlyout>
                     </Button.Flyout>
                     <icons:FluentIcon Icon="MoreVertical" />

--- a/src/Beutl/Views/Editors/TransformEditor.axaml.cs
+++ b/src/Beutl/Views/Editors/TransformEditor.axaml.cs
@@ -86,7 +86,7 @@ public partial class TransformEditor : UserControl
         EditorDragDropHelper.HandleEditorDragOver(e, BeutlDataFormats.Transform);
     }
 
-    private static MenuFlyoutItem[] CreateMenuItems(EventHandler<RoutedEventArgs>? handler)
+    private static FAMenuFlyoutItem[] CreateMenuItems(EventHandler<RoutedEventArgs>? handler)
     {
         var items = new (KnownTransformType Tag, string Name, string? Icon)[]
         {
@@ -100,7 +100,7 @@ public partial class TransformEditor : UserControl
         };
         return items.Select(x =>
             {
-                var obj = new MenuFlyoutItem() { Tag = x.Tag, Text = x.Name };
+                var obj = new FAMenuFlyoutItem() { Tag = x.Tag, Text = x.Name };
                 if (handler != null)
                 {
                     obj.Click += handler;
@@ -108,7 +108,7 @@ public partial class TransformEditor : UserControl
 
                 if (x.Icon != null)
                 {
-                    obj.IconSource = new PathIconSource
+                    obj.IconSource = new FAPathIconSource
                     {
                         Data = Application.Current?.FindResource(x.Icon) as Avalonia.Media.Geometry
                     };
@@ -158,7 +158,7 @@ public partial class TransformEditor : UserControl
 
     private void AddTransformClick(object? sender, RoutedEventArgs e)
     {
-        if (sender is MenuFlyoutItem { Tag: KnownTransformType type }
+        if (sender is FAMenuFlyoutItem { Tag: KnownTransformType type }
             && DataContext is TransformEditorViewModel { IsDisposed: false } viewModel)
         {
             viewModel.AddItem(type);
@@ -167,7 +167,7 @@ public partial class TransformEditor : UserControl
 
     private void TransformTypeClicked(object? sender, RoutedEventArgs e)
     {
-        if (sender is MenuFlyoutItem { Tag: KnownTransformType type }
+        if (sender is FAMenuFlyoutItem { Tag: KnownTransformType type }
             && DataContext is TransformEditorViewModel { IsDisposed: false } viewModel)
         {
             viewModel.ChangeType(type);

--- a/src/Beutl/Views/KeyModifierMonitor.axaml
+++ b/src/Beutl/Views/KeyModifierMonitor.axaml
@@ -1,4 +1,4 @@
-<wnd:AppWindow x:Class="Beutl.KeyModifierMonitor"
+<wnd:FAAppWindow x:Class="Beutl.KeyModifierMonitor"
                xmlns="https://github.com/avaloniaui"
                xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -22,4 +22,4 @@
             </Style>
         </StackPanel.Styles>
     </StackPanel>
-</wnd:AppWindow>
+</wnd:FAAppWindow>

--- a/src/Beutl/Views/KeyModifierMonitor.axaml.cs
+++ b/src/Beutl/Views/KeyModifierMonitor.axaml.cs
@@ -7,7 +7,7 @@ using FluentAvalonia.UI.Windowing;
 
 namespace Beutl;
 
-public partial class KeyModifierMonitor : AppWindow
+public partial class KeyModifierMonitor : FAAppWindow
 {
     private readonly CompositeDisposable _disposables = [];
     private readonly Dictionary<Key, Button> _buttons = [];

--- a/src/Beutl/Views/KeyModifierMonitor.axaml.cs
+++ b/src/Beutl/Views/KeyModifierMonitor.axaml.cs
@@ -20,6 +20,7 @@ public partial class KeyModifierMonitor : FAAppWindow
 
     protected override void OnOpened(EventArgs e)
     {
+        base.OnOpened(e);
         if (Owner != null)
         {
             Owner.AddDisposableHandler(KeyDownEvent, OnOwnerKeyDown, RoutingStrategies.Tunnel)

--- a/src/Beutl/Views/MacWindow.axaml.cs
+++ b/src/Beutl/Views/MacWindow.axaml.cs
@@ -4,6 +4,7 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Platform;
 using Beutl.Configuration;
+using Beutl.Helpers;
 using Beutl.Language;
 using Beutl.Services;
 using Beutl.ViewModels;
@@ -16,6 +17,7 @@ namespace Beutl.Views;
 public sealed partial class MacWindow : Window
 {
     private readonly Dictionary<ToolWindowExtension, List<Window>> _openToolWindows = new();
+    private MacOSTitleBar? _titleBar;
 
     public MacWindow()
     {
@@ -51,6 +53,7 @@ public sealed partial class MacWindow : Window
     protected override void OnOpened(EventArgs e)
     {
         base.OnOpened(e);
+        _titleBar ??= MacOSTitleBar.TryAttach(this);
         Screen? screen = Screens.ScreenFromWindow(this);
         if (screen != null && WindowState != WindowState.Maximized)
         {

--- a/src/Beutl/Views/MacWindow.axaml.cs
+++ b/src/Beutl/Views/MacWindow.axaml.cs
@@ -23,8 +23,6 @@ public sealed partial class MacWindow : Window
         {
             ExtendClientAreaToDecorationsHint = true;
             ExtendClientAreaTitleBarHeightHint = 40;
-            ExtendClientAreaChromeHints = ExtendClientAreaChromeHints.OSXThickTitleBar |
-                                          ExtendClientAreaChromeHints.PreferSystemChrome;
         }
 
         InitializeComponent();
@@ -41,10 +39,6 @@ public sealed partial class MacWindow : Window
             var rect = new PixelRect(pos.Value.X, pos.Value.Y, size.Value.Width, size.Value.Height);
             SetRect(rect);
         }
-
-#if DEBUG
-        this.AttachDevTools();
-#endif
     }
 
     private void SetRect(PixelRect rect)

--- a/src/Beutl/Views/MainView.axaml
+++ b/src/Beutl/Views/MainView.axaml
@@ -52,7 +52,7 @@
 
             <Menu x:Name="MenuBar"
                   Grid.Column="1"
-                  wnd:AppWindow.AllowInteractionInTitleBar="True">
+                  WindowDecorationProperties.ElementRole="User">
                 <!--  ファイル  -->
                 <MenuItem Header="{x:Static lang:Strings.File}">
                     <!--  新規作成  -->
@@ -258,11 +258,11 @@
                 <views:TitleBreadcrumbBar Name="TitleBreadcrumbBar"
                                           Margin="8,0,0,0"
                                           MinWidth="0"
-                                          wnd:AppWindow.AllowInteractionInTitleBar="True"
+                                          WindowDecorationProperties.ElementRole="User"
                                           DataContext="{Binding TitleBreadcrumbBar}" />
                 <views:TitleBarBranchView x:Name="TitleBarBranchWidget"
                                           VerticalAlignment="Center"
-                                          wnd:AppWindow.AllowInteractionInTitleBar="True"
+                                          WindowDecorationProperties.ElementRole="User"
                                           DataContext="{Binding TitleBarBranch}" />
             </StackPanel>
 
@@ -278,7 +278,7 @@
                            Text="{x:Static lang:Strings.Debug}" />
 
                 <Border Margin="4,0,0,0"
-                        wnd:AppWindow.AllowInteractionInTitleBar="True"
+                        WindowDecorationProperties.ElementRole="User"
                         Background="Transparent"
                         ToolTip.Tip="{x:Static lang:Strings.RunningStartupTasks}">
                     <ProgressRing Width="20"
@@ -291,7 +291,7 @@
                 </Border>
 
                 <Button x:Name="OpenFeedbackButton"
-                        wnd:AppWindow.AllowInteractionInTitleBar="True"
+                        WindowDecorationProperties.ElementRole="User"
                         Click="OpenFeedbackClick"
                         ToolTip.Tip="{x:Static lang:Strings.Feedback}"
                         Theme="{StaticResource TitleBarButtonStyle}">
@@ -301,7 +301,7 @@
                 <Button x:Name="OpenNotificationsButton"
                         HorizontalContentAlignment="Stretch"
                         VerticalContentAlignment="Stretch"
-                        wnd:AppWindow.AllowInteractionInTitleBar="True"
+                        WindowDecorationProperties.ElementRole="User"
                         Click="OpenNotificationsClick"
                         Theme="{StaticResource TitleBarButtonStyle}">
                     <Button.Flyout>
@@ -315,7 +315,7 @@
                         <icons:FluentIcon HorizontalAlignment="Center"
                                           VerticalAlignment="Center"
                                           Icon="Alert" />
-                        <ui:InfoBadge Width="8"
+                        <ui:FAInfoBadge Width="8"
                                       Height="8"
                                       Margin="0,4,4,0"
                                       HorizontalAlignment="Right"
@@ -342,7 +342,7 @@
                     VerticalAlignment="Top"
                     Spacing="4">
             <StackPanel.Styles>
-                <Style Selector="ui|InfoBar">
+                <Style Selector="ui|FAInfoBar">
                     <Style Selector="^">
                         <Style.Animations>
                             <Animation FillMode="Forward" Duration="00:00:00.250">

--- a/src/Beutl/Views/MainView.axaml.InitializeMenuBar.cs
+++ b/src/Beutl/Views/MainView.axaml.InitializeMenuBar.cs
@@ -370,7 +370,7 @@ public partial class MainView
 
     private async Task OnOpenFile()
     {
-        if (VisualRoot is not Window window || DataContext is not MainViewModel viewModel)
+        if (TopLevel.GetTopLevel(this) is not Window window || DataContext is not MainViewModel viewModel)
         {
             return;
         }
@@ -397,7 +397,7 @@ public partial class MainView
 
     private async Task OnOpenProject()
     {
-        if (VisualRoot is Window window)
+        if (TopLevel.GetTopLevel(this) is Window window)
         {
             var options = new FilePickerOpenOptions
             {
@@ -421,7 +421,7 @@ public partial class MainView
 
     private async Task OnExportProject()
     {
-        if (VisualRoot is not Window window)
+        if (TopLevel.GetTopLevel(this) is not Window window)
         {
             return;
         }
@@ -496,7 +496,7 @@ public partial class MainView
 
     private async Task OnImportProject()
     {
-        if (VisualRoot is not Window window)
+        if (TopLevel.GetTopLevel(this) is not Window window)
         {
             return;
         }

--- a/src/Beutl/Views/MainView.axaml.InitializeMenuBar.cs
+++ b/src/Beutl/Views/MainView.axaml.InitializeMenuBar.cs
@@ -315,15 +315,15 @@ public partial class MainView
         {
             string path = element.Uri!.LocalPath;
             string name = Path.GetFileName(path);
-            var dialog = new ContentDialog
+            var dialog = new FAContentDialog
             {
                 CloseButtonText = Strings.Cancel,
                 PrimaryButtonText = Strings.OK,
-                DefaultButton = ContentDialogButton.Primary,
+                DefaultButton = FAContentDialogButton.Primary,
                 Content = MessageStrings.ConfirmDeleteFile + "\n" + name
             };
 
-            if (await dialog.ShowAsync() == ContentDialogResult.Primary)
+            if (await dialog.ShowAsync() == FAContentDialogResult.Primary)
             {
                 viewModel.GetRequiredService<IElementStructureService>()
                     .Delete(scene, [element], GlobalConfiguration.Instance.EditorConfig.IsRippleEnabled);
@@ -344,15 +344,15 @@ public partial class MainView
             if (projItem == null)
                 return;
 
-            var dialog = new ContentDialog
+            var dialog = new FAContentDialog
             {
                 CloseButtonText = Strings.Cancel,
                 PrimaryButtonText = Strings.OK,
-                DefaultButton = ContentDialogButton.Primary,
+                DefaultButton = FAContentDialogButton.Primary,
                 Content = MessageStrings.ConfirmExcludeItem + "\n" + filePath
             };
 
-            if (await dialog.ShowAsync() == ContentDialogResult.Primary)
+            if (await dialog.ShowAsync() == FAContentDialogResult.Primary)
             {
                 try
                 {

--- a/src/Beutl/Views/MainView.axaml.cs
+++ b/src/Beutl/Views/MainView.axaml.cs
@@ -1,6 +1,8 @@
 ﻿using System.Collections.ObjectModel;
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.Chrome;
+using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.VisualTree;
 using Beutl.AgentToolkit.Installation;
@@ -109,17 +111,19 @@ public sealed partial class MainView : UserControl
         var cm = App.GetContextCommandManager();
         cm?.Attach(this, MainViewExtension.Instance);
 
-        if (sender is AppWindow cw)
+        if (sender is FAAppWindow cw)
         {
-            AppWindowTitleBar titleBar = cw.TitleBar;
+            FAAppWindowTitleBar titleBar = cw.TitleBar;
             if (titleBar != null)
             {
                 titleBar.ExtendsContentIntoTitleBar = true;
 
-                Titlebar.Margin = new Thickness(0, 0, titleBar.LeftInset, 0);
-                AppWindow.SetAllowInteractionInTitleBar(MenuBar, true);
-                AppWindow.SetAllowInteractionInTitleBar(TitleBarBranchWidget, true);
-                AppWindow.SetAllowInteractionInTitleBar(OpenNotificationsButton, true);
+                // Avalonia 12 draws three 46 DIP caption buttons; reserve their width plus spacing.
+                Titlebar.Margin = new Thickness(0, 0, OperatingSystem.IsWindows() ? 140 : 0, 0);
+                WindowDecorationProperties.SetElementRole(Titlebar, WindowDecorationsElementRole.TitleBar);
+                WindowDecorationProperties.SetElementRole(MenuBar, WindowDecorationsElementRole.User);
+                WindowDecorationProperties.SetElementRole(TitleBarBranchWidget, WindowDecorationsElementRole.User);
+                WindowDecorationProperties.SetElementRole(OpenNotificationsButton, WindowDecorationsElementRole.User);
                 NotificationPanel.Margin = new(0, titleBar.Height + 8, 8, 0);
             }
         }
@@ -194,7 +198,7 @@ public sealed partial class MainView : UserControl
             {
                 if (lastStartedVersion < currentVersion)
                 {
-                    var dialog = new ContentDialog
+                    var dialog = new FAContentDialog
                     {
                         Title = MessageStrings.CheckDifferentVersion_Title,
                         Content = MessageStrings.CheckDifferentVersion_Content,
@@ -486,8 +490,8 @@ public sealed partial class MainView : UserControl
 
         var dialogVm = new WindowCaptureDialogViewModel();
         var dialog = new WindowCaptureDialog { DataContext = dialogVm };
-        ContentDialogResult result = await dialog.ShowAsync();
-        if (result != ContentDialogResult.Primary || !dialogVm.CanStart.Value)
+        FAContentDialogResult result = await dialog.ShowAsync();
+        if (result != FAContentDialogResult.Primary || !dialogVm.CanStart.Value)
             return;
 
         WindowCaptureSession? session = null;

--- a/src/Beutl/Views/MainView.axaml.cs
+++ b/src/Beutl/Views/MainView.axaml.cs
@@ -98,7 +98,7 @@ public sealed partial class MainView : UserControl
     {
         base.OnAttachedToVisualTree(e);
 
-        if (e.Root is TopLevel b)
+        if (TopLevel.GetTopLevel(this) is { } b)
         {
             b.Opened += OnParentWindowOpened;
         }

--- a/src/Beutl/Views/MainWindow.axaml
+++ b/src/Beutl/Views/MainWindow.axaml
@@ -1,4 +1,4 @@
-<wnd:AppWindow x:Class="Beutl.Views.MainWindow"
+<wnd:FAAppWindow x:Class="Beutl.Views.MainWindow"
                xmlns="https://github.com/avaloniaui"
                xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -13,4 +13,4 @@
                Icon="avares://Beutl.Controls/Assets/logo.png"
                mc:Ignorable="d">
     <local:MainView x:Name="mainView" />
-</wnd:AppWindow>
+</wnd:FAAppWindow>

--- a/src/Beutl/Views/MainWindow.axaml.cs
+++ b/src/Beutl/Views/MainWindow.axaml.cs
@@ -10,7 +10,7 @@ using FluentAvalonia.UI.Windowing;
 
 namespace Beutl.Views;
 
-public sealed partial class MainWindow : AppWindow
+public sealed partial class MainWindow : FAAppWindow
 {
     public MainWindow()
     {
@@ -30,9 +30,6 @@ public sealed partial class MainWindow : AppWindow
         }
 
         TitleBar.Height = 40;
-#if DEBUG
-        this.AttachDevTools();
-#endif
     }
 
     private void SetRect(PixelRect rect)

--- a/src/Beutl/Views/PlayerView.axaml.FrameContextMenu.cs
+++ b/src/Beutl/Views/PlayerView.axaml.FrameContextMenu.cs
@@ -108,7 +108,7 @@ public partial class PlayerView
     {
         using var dialogViewModel = new SaveFrameDialogViewModel(baseSize);
         var dialog = new SaveFrameDialog { DataContext = dialogViewModel };
-        if (await dialog.ShowAsync() != ContentDialogResult.Primary) return null;
+        if (await dialog.ShowAsync() != FAContentDialogResult.Primary) return null;
 
         return dialogViewModel.SelectedScale.Value;
     }
@@ -169,7 +169,7 @@ public partial class PlayerView
                 {
                     using Bitmap bitmap = await viewModel.DrawFrameAtScale(scale);
                     await SaveImage(file, bitmap);
-                    _logger.LogInformation("Frame saved as image: {FilePath}", file.Path);
+                    _logger.LogInformation("FAFrame saved as image: {FilePath}", file.Path);
                 }
             }
             catch (Exception ex)

--- a/src/Beutl/Views/PlayerView.axaml.MouseControl.cs
+++ b/src/Beutl/Views/PlayerView.axaml.MouseControl.cs
@@ -1669,7 +1669,7 @@ public partial class PlayerView
             if (_movementTimer != null)
                 return;
 
-            _movementTimer = new DispatcherTimer
+            _movementTimer = new DispatcherTimer(DispatcherPriority.Background, View.Dispatcher)
             {
                 Interval = TimeSpan.FromMilliseconds(16) // ~60fps
             };

--- a/src/Beutl/Views/PlayerView.axaml.MouseControl.cs
+++ b/src/Beutl/Views/PlayerView.axaml.MouseControl.cs
@@ -1,6 +1,7 @@
 ﻿using System.Numerics;
 using Avalonia.Controls;
 using Avalonia.Input;
+using Avalonia.Input.Platform;
 using Avalonia.Platform.Storage;
 using Avalonia.Threading;
 using Beutl.Animation;
@@ -998,12 +999,12 @@ public partial class PlayerView
 
                 if (ViewModel.TcsForCrop == null)
                 {
-                    var copyAsString = new MenuFlyoutItem()
+                    var copyAsString = new FAMenuFlyoutItem()
                     {
                         Text = Strings.Copy,
                         IconSource = new FluentIconSource() { Icon = Icon.Copy }
                     };
-                    var saveAsImage = new MenuFlyoutItem()
+                    var saveAsImage = new FAMenuFlyoutItem()
                     {
                         Text = Strings.SaveAsImage,
                         IconSource = new FluentIconSource() { Icon = Icon.SaveImage }
@@ -1041,10 +1042,10 @@ public partial class PlayerView
                         }
                     };
 
-                    var list = new List<MenuFlyoutItem>();
+                    var list = new List<FAMenuFlyoutItem>();
                     if (OperatingSystem.IsWindows())
                     {
-                        var copyAsImage = new MenuFlyoutItem()
+                        var copyAsImage = new FAMenuFlyoutItem()
                         {
                             Text = Strings.CopyAsImage,
                             IconSource = new FluentIconSource() { Icon = Icon.ImageCopy }

--- a/src/Beutl/Views/PlayerView.axaml.cs
+++ b/src/Beutl/Views/PlayerView.axaml.cs
@@ -44,6 +44,7 @@ public partial class PlayerView : UserControl
     private readonly ILogger _logger = Log.CreateLogger<PlayerView>();
     private IDisposable? _imageConfigSubscription;
     private IDisposable? _boundsSubscription;
+    private TopLevel? _scalingTopLevel;
     internal Control image = null!;
 
     // The Resource is RenderThread-owned: create/update/dispose only via RenderThread.Dispatcher.
@@ -184,7 +185,8 @@ public partial class PlayerView : UserControl
     protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
     {
         base.OnAttachedToVisualTree(e);
-        if (e.Root is TopLevel topLevel)
+        _scalingTopLevel = TopLevel.GetTopLevel(this);
+        if (_scalingTopLevel is { } topLevel)
         {
             topLevel.ScalingChanged += OnTopLevelScalingChanged;
         }
@@ -193,10 +195,12 @@ public partial class PlayerView : UserControl
 
     protected override async void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
     {
-        if (e.Root is TopLevel topLevel)
+        // The visual parent is already gone during detachment. Use the original subscription source.
+        if (_scalingTopLevel is { } topLevel)
         {
             topLevel.ScalingChanged -= OnTopLevelScalingChanged;
         }
+        _scalingTopLevel = null;
         base.OnDetachedFromVisualTree(e);
         _imageConfigSubscription?.Dispose();
         _boundsSubscription?.Dispose();

--- a/src/Beutl/Views/PlayerView.axaml.cs
+++ b/src/Beutl/Views/PlayerView.axaml.cs
@@ -149,17 +149,17 @@ public partial class PlayerView : UserControl
         if (useHdr)
         {
             var hdr = new HdrBitmapView();
-            hdr.Bind(HdrBitmapView.SourceProperty, new Binding("PreviewImage.Value") { Mode = BindingMode.OneWay });
-            hdr.Bind(HdrBitmapView.ToneMappingProperty, new Binding("ToneMappingMode.Value") { Mode = BindingMode.OneWay });
-            hdr.Bind(HdrBitmapView.ToneMappingExposureProperty, new Binding("ToneMappingExposure.Value") { Mode = BindingMode.OneWay });
+            hdr.Bind(HdrBitmapView.SourceProperty, new ReflectionBinding("PreviewImage.Value") { Mode = BindingMode.OneWay });
+            hdr.Bind(HdrBitmapView.ToneMappingProperty, new ReflectionBinding("ToneMappingMode.Value") { Mode = BindingMode.OneWay });
+            hdr.Bind(HdrBitmapView.ToneMappingExposureProperty, new ReflectionBinding("ToneMappingExposure.Value") { Mode = BindingMode.OneWay });
             newImage = hdr;
         }
         else
         {
             var sdr = new BitmapView();
-            sdr.Bind(BitmapView.SourceProperty, new Binding("PreviewImage.Value") { Mode = BindingMode.OneWay });
-            sdr.Bind(BitmapView.ToneMappingProperty, new Binding("ToneMappingMode.Value") { Mode = BindingMode.OneWay });
-            sdr.Bind(BitmapView.ToneMappingExposureProperty, new Binding("ToneMappingExposure.Value") { Mode = BindingMode.OneWay });
+            sdr.Bind(BitmapView.SourceProperty, new ReflectionBinding("PreviewImage.Value") { Mode = BindingMode.OneWay });
+            sdr.Bind(BitmapView.ToneMappingProperty, new ReflectionBinding("ToneMappingMode.Value") { Mode = BindingMode.OneWay });
+            sdr.Bind(BitmapView.ToneMappingExposureProperty, new ReflectionBinding("ToneMappingExposure.Value") { Mode = BindingMode.OneWay });
             newImage = sdr;
         }
 

--- a/src/Beutl/Views/Tools/AiImageEditView.axaml
+++ b/src/Beutl/Views/Tools/AiImageEditView.axaml
@@ -46,7 +46,7 @@
                     <TextBox AutomationProperties.Name="{x:Static lang:Strings.AiEditSourceImage}"
                              IsReadOnly="True"
                              Text="{CompiledBinding SourceFilePath.Value}"
-                             Watermark="{x:Static lang:Strings.AiEditNoSourceSelected}" />
+                             PlaceholderText="{x:Static lang:Strings.AiEditNoSourceSelected}" />
                     <Button Grid.Column="1"
                             Margin="8,0,0,0"
                             AutomationProperties.Name="{x:Static lang:Strings.AiEditBrowse}"
@@ -93,7 +93,7 @@
                          MaxLength="4000"
                          Text="{CompiledBinding Prompt.Value}"
                          TextWrapping="Wrap"
-                         Watermark="{CompiledBinding PromptWatermark.Value}" />
+                         PlaceholderText="{CompiledBinding PromptWatermark.Value}" />
                 <TextBlock AutomationProperties.LiveSetting="Assertive"
                            Foreground="{DynamicResource SystemFillColorCautionBrush}"
                            IsVisible="{CompiledBinding VisiblePromptValidationError.Value, Converter={x:Static ObjectConverters.IsNotNull}}"

--- a/src/Beutl/Views/Tools/AiImageGenerationView.axaml
+++ b/src/Beutl/Views/Tools/AiImageGenerationView.axaml
@@ -59,7 +59,7 @@
                          MaxLength="4000"
                          Text="{CompiledBinding Prompt.Value}"
                          TextWrapping="Wrap"
-                         Watermark="{x:Static lang:Strings.AiPrompt_Placeholder}" />
+                         PlaceholderText="{x:Static lang:Strings.AiPrompt_Placeholder}" />
                 <TextBlock AutomationProperties.LiveSetting="Assertive"
                            Foreground="{DynamicResource SystemFillColorCautionBrush}"
                            IsVisible="{CompiledBinding VisiblePromptValidationError.Value, Converter={x:Static ObjectConverters.IsNotNull}}"
@@ -106,21 +106,21 @@
                         <TextBox AutomationProperties.Name="{x:Static lang:Strings.AiPromptStyle}"
                                  MaxLength="4000"
                                  Text="{CompiledBinding Style.Value}"
-                                 Watermark="{x:Static lang:Strings.AiPromptStylePlaceholder}" />
+                                 PlaceholderText="{x:Static lang:Strings.AiPromptStylePlaceholder}" />
                     </StackPanel>
                     <StackPanel Spacing="4">
                         <TextBlock Text="{x:Static lang:Strings.AiPromptComposition}" />
                         <TextBox AutomationProperties.Name="{x:Static lang:Strings.AiPromptComposition}"
                                  MaxLength="4000"
                                  Text="{CompiledBinding Composition.Value}"
-                                 Watermark="{x:Static lang:Strings.AiPromptCompositionPlaceholder}" />
+                                 PlaceholderText="{x:Static lang:Strings.AiPromptCompositionPlaceholder}" />
                     </StackPanel>
                     <StackPanel Spacing="4">
                         <TextBlock Text="{x:Static lang:Strings.AiPromptAvoid}" />
                         <TextBox AutomationProperties.Name="{x:Static lang:Strings.AiPromptAvoid}"
                                  MaxLength="4000"
                                  Text="{CompiledBinding Exclusions.Value}"
-                                 Watermark="{x:Static lang:Strings.AiPromptAvoidPlaceholder}" />
+                                 PlaceholderText="{x:Static lang:Strings.AiPromptAvoidPlaceholder}" />
                     </StackPanel>
                     <StackPanel IsVisible="{CompiledBinding SupportsSeed.Value}" Spacing="4">
                         <TextBlock Text="{x:Static lang:Strings.AiPromptSeed}" />
@@ -129,7 +129,7 @@
                                        Maximum="{CompiledBinding SeedMaximum}"
                                        Minimum="{CompiledBinding SeedMinimum}"
                                        Value="{CompiledBinding Seed.Value}"
-                                       Watermark="{x:Static lang:Strings.AiPromptSeedPlaceholder}" />
+                                       PlaceholderText="{x:Static lang:Strings.AiPromptSeedPlaceholder}" />
                     </StackPanel>
                 </StackPanel>
             </Expander>

--- a/src/Beutl/Views/Tools/AiJobCenterView.axaml
+++ b/src/Beutl/Views/Tools/AiJobCenterView.axaml
@@ -64,7 +64,7 @@
                            Text="{CompiledBinding ConfirmationMessage.Value}"
                            TextWrapping="Wrap" />
                 <WrapPanel HorizontalAlignment="Right" Orientation="Horizontal">
-                    <ui:ProgressRing Width="18"
+                    <ui:FAProgressRing Width="18"
                                      Height="18"
                                      Margin="0,0,8,8"
                                      AutomationProperties.Name="{x:Static lang:Strings.AiJobCenter_CheckingRetryCost}"
@@ -193,13 +193,13 @@
                                                     ToolTip.Tip="{x:Static lang:Strings.Delete}">
                                                 <icons:FluentIcon FontSize="16" Icon="Delete" />
                                             </Button>
-                                            <ui:ProgressRing Width="18"
+                                            <ui:FAProgressRing Width="18"
                                                              Height="18"
                                                              Margin="0,0,6,6"
                                                              AutomationProperties.Name="{CompiledBinding StatusDisplayName}"
                                                              IsIndeterminate="True"
                                                              IsVisible="{CompiledBinding ShouldPoll}" />
-                                            <ui:ProgressRing Width="18"
+                                            <ui:FAProgressRing Width="18"
                                                              Height="18"
                                                              Margin="0,0,0,6"
                                                              AutomationProperties.Name="{x:Static lang:Strings.AiJobCenter_StatusRunning}"
@@ -225,7 +225,7 @@
                             Content="{x:Static lang:Strings.AiJobCenter_LoadMore}"
                             IsVisible="{CompiledBinding HasMore.Value}"
                             ToolTip.Tip="{x:Static lang:Strings.AiJobCenter_LoadMore}" />
-                    <ui:ProgressRing Width="18"
+                    <ui:FAProgressRing Width="18"
                                      Height="18"
                                      Margin="0,0,0,8"
                                      AutomationProperties.Name="{x:Static lang:Strings.Refresh}"
@@ -234,7 +234,7 @@
                 </WrapPanel>
             </Grid>
 
-            <ui:ProgressRing Width="28"
+            <ui:FAProgressRing Width="28"
                              Height="28"
                              HorizontalAlignment="Center"
                              VerticalAlignment="Center"

--- a/src/Beutl/Views/Tools/AiPromptTemplatesView.axaml
+++ b/src/Beutl/Views/Tools/AiPromptTemplatesView.axaml
@@ -23,7 +23,7 @@
         <Grid ColumnDefinitions="*,Auto">
             <TextBox AutomationProperties.Name="{x:Static lang:Strings.AiPromptTemplateName}"
                      Text="{CompiledBinding TemplateName.Value}"
-                     Watermark="{x:Static lang:Strings.AiPromptTemplateName}" />
+                     PlaceholderText="{x:Static lang:Strings.AiPromptTemplateName}" />
             <Button Grid.Column="1"
                     Margin="8,0,0,0"
                     AutomationProperties.Name="{x:Static lang:Strings.AiPromptSaveTemplate}"

--- a/src/Beutl/Views/Tools/AiSubtitleView.axaml
+++ b/src/Beutl/Views/Tools/AiSubtitleView.axaml
@@ -194,7 +194,7 @@
                         Content="{x:Static lang:Strings.AiSubtitle_Transcribe}"
                         IsEnabled="{CompiledBinding CanTranscribe.Value}" />
                 <StackPanel Orientation="Horizontal" Spacing="6">
-                    <ui:ProgressRing x:Name="TranscriptionProgressRing"
+                    <ui:FAProgressRing x:Name="TranscriptionProgressRing"
                                      Width="16"
                                      Height="16"
                                      AutomationProperties.Name="{CompiledBinding TranscriptionStatusText.Value}"

--- a/src/Beutl/Views/Tools/AiSubtitleView.axaml
+++ b/src/Beutl/Views/Tools/AiSubtitleView.axaml
@@ -56,12 +56,12 @@
                              Margin="0,0,6,6"
                              AutomationProperties.Name="{x:Static lang:Strings.AiSubtitle_Speaker}"
                              Text="{CompiledBinding Speaker}"
-                             Watermark="{x:Static lang:Strings.AiSubtitle_Speaker}" />
+                             PlaceholderText="{x:Static lang:Strings.AiSubtitle_Speaker}" />
                     <TextBox MinWidth="116"
                              Margin="0,0,0,6"
                              AutomationProperties.Name="{x:Static lang:Strings.AiSubtitle_Language}"
                              Text="{CompiledBinding Language}"
-                             Watermark="{x:Static lang:Strings.AiSubtitle_Language}" />
+                             PlaceholderText="{x:Static lang:Strings.AiSubtitle_Language}" />
                 </WrapPanel>
                 <TextBox AcceptsReturn="True"
                          AutomationProperties.Name="{x:Static lang:Strings.AiSubtitle_Text}"
@@ -69,7 +69,7 @@
                          MinHeight="48"
                          Text="{CompiledBinding Text}"
                          TextWrapping="Wrap"
-                         Watermark="{x:Static lang:Strings.AiSubtitle_Text}" />
+                         PlaceholderText="{x:Static lang:Strings.AiSubtitle_Text}" />
             </StackPanel>
         </DataTemplate>
     </UserControl.Resources>

--- a/src/Beutl/Views/Tools/AiVideoGenerationView.axaml
+++ b/src/Beutl/Views/Tools/AiVideoGenerationView.axaml
@@ -59,7 +59,7 @@
                          MaxLength="4000"
                          Text="{CompiledBinding Prompt.Value}"
                          TextWrapping="Wrap"
-                         Watermark="{x:Static lang:Strings.AiVideoPrompt_Placeholder}" />
+                         PlaceholderText="{x:Static lang:Strings.AiVideoPrompt_Placeholder}" />
                 <TextBlock AutomationProperties.LiveSetting="Assertive"
                            Foreground="{DynamicResource SystemFillColorCautionBrush}"
                            IsVisible="{CompiledBinding VisiblePromptValidationError.Value, Converter={x:Static ObjectConverters.IsNotNull}}"
@@ -149,28 +149,28 @@
                         <TextBox AutomationProperties.Name="{x:Static lang:Strings.AiPromptStyle}"
                                  MaxLength="4000"
                                  Text="{CompiledBinding Style.Value}"
-                                 Watermark="{x:Static lang:Strings.AiPromptStylePlaceholder}" />
+                                 PlaceholderText="{x:Static lang:Strings.AiPromptStylePlaceholder}" />
                     </StackPanel>
                     <StackPanel Spacing="4">
                         <TextBlock Text="{x:Static lang:Strings.AiPromptComposition}" />
                         <TextBox AutomationProperties.Name="{x:Static lang:Strings.AiPromptComposition}"
                                  MaxLength="4000"
                                  Text="{CompiledBinding Composition.Value}"
-                                 Watermark="{x:Static lang:Strings.AiPromptCompositionPlaceholder}" />
+                                 PlaceholderText="{x:Static lang:Strings.AiPromptCompositionPlaceholder}" />
                     </StackPanel>
                     <StackPanel Spacing="4">
                         <TextBlock Text="{x:Static lang:Strings.AiPromptMotion}" />
                         <TextBox AutomationProperties.Name="{x:Static lang:Strings.AiPromptMotion}"
                                  MaxLength="4000"
                                  Text="{CompiledBinding Motion.Value}"
-                                 Watermark="{x:Static lang:Strings.AiPromptMotionPlaceholder}" />
+                                 PlaceholderText="{x:Static lang:Strings.AiPromptMotionPlaceholder}" />
                     </StackPanel>
                     <StackPanel Spacing="4">
                         <TextBlock Text="{x:Static lang:Strings.AiPromptAvoid}" />
                         <TextBox AutomationProperties.Name="{x:Static lang:Strings.AiPromptAvoid}"
                                  MaxLength="4000"
                                  Text="{CompiledBinding Exclusions.Value}"
-                                 Watermark="{x:Static lang:Strings.AiPromptAvoidPlaceholder}" />
+                                 PlaceholderText="{x:Static lang:Strings.AiPromptAvoidPlaceholder}" />
                     </StackPanel>
                     <StackPanel IsVisible="{CompiledBinding SupportsSeed.Value}" Spacing="4">
                         <TextBlock Text="{x:Static lang:Strings.AiPromptSeed}" />
@@ -179,7 +179,7 @@
                                        Maximum="{CompiledBinding SeedMaximum}"
                                        Minimum="{CompiledBinding SeedMinimum}"
                                        Value="{CompiledBinding Seed.Value}"
-                                       Watermark="{x:Static lang:Strings.AiPromptSeedPlaceholder}" />
+                                       PlaceholderText="{x:Static lang:Strings.AiPromptSeedPlaceholder}" />
                     </StackPanel>
                 </StackPanel>
             </Expander>

--- a/src/Beutl/Views/Tools/OutputPickerFlyout.cs
+++ b/src/Beutl/Views/Tools/OutputPickerFlyout.cs
@@ -9,7 +9,7 @@ using FluentAvalonia.UI.Controls.Primitives;
 
 namespace Beutl.Views.Tools;
 
-public sealed class OutputPickerFlyout(OutputPickerViewModel viewModel) : PickerFlyoutBase
+public sealed class OutputPickerFlyout(OutputPickerViewModel viewModel) : FAPickerFlyoutBase
 {
     public event TypedEventHandler<OutputPickerFlyout, EventArgs>? Confirmed;
 

--- a/src/Beutl/Views/Tools/OutputTab.axaml
+++ b/src/Beutl/Views/Tools/OutputTab.axaml
@@ -35,16 +35,16 @@
                         Theme="{StaticResource TransparentButton}">
                     <Button.Flyout>
                         <ui:FAMenuFlyout>
-                            <ui:MenuFlyoutItem Click="OnRemoveClick"
+                            <ui:FAMenuFlyoutItem Click="OnRemoveClick"
                                                CommandParameter="{Binding SelectedItem.Value}"
                                                IconSource="Delete"
                                                IsEnabled="{Binding CanRemove.Value}"
                                                Text="{x:Static lang:Strings.Remove}" />
-                            <ui:MenuFlyoutItem Click="OnRenameClick"
+                            <ui:FAMenuFlyoutItem Click="OnRenameClick"
                                                CommandParameter="{Binding SelectedItem.Value}"
                                                IsEnabled="{Binding !!SelectedItem.Value}"
                                                Text="{x:Static lang:Strings.Rename}" />
-                            <ui:MenuFlyoutItem Click="OnConvertPresetClick"
+                            <ui:FAMenuFlyoutItem Click="OnConvertPresetClick"
                                                CommandParameter="{Binding SelectedItem.Value}"
                                                IsEnabled="{Binding !!SelectedItem.Value}"
                                                Text="{x:Static lang:Strings.Convert_to_preset}" />

--- a/src/Beutl/Views/Tools/OutputTab.axaml.cs
+++ b/src/Beutl/Views/Tools/OutputTab.axaml.cs
@@ -163,7 +163,7 @@ public partial class OutputTab : UserControl
         {
             case OutputProfileItem profile:
                 {
-                    var removeItem = new MenuFlyoutItem
+                    var removeItem = new FAMenuFlyoutItem
                     {
                         Text = Language.Strings.Remove,
                         IconSource = new FluentIconSource { Icon = Icon.Delete }
@@ -175,11 +175,11 @@ public partial class OutputTab : UserControl
                     };
                     menu.Items.Add(removeItem);
 
-                    var renameItem = new MenuFlyoutItem { Text = Language.Strings.Rename };
+                    var renameItem = new FAMenuFlyoutItem { Text = Language.Strings.Rename };
                     renameItem.Click += (_, _) => ShowRenameFlyout(profile, args.Anchor);
                     menu.Items.Add(renameItem);
 
-                    var convertItem = new MenuFlyoutItem { Text = Language.Strings.Convert_to_preset };
+                    var convertItem = new FAMenuFlyoutItem { Text = Language.Strings.Convert_to_preset };
                     convertItem.Click += (_, _) =>
                     {
                         OutputPresetService.Instance.AddItem(profile.Context, $"{profile.Context.Name.Value} (Preset)");
@@ -190,7 +190,7 @@ public partial class OutputTab : UserControl
                 }
             case OutputPresetItem preset:
                 {
-                    var removeItem = new MenuFlyoutItem
+                    var removeItem = new FAMenuFlyoutItem
                     {
                         Text = Language.Strings.Remove,
                         IconSource = new FluentIconSource { Icon = Icon.Delete }
@@ -202,7 +202,7 @@ public partial class OutputTab : UserControl
                     };
                     menu.Items.Add(removeItem);
 
-                    var renameItem = new MenuFlyoutItem { Text = Language.Strings.Rename };
+                    var renameItem = new FAMenuFlyoutItem { Text = Language.Strings.Rename };
                     renameItem.Click += (_, _) => ShowRenameFlyout(preset, args.Anchor);
                     menu.Items.Add(renameItem);
                     break;

--- a/src/Beutl/Views/Tools/OutputView.axaml.cs
+++ b/src/Beutl/Views/Tools/OutputView.axaml.cs
@@ -30,7 +30,7 @@ public partial class OutputView : UserControl
     private async void SelectDestinationFileClick(object? sender, RoutedEventArgs e)
     {
         if (DataContext is OutputViewModel viewModel
-            && VisualRoot is TopLevel topLevel)
+            && TopLevel.GetTopLevel(this) is TopLevel topLevel)
         {
             var options = new FilePickerSaveOptions()
             {

--- a/src/Beutl/Views/Tutorial/TutorialListDialog.axaml
+++ b/src/Beutl/Views/Tutorial/TutorialListDialog.axaml
@@ -1,4 +1,4 @@
-<ui:ContentDialog x:Class="Beutl.Views.Tutorial.TutorialListDialog"
+<ui:FAContentDialog x:Class="Beutl.Views.Tutorial.TutorialListDialog"
                   xmlns="https://github.com/avaloniaui"
                   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                   xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -35,4 +35,4 @@
                    Text="{x:Static lang:TutorialStrings.NoTutorialsAvailable}" />
     </StackPanel>
 
-</ui:ContentDialog>
+</ui:FAContentDialog>

--- a/src/Beutl/Views/Tutorial/TutorialListDialog.axaml.cs
+++ b/src/Beutl/Views/Tutorial/TutorialListDialog.axaml.cs
@@ -7,7 +7,7 @@ using FluentAvalonia.UI.Controls;
 
 namespace Beutl.Views.Tutorial;
 
-public partial class TutorialListDialog : ContentDialog
+public partial class TutorialListDialog : FAContentDialog
 {
     public TutorialListDialog()
     {
@@ -15,7 +15,7 @@ public partial class TutorialListDialog : ContentDialog
         LoadTutorials();
     }
 
-    protected override Type StyleKeyOverride => typeof(ContentDialog);
+    protected override Type StyleKeyOverride => typeof(FAContentDialog);
 
     private void LoadTutorials()
     {

--- a/tests/Beutl.HeadlessUITests/AiCompactPresentationTests.cs
+++ b/tests/Beutl.HeadlessUITests/AiCompactPresentationTests.cs
@@ -704,7 +704,7 @@ public sealed class AiCompactPresentationTests
         {
             window.Show();
             HeadlessTestHelpers.Render();
-            ProgressRing progress = view.FindControl<ProgressRing>("TranscriptionProgressRing")!;
+            FAProgressRing progress = view.FindControl<FAProgressRing>("TranscriptionProgressRing")!;
             TextBlock status = view.FindControl<TextBlock>("TranscriptionStatusText")!;
             AutomationPeer statusPeer = ControlAutomationPeer.CreatePeerForElement(status);
             var automationChanges = new List<AutomationPropertyChangedEventArgs>();

--- a/tests/Beutl.HeadlessUITests/AiDialogWorkflowTests.cs
+++ b/tests/Beutl.HeadlessUITests/AiDialogWorkflowTests.cs
@@ -5440,7 +5440,7 @@ public sealed class AiDialogWorkflowTests
             transcription = viewModel.Transcribe.ExecuteAsync();
             await preparationStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
             HeadlessTestHelpers.Render();
-            ProgressRing progress = view.FindControl<ProgressRing>("TranscriptionProgressRing")!;
+            FAProgressRing progress = view.FindControl<FAProgressRing>("TranscriptionProgressRing")!;
             TextBlock status = view.FindControl<TextBlock>("TranscriptionStatusText")!;
             using (Assert.EnterMultipleScope())
             {

--- a/tests/Beutl.HeadlessUITests/AiToolTabCaptureTests.cs
+++ b/tests/Beutl.HeadlessUITests/AiToolTabCaptureTests.cs
@@ -165,7 +165,7 @@ public class AiToolTabCaptureTests
 
             Directory.CreateDirectory(OutputDirectory);
             string path = Path.Combine(OutputDirectory, name);
-            frame!.Save(path);
+            frame!.Save(path, PngBitmapEncoderOptions.Default);
             TestContext.Out.WriteLine($"Saved capture: {path}");
         }
         finally

--- a/tests/Beutl.HeadlessUITests/Avalonia12ColorPickerTests.cs
+++ b/tests/Beutl.HeadlessUITests/Avalonia12ColorPickerTests.cs
@@ -1,0 +1,118 @@
+﻿using System.Reflection;
+using Avalonia.Controls;
+using Avalonia.Headless.NUnit;
+using Avalonia.Interactivity;
+using Avalonia.VisualTree;
+using Beutl.Testing.Headless;
+using FluentAvalonia.UI.Controls;
+using FluentAvalonia.UI.Controls.Primitives;
+using AvaColors = Avalonia.Media.Colors;
+
+namespace Beutl.HeadlessUITests;
+
+[TestFixture]
+public class Avalonia12ColorPickerTests
+{
+    [AvaloniaTest]
+    public void Numeric_components_update_the_color_and_follow_programmatic_changes()
+    {
+        var picker = new FAColorPicker
+        {
+            Color = AvaColors.Red,
+            IsCompact = false,
+            IsAlphaEnabled = true,
+            UseColorWheel = true,
+            UseColorTriangle = true,
+            UseColorPalette = true
+        };
+        var window = new Window { Content = picker, Width = 800, Height = 800 };
+        try
+        {
+            window.Show();
+            HeadlessTestHelpers.Render();
+            FANumberBox FindBox(string name) => picker.GetVisualDescendants()
+                .OfType<FANumberBox>().Single(box => box.Name == name);
+
+            Assert.That(FindBox("RedBox").Value, Is.EqualTo(255));
+            FindBox("RedBox").Value = 0;
+            FindBox("BlueBox").Value = 255;
+            HeadlessTestHelpers.Settle();
+            Assert.That((Avalonia.Media.Color)picker.Color, Is.EqualTo(AvaColors.Blue));
+
+            picker.Color = AvaColors.Lime;
+            HeadlessTestHelpers.Settle();
+            Assert.Multiple(() =>
+            {
+                Assert.That(FindBox("RedBox").Value, Is.Zero);
+                Assert.That(FindBox("GreenBox").Value, Is.EqualTo(255));
+                Assert.That(FindBox("BlueBox").Value, Is.Zero);
+                Assert.That(FindBox("AlphaBox").Value, Is.EqualTo(255));
+            });
+
+            TabControl modes = picker.GetVisualDescendants().OfType<TabControl>()
+                .Single(control => control.Name == "DisplayItemTabControl");
+            for (int index = 0; index < modes.Items.Count; index++)
+            {
+                modes.SelectedIndex = index;
+                HeadlessTestHelpers.Render();
+                Assert.That((Avalonia.Media.Color)picker.Color, Is.EqualTo(AvaColors.Lime),
+                    "Switching the spectrum, wheel, triangle, or palette must preserve the selected color.");
+            }
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaTest]
+    [TestCase(true)]
+    [TestCase(false)]
+    public void Color_button_commits_only_when_the_flyout_is_confirmed(bool confirm)
+    {
+        var pickerButton = new ColorPickerButton
+        {
+            Color = AvaColors.Red,
+            ShowAcceptDismissButtons = true
+        };
+        var window = new Window { Content = pickerButton, Width = 400, Height = 400 };
+        int confirmed = 0;
+        int dismissed = 0;
+        pickerButton.FlyoutConfirmed += (_, _) => confirmed++;
+        pickerButton.FlyoutDismissed += (_, _) => dismissed++;
+        try
+        {
+            window.Show();
+            HeadlessTestHelpers.Render();
+            pickerButton.GetVisualDescendants().OfType<Button>().Single()
+                .RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+            HeadlessTestHelpers.Render();
+
+            // The buttons share a private flyout whose popup is a separate visual tree.
+            var flyout = (ColorPickerFlyout)typeof(ColorPickerButton)
+                .GetField("_flyout", BindingFlags.Static | BindingFlags.NonPublic)!
+                .GetValue(null)!;
+            FAColorPicker picker = flyout.ColorPicker;
+            Control presenter = picker.GetVisualAncestors().OfType<FAPickerFlyoutPresenter>().Single();
+            picker.Color = AvaColors.Blue;
+            Assert.That(pickerButton.Color, Is.EqualTo(AvaColors.Red));
+            Button action = presenter.GetVisualDescendants().OfType<Button>()
+                .Single(button => button.Name == (confirm ? "AcceptButton" : "DismissButton"));
+            action.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+            HeadlessTestHelpers.Settle();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(pickerButton.Color, Is.EqualTo(confirm ? AvaColors.Blue : AvaColors.Red));
+                Assert.That(confirmed, Is.EqualTo(confirm ? 1 : 0));
+                Assert.That(dismissed, Is.EqualTo(confirm ? 0 : 1));
+                Assert.That(flyout.IsOpen, Is.False);
+            });
+        }
+        finally
+        {
+            window.Close();
+            HeadlessTestHelpers.Settle();
+        }
+    }
+}

--- a/tests/Beutl.HeadlessUITests/Avalonia12MenuTests.cs
+++ b/tests/Beutl.HeadlessUITests/Avalonia12MenuTests.cs
@@ -1,0 +1,92 @@
+﻿using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Headless.NUnit;
+using Avalonia.LogicalTree;
+using Avalonia.VisualTree;
+using Beutl.Editor.Components.PathEditorTab.Views;
+using Beutl.Testing.Headless;
+using Beutl.Views.Editors;
+using FluentAvalonia.UI.Controls;
+
+namespace Beutl.HeadlessUITests;
+
+[TestFixture]
+public class Avalonia12MenuTests
+{
+    // These views declare flyouts outside the visual tree. Constructing the view alone
+    // does not verify that the renamed menu items still acquire a presenter and theme.
+    [AvaloniaTest]
+    [TestCase(typeof(BrushEditor))]
+    [TestCase(typeof(PropertyEditorMenu))]
+    [TestCase(typeof(AudioEffectEditor))]
+    [TestCase(typeof(CoreObjectEditor))]
+    [TestCase(typeof(GeometryEditor))]
+    [TestCase(typeof(TransformEditor))]
+    [TestCase(typeof(DisplacementMapTransformEditor))]
+    [TestCase(typeof(PathFigureListItemEditor))]
+    [TestCase(typeof(PenEditor))]
+    [TestCase(typeof(TextureSourceEditor))]
+    [TestCase(typeof(FilterEffectEditor))]
+    [TestCase(typeof(PathEditorTabView))]
+    public void Editor_menus_open_with_their_items_and_labels(Type viewType)
+    {
+        var view = (Control)Activator.CreateInstance(viewType)!;
+        var anchor = new Button { Content = "Menu" };
+        var window = new Window
+        {
+            Content = new StackPanel { Children = { view, anchor } },
+            Width = 640,
+            Height = 480
+        };
+        try
+        {
+            window.Show();
+            HeadlessTestHelpers.Render();
+
+            Control[] controls = view.GetLogicalDescendants().OfType<Control>()
+                .Concat(view.GetVisualDescendants().OfType<Control>())
+                .Prepend(view)
+                .Distinct()
+                .ToArray();
+            FAMenuFlyout[] menus = controls
+                .SelectMany(control => new[] { control.ContextFlyout, (control as Button)?.Flyout })
+                .OfType<FAMenuFlyout>()
+                .Distinct()
+                .ToArray();
+            Assert.That(menus, Is.Not.Empty, $"{viewType.Name} must expose its editing menus.");
+
+            foreach (FAMenuFlyout menu in menus)
+            {
+                try
+                {
+                    menu.ShowAt(anchor);
+                    HeadlessTestHelpers.Render();
+                    Assert.That(menu.IsOpen, Is.True);
+                    FAMenuFlyoutItem[] items = menu.Items.OfType<FAMenuFlyoutItem>()
+                        .Where(item => item.IsVisible).ToArray();
+                    Assert.That(items, Is.Not.Empty);
+                    foreach (FAMenuFlyoutItem item in items)
+                    {
+                        Assert.Multiple(() =>
+                        {
+                            Assert.That(item.Text, Is.Not.Null.And.Not.Empty);
+                            Assert.That(item.Bounds.Height, Is.GreaterThan(0), item.Text);
+                            Assert.That(item.GetVisualDescendants().OfType<TextBlock>()
+                                .Any(text => text.Text == item.Text), Is.True, item.Text);
+                        });
+                    }
+                }
+                finally
+                {
+                    menu.Hide();
+                    HeadlessTestHelpers.Settle();
+                }
+            }
+        }
+        finally
+        {
+            window.Close();
+            HeadlessTestHelpers.Settle();
+        }
+    }
+}

--- a/tests/Beutl.HeadlessUITests/Avalonia12NavigationTests.cs
+++ b/tests/Beutl.HeadlessUITests/Avalonia12NavigationTests.cs
@@ -1,0 +1,127 @@
+﻿using Avalonia.Controls;
+using Avalonia.Headless.NUnit;
+using Avalonia.Xaml.Interactivity;
+using Beutl.Controls;
+using Beutl.Controls.Navigation;
+using Beutl.Testing.Headless;
+using FluentAvalonia.UI.Controls;
+using FluentIcons.Avalonia.Fluent;
+using FluentIcons.Common;
+
+namespace Beutl.HeadlessUITests;
+
+[TestFixture]
+public class Avalonia12NavigationTests
+{
+    [AvaloniaTest]
+    public void Navigation_item_switches_between_regular_and_selected_icons()
+    {
+        var regular = new FAFontIconSource { Glyph = "R" };
+        var filled = new FluentIconSource { Icon = Icon.Settings };
+        var behavior = new NavItemHelper { RegularIcon = regular, FilledIcon = filled };
+        var item = new FANavigationViewItem { Content = "Settings" };
+        Interaction.GetBehaviors(item).Add(behavior);
+        try
+        {
+            Assert.That(item.IconSource, Is.SameAs(regular));
+            item.IsSelected = true;
+            Assert.That(item.IconSource, Is.SameAs(filled));
+            item.IsSelected = false;
+            Assert.Multiple(() =>
+            {
+                Assert.That(item.IconSource, Is.SameAs(regular));
+                Assert.That(regular.FontSize, Is.EqualTo(48));
+                Assert.That(filled.FontSize, Is.EqualTo(48));
+            });
+        }
+        finally
+        {
+            Interaction.GetBehaviors(item).Remove(behavior);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task Navigation_reuses_contexts_and_removes_them_from_both_history_stacks()
+    {
+        var frame = new FAFrame();
+        var navigation = new NavigationProvider(frame, new PageResolver());
+        var first = new Context("first");
+        var second = new Context("second");
+        var third = new Context("third");
+        var window = new Window { Content = frame, Width = 400, Height = 300 };
+        try
+        {
+            window.Show();
+            await navigation.NavigateAsync<Context>(_ => false, () => first);
+            await navigation.NavigateAsync<Context>(_ => false, () => second);
+            await navigation.NavigateAsync<Context>(_ => false, () => third);
+            await navigation.GoBackAsync();
+            HeadlessTestHelpers.Settle();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(navigation.CurrentContext, Is.SameAs(second));
+                Assert.That(((Control)frame.Content!).DataContext, Is.SameAs(second));
+                Assert.That(frame.BackStack.Single().Parameter, Is.SameAs(first));
+                Assert.That(frame.ForwardStack.Single().Parameter, Is.SameAs(third));
+            });
+            Assert.That(await navigation.FindAsync<Context>(context => context.Name == "third"), Is.SameAs(third));
+            await navigation.NavigateAsync<Context>(context => context.Name == "first",
+                () => throw new AssertionException("Navigation must reuse the cached context."));
+            await navigation.GoBackAsync();
+            await navigation.RemoveAllAsync<Context>(context => context == first);
+            Assert.Multiple(() =>
+            {
+                Assert.That(frame.BackStack, Is.Empty);
+                Assert.That(frame.ForwardStack, Is.Empty);
+                Assert.That(navigation.CurrentContext, Is.SameAs(second));
+            });
+        }
+        finally
+        {
+            window.Close();
+            HeadlessTestHelpers.Settle();
+        }
+    }
+
+    private sealed record Context(string Name);
+
+    [AvaloniaTest]
+    public void Frame_helpers_find_and_remove_matching_contexts_from_both_stacks()
+    {
+        var frame = new FAFrame();
+        var first = new Context("first");
+        var second = new Context("second");
+        var third = new Context("third");
+        frame.Navigate(typeof(Page), first);
+        frame.Navigate(typeof(Page), second);
+        frame.Navigate(typeof(Page), third);
+        frame.GoBack();
+        object currentPage = frame.Content!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(frame.FindParameter<Context>(context => context.Name == "first"), Is.SameAs(first));
+            Assert.That(frame.FindParameter<Context>(context => context.Name == "third"), Is.SameAs(third));
+            Assert.That(frame.FindParameter<Context>(_ => false), Is.Null);
+        });
+        frame.RemoveAllStack(context => ReferenceEquals(context, first) || ReferenceEquals(context, third));
+        Assert.Multiple(() =>
+        {
+            Assert.That(frame.BackStack, Is.Empty);
+            Assert.That(frame.ForwardStack, Is.Empty);
+            Assert.That(frame.Content, Is.SameAs(currentPage));
+        });
+    }
+
+    public sealed class Page : UserControl;
+
+    private sealed class PageResolver : IPageResolver
+    {
+        public int GetOrder(Type pagetype) => 0;
+
+        public int GetDepth(Type pagetype) => 0;
+
+        public Type GetPageType(Type contextType) => typeof(Page);
+    }
+}

--- a/tests/Beutl.HeadlessUITests/AvaloniaWindowInitializationTests.cs
+++ b/tests/Beutl.HeadlessUITests/AvaloniaWindowInitializationTests.cs
@@ -1,0 +1,97 @@
+﻿using Avalonia.Controls;
+using Avalonia.Headless.NUnit;
+using Avalonia.VisualTree;
+using Beutl.Configuration;
+using Beutl.PackageTools.UI.Views;
+using Beutl.Pages;
+using Beutl.Testing.Headless;
+using Beutl.Views;
+
+namespace Beutl.HeadlessUITests;
+
+[TestFixture]
+public class AvaloniaWindowInitializationTests
+{
+    [AvaloniaTest]
+    public async Task Editor_windows_can_be_constructed_and_closed_before_being_shown()
+    {
+        ViewConfig config = GlobalConfiguration.Instance.ViewConfig;
+        var previous = (config.WindowPosition, config.WindowSize, config.IsWindowMaximized);
+        Func<Window>[] factories =
+        [
+            () => new Beutl.Views.MainWindow(),
+            () => new MacWindow(),
+            () => new KeyModifierMonitor(),
+            () => new SettingsDialog(),
+            () => new ExtensionsPage(),
+        ];
+
+        try
+        {
+            foreach (Func<Window> factory in factories)
+            {
+                Window window = factory();
+                try
+                {
+                    Assert.That(window.Content, Is.Not.Null, window.GetType().FullName);
+                }
+                finally
+                {
+                    await CloseAsync(window);
+                }
+            }
+        }
+        finally
+        {
+            config.WindowPosition = previous.WindowPosition;
+            config.WindowSize = previous.WindowSize;
+            config.IsWindowMaximized = previous.IsWindowMaximized;
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task Key_monitor_runs_the_base_window_opening_lifecycle()
+    {
+        var window = new KeyModifierMonitor();
+        int opened = 0;
+        window.Opened += (_, _) => opened++;
+        try
+        {
+            window.Show();
+            HeadlessTestHelpers.Render();
+            Assert.That(opened, Is.EqualTo(1));
+        }
+        finally
+        {
+            await CloseAsync(window);
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task Package_tools_first_page_is_visible_on_open()
+    {
+        var window = new Beutl.PackageTools.UI.Views.MainWindow();
+        try
+        {
+            window.Show();
+            HeadlessTestHelpers.Render(3);
+
+            DisplayPackagesPage? page = window.GetVisualDescendants().OfType<DisplayPackagesPage>().SingleOrDefault();
+            Assert.That(page, Is.Not.Null, "The initial package list must render without another navigation request.");
+            Assert.That(page!.DataContext, Is.SameAs(window.DataContext));
+        }
+        finally
+        {
+            await CloseAsync(window);
+        }
+    }
+
+    private static async Task CloseAsync(Window window)
+    {
+        var closed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        window.Closed += (_, _) => closed.TrySetResult();
+        window.Close();
+        await closed.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        HeadlessTestHelpers.Settle();
+    }
+}

--- a/tests/Beutl.HeadlessUITests/DarkBorderThemeColorTests.cs
+++ b/tests/Beutl.HeadlessUITests/DarkBorderThemeColorTests.cs
@@ -166,7 +166,7 @@ public class DarkBorderThemeColorTests
         }
     }
 
-    // The disabled text-input family (TextBox / NumberBox / AutoCompleteBox) must resolve the same
+    // The disabled text-input family (TextBox / FANumberBox / AutoCompleteBox) must resolve the same
     // disabled colors as ComboBox — nothing in the theme dictionaries keeps the two key families
     // in step.
     [AvaloniaTest]

--- a/tests/Beutl.HeadlessUITests/DataContextEventsTests.cs
+++ b/tests/Beutl.HeadlessUITests/DataContextEventsTests.cs
@@ -60,6 +60,93 @@ public class DataContextEventsTests
     }
 
     [AvaloniaTest]
+    public void Disposing_from_detached_during_a_context_change_releases_the_context_once()
+    {
+        var context = new object();
+        var control = new TextBlock { DataContext = context };
+        var attached = new List<object>();
+        var detached = new List<object>();
+        IDisposable? subscription = null;
+        using (subscription = control.SubscribeDataContextChange<object>(attached.Add, value =>
+               {
+                   detached.Add(value);
+                   subscription?.Dispose();
+               }))
+        {
+            control.DataContext = new object();
+            control.DataContext = new object();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(attached, Is.EqualTo(new[] { context }));
+                Assert.That(detached, Is.EqualTo(new[] { context }));
+            });
+        }
+    }
+
+    [AvaloniaTest]
+    public void Disposing_from_detached_during_tree_removal_releases_the_context_once()
+    {
+        var context = new object();
+        var control = new TextBlock { DataContext = context };
+        var attached = new List<object>();
+        var detached = new List<object>();
+        IDisposable? subscription = null;
+        using (subscription = control.SubscribeDataContextChange<object>(attached.Add, value =>
+               {
+                   detached.Add(value);
+                   subscription?.Dispose();
+               }))
+        {
+            var window = new Window { Content = control };
+            try
+            {
+                window.Show();
+                HeadlessTestHelpers.Settle();
+                window.Content = null;
+                window.Content = control;
+                control.DataContext = new object();
+                HeadlessTestHelpers.Settle();
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(attached, Is.EqualTo(new[] { context }));
+                    Assert.That(detached, Is.EqualTo(new[] { context }));
+                });
+            }
+            finally
+            {
+                window.Close();
+            }
+        }
+    }
+
+    [AvaloniaTest]
+    public void Disposing_from_attached_releases_the_context_once()
+    {
+        var context = new object();
+        var control = new TextBlock();
+        var attached = new List<object>();
+        var detached = new List<object>();
+        IDisposable? subscription = null;
+        using (subscription = control.SubscribeDataContextChange<object>(value =>
+               {
+                   attached.Add(value);
+                   subscription?.Dispose();
+               }, detached.Add))
+        {
+            control.DataContext = context;
+            control.DataContext = new object();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(attached, Is.EqualTo(new[] { context }));
+                Assert.That(detached, Is.EqualTo(new[] { context }));
+            });
+        }
+    }
+
+    [AvaloniaTest]
     public void Reattaching_a_view_balances_its_context_callbacks()
     {
         var context = new object();

--- a/tests/Beutl.HeadlessUITests/DataContextEventsTests.cs
+++ b/tests/Beutl.HeadlessUITests/DataContextEventsTests.cs
@@ -1,0 +1,92 @@
+﻿using Avalonia.Controls;
+using Avalonia.Headless.NUnit;
+using Beutl.Editor.Components.Helpers;
+using Beutl.Testing.Headless;
+
+namespace Beutl.HeadlessUITests;
+
+[TestFixture]
+public class DataContextEventsTests
+{
+    [AvaloniaTest]
+    public void Disposing_stops_future_data_context_callbacks()
+    {
+        var control = new TextBlock();
+        var attached = new List<object>();
+        var detached = new List<object>();
+        using IDisposable subscription = control.SubscribeDataContextChange<object>(attached.Add, detached.Add);
+
+        subscription.Dispose();
+        control.DataContext = new object();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(attached, Is.Empty);
+            Assert.That(detached, Is.Empty);
+        });
+    }
+
+    [AvaloniaTest]
+    public void Disposing_releases_the_current_context_once()
+    {
+        var context = new object();
+        var control = new TextBlock { DataContext = context };
+        var attached = new List<object>();
+        var detached = new List<object>();
+        using IDisposable subscription = control.SubscribeDataContextChange<object>(attached.Add, detached.Add);
+
+        subscription.Dispose();
+        subscription.Dispose();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(attached, Is.EqualTo(new[] { context }));
+            Assert.That(detached, Is.EqualTo(new[] { context }));
+        });
+    }
+
+    [AvaloniaTest]
+    public void Disposing_during_a_data_context_event_does_not_reactivate_the_subscription()
+    {
+        var control = new TextBlock();
+        int attached = 0;
+        IDisposable? subscription = null;
+        control.DataContextChanged += (_, _) => subscription?.Dispose();
+        using (subscription = control.SubscribeDataContextChange<object>(_ => attached++, _ => { }))
+        {
+            control.DataContext = new object();
+            Assert.That(attached, Is.Zero);
+        }
+    }
+
+    [AvaloniaTest]
+    public void Reattaching_a_view_balances_its_context_callbacks()
+    {
+        var context = new object();
+        var control = new TextBlock { DataContext = context };
+        var attached = new List<object>();
+        var detached = new List<object>();
+        using IDisposable subscription = control.SubscribeDataContextChange<object>(attached.Add, detached.Add);
+        var window = new Window { Content = control };
+        try
+        {
+            window.Show();
+            HeadlessTestHelpers.Settle();
+            window.Content = null;
+            window.Content = control;
+            HeadlessTestHelpers.Settle();
+            subscription.Dispose();
+            window.Content = null;
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(attached, Is.EqualTo(new[] { context, context }));
+                Assert.That(detached, Is.EqualTo(new[] { context, context }));
+            });
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+}

--- a/tests/Beutl.HeadlessUITests/DispatcherTimerOwnershipTests.cs
+++ b/tests/Beutl.HeadlessUITests/DispatcherTimerOwnershipTests.cs
@@ -1,0 +1,27 @@
+﻿using Avalonia.Headless.NUnit;
+using Beutl.Controls.PropertyEditors;
+using FluentAvalonia.UI.Media;
+
+namespace Beutl.HeadlessUITests;
+
+[TestFixture]
+public class DispatcherTimerOwnershipTests
+{
+    [AvaloniaTest]
+    public async Task Color_dropper_created_on_a_worker_processes_cancellation_on_the_UI_dispatcher()
+    {
+        var completion = new TaskCompletionSource<(Color2 Color, int X, int Y)>();
+        using ColorDropper dropper = await Task.Run(() =>
+            new ColorDropper(completion, new CancellationToken(canceled: true)));
+
+        // Cancellation is handled on the first timer tick, before any platform-specific sampling.
+        // A timer attached to the worker's unpumped Dispatcher never completes this operation.
+        dropper.Start();
+        Task finished = await Task.WhenAny(completion.Task, Task.Delay(TimeSpan.FromSeconds(2)));
+        Assert.Multiple(() =>
+        {
+            Assert.That(finished, Is.SameAs(completion.Task), "The timer must tick on the running UI dispatcher.");
+            Assert.That(completion.Task.IsCanceled, Is.True);
+        });
+    }
+}

--- a/tests/Beutl.HeadlessUITests/EditorExtensionPriorityPageTests.cs
+++ b/tests/Beutl.HeadlessUITests/EditorExtensionPriorityPageTests.cs
@@ -1,0 +1,62 @@
+﻿using Avalonia.Controls;
+using Avalonia.Headless.NUnit;
+using Avalonia.VisualTree;
+using Beutl.Api.Services;
+using Beutl.Pages.SettingsPages;
+using Beutl.Testing.Headless;
+using Beutl.ViewModels.SettingsPages;
+using FluentAvalonia.UI.Controls;
+
+namespace Beutl.HeadlessUITests;
+
+[TestFixture]
+public class EditorExtensionPriorityPageTests
+{
+    [AvaloniaTest]
+    public void Priority_and_available_editor_rows_display_their_command_bar_actions()
+    {
+        using var viewModel = new EditorExtensionPriorityPageViewModel(new ExtensionProvider());
+        // Populate both row templates without modifying the persisted extension priorities.
+        viewModel.SelectedFileExtension.Value = null;
+        viewModel.EditorExtensions1.Add(new("Preferred editor", "preferred", "PreferredEditor"));
+        viewModel.EditorExtensions2.Add(new("Available editor", "available", "AvailableEditor"));
+        var view = new EditorExtensionPriorityPage { DataContext = viewModel };
+        var window = new Window { Content = view, Width = 900, Height = 600 };
+        try
+        {
+            window.Show();
+            HeadlessTestHelpers.Render();
+            ListBox[] lists = view.GetVisualDescendants().OfType<ListBox>().ToArray();
+            Assert.That(lists, Has.Length.EqualTo(2));
+            Assert.Multiple(() =>
+            {
+                Assert.That(lists[0].GetVisualDescendants().OfType<TextBlock>()
+                    .Any(text => text.Text == "Preferred editor"), Is.True);
+                Assert.That(lists[1].GetVisualDescendants().OfType<TextBlock>()
+                    .Any(text => text.Text == "Available editor"), Is.True);
+                Assert.That(lists[0].GetVisualDescendants().OfType<FACommandBarButton>().Count(), Is.EqualTo(3));
+                Assert.That(lists[1].GetVisualDescendants().OfType<FACommandBarButton>().Count(), Is.EqualTo(1));
+            });
+
+            FACommandBar bar = view.GetVisualDescendants().OfType<FACommandBar>().Single();
+            Assert.That(bar.PrimaryCommands.OfType<FACommandBarButton>().Single().IconSource, Is.Not.Null);
+            foreach (FACommandBarButton button in lists.SelectMany(list => list.GetVisualDescendants())
+                         .OfType<FACommandBarButton>())
+            {
+                Assert.Multiple(() =>
+                {
+                    Assert.That(button.IconSource, Is.Not.Null, button.Label);
+                    Assert.That(button.Label, Is.Not.Null.And.Not.Empty);
+                    Assert.That(button.CommandParameter,
+                        Is.InstanceOf<EditorExtensionPriorityPageViewModel.EditorExtensionWrapper>());
+                });
+            }
+        }
+        finally
+        {
+            view.DataContext = null;
+            window.Close();
+            HeadlessTestHelpers.Settle();
+        }
+    }
+}

--- a/tests/Beutl.HeadlessUITests/EditorSettingsPageViewModelTests.cs
+++ b/tests/Beutl.HeadlessUITests/EditorSettingsPageViewModelTests.cs
@@ -92,7 +92,10 @@ public sealed class EditorSettingsPageViewModelTests
 
         try
         {
+            config.GitExecutablePath = null;
             using var viewModel = new EditorSettingsPageViewModel();
+
+            Assert.That(viewModel.GitExecutablePath.Value, Is.EqualTo(string.Empty));
 
             viewModel.EnableVersionControlForNewProjects.Value = false;
             viewModel.AutoCommitOnSave.Value = false;
@@ -114,6 +117,7 @@ public sealed class EditorSettingsPageViewModelTests
 
             viewModel.GitExecutablePath.Value = "  ";
             Assert.That(config.GitExecutablePath, Is.Null);
+            Assert.That(viewModel.GitExecutablePath.Value, Is.EqualTo(string.Empty));
         }
         finally
         {

--- a/tests/Beutl.HeadlessUITests/FileItemDragBehaviorTests.cs
+++ b/tests/Beutl.HeadlessUITests/FileItemDragBehaviorTests.cs
@@ -1,0 +1,82 @@
+﻿using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Headless.NUnit;
+using Avalonia.Input;
+using Avalonia.Platform.Storage;
+using Avalonia.Xaml.Interactivity;
+using Beutl.Editor.Components.FileBrowserTab.ViewModels;
+using Beutl.Editor.Components.FileBrowserTab.Views;
+using Beutl.Testing.Headless;
+using Moq;
+
+namespace Beutl.HeadlessUITests;
+
+[TestFixture]
+public class FileItemDragBehaviorTests
+{
+    [AvaloniaTest]
+    [TestCase(false)]
+    [TestCase(true)]
+    public async Task Drag_resolves_storage_from_the_window_and_releases_its_state(bool isDirectory)
+    {
+        string path = Path.Combine(BeutlHomeIsolation.CurrentHome!, "drag-source.bin");
+        var folderUri = new Uri(path + Path.DirectorySeparatorChar);
+        using var item = new FileSystemItemViewModel(path, isDirectory);
+        var control = new Border { Background = Avalonia.Media.Brushes.White, DataContext = item };
+        var behavior = new FileItemDragBehavior();
+        Interaction.GetBehaviors(control).Add(behavior);
+        var file = new Mock<IStorageFile>();
+        var folder = new Mock<IStorageFolder>();
+        var fileSource = new TaskCompletionSource<IStorageFile?>();
+        var folderSource = new TaskCompletionSource<IStorageFolder?>();
+        var storage = new Mock<IStorageProvider>(MockBehavior.Strict);
+        storage.Setup(provider => provider.TryGetFileFromPathAsync(new Uri(path))).Returns(fileSource.Task);
+        storage.Setup(provider => provider.TryGetFolderFromPathAsync(folderUri)).Returns(folderSource.Task);
+        var window = new Window { Content = control, Width = 300, Height = 200 };
+        TestStorageProviderFactory.SetProvider(window, storage.Object);
+        try
+        {
+            window.Show();
+            HeadlessTestHelpers.Render();
+            window.MouseDown(new Point(20, 20), MouseButton.Left);
+            window.MouseMove(new Point(22, 22), RawInputModifiers.LeftMouseButton);
+            HeadlessTestHelpers.Settle();
+            Assert.That(FileItemDragBehavior.IsInternalDragInProgress, Is.False,
+                "Moving below the threshold must not start a drag.");
+            window.MouseMove(new Point(40, 40), RawInputModifiers.LeftMouseButton);
+            HeadlessTestHelpers.Settle();
+            window.MouseMove(new Point(60, 60), RawInputModifiers.LeftMouseButton);
+            HeadlessTestHelpers.Settle();
+            Assert.That(FileItemDragBehavior.IsInternalDragInProgress, Is.True);
+            storage.Verify(provider => provider.TryGetFileFromPathAsync(new Uri(path)),
+                isDirectory ? Times.Never() : Times.Once());
+            storage.Verify(provider => provider.TryGetFolderFromPathAsync(folderUri),
+                isDirectory ? Times.Once() : Times.Never());
+
+            fileSource.SetResult(file.Object);
+            folderSource.SetResult(folder.Object);
+            HeadlessTestHelpers.Settle();
+            window.MouseUp(new Point(60, 60), MouseButton.Left);
+            for (int attempt = 0; attempt < 100 && FileItemDragBehavior.IsInternalDragInProgress; attempt++)
+            {
+                await Task.Delay(10);
+                HeadlessTestHelpers.Settle();
+            }
+
+            Assert.That(FileItemDragBehavior.IsInternalDragInProgress, Is.False,
+                "Completing or cancelling the drag must clear the shared internal-drag flag.");
+            window.MouseMove(new Point(80, 80));
+            Assert.That(FileItemDragBehavior.IsInternalDragInProgress, Is.False);
+        }
+        finally
+        {
+            fileSource.TrySetResult(null);
+            folderSource.TrySetResult(null);
+            window.MouseUp(new Point(60, 60), MouseButton.Left);
+            Interaction.GetBehaviors(control).Remove(behavior);
+            window.Close();
+            HeadlessTestHelpers.Settle();
+        }
+    }
+}

--- a/tests/Beutl.HeadlessUITests/MacOSTitleBarTests.cs
+++ b/tests/Beutl.HeadlessUITests/MacOSTitleBarTests.cs
@@ -1,0 +1,150 @@
+﻿using Avalonia.Controls;
+using Avalonia.Headless.NUnit;
+using Beutl.Helpers;
+using Beutl.Testing.Headless;
+
+namespace Beutl.HeadlessUITests;
+
+[TestFixture]
+public class MacOSTitleBarTests
+{
+    [AvaloniaTest]
+    public void Fullscreen_exit_restores_the_toolbar()
+    {
+        var window = new Window();
+        var native = new RecordingToolbar();
+        using var titleBar = new MacOSTitleBar(window, native);
+
+        try
+        {
+            window.WindowState = WindowState.FullScreen;
+            HeadlessTestHelpers.Settle();
+            window.WindowState = WindowState.Normal;
+            HeadlessTestHelpers.Settle();
+
+            Assert.That(native.FullscreenUpdates, Is.EqualTo(new[] { false, true, false }));
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaTest]
+    public void Initially_fullscreen_window_does_not_attach_the_toolbar()
+    {
+        var window = new Window { WindowState = WindowState.FullScreen };
+        var native = new RecordingToolbar();
+        using var titleBar = new MacOSTitleBar(window, native);
+
+        try
+        {
+            Assert.That(native.FullscreenUpdates, Is.EqualTo(new[] { true }));
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaTest]
+    public void Queued_update_uses_the_latest_window_state()
+    {
+        var window = new Window();
+        var native = new RecordingToolbar();
+        using var titleBar = new MacOSTitleBar(window, native);
+
+        try
+        {
+            window.WindowState = WindowState.FullScreen;
+            window.WindowState = WindowState.Normal;
+            HeadlessTestHelpers.Settle();
+
+            Assert.That(native.FullscreenUpdates, Is.EqualTo(new[] { false, false }));
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaTest]
+    public void Closing_with_a_queued_update_releases_once_without_accessing_the_closed_window()
+    {
+        var window = new Window();
+        var native = new RecordingToolbar();
+        using var titleBar = new MacOSTitleBar(window, native);
+        window.Show();
+
+        window.WindowState = WindowState.FullScreen;
+        window.Close();
+        titleBar.Dispose();
+        HeadlessTestHelpers.Settle();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(native.DisposeCount, Is.EqualTo(1));
+            Assert.That(native.FullscreenUpdates, Is.EqualTo(new[] { false }));
+        });
+    }
+
+    [AvaloniaTest]
+    public void Cancelled_close_keeps_the_toolbar_active()
+    {
+        var window = new Window();
+        var native = new RecordingToolbar();
+        using var titleBar = new MacOSTitleBar(window, native);
+        window.Show();
+        window.Closing += CancelClose;
+
+        try
+        {
+            window.Close();
+            window.WindowState = WindowState.FullScreen;
+            HeadlessTestHelpers.Settle();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(native.DisposeCount, Is.Zero);
+                Assert.That(native.FullscreenUpdates, Is.EqualTo(new[] { false, true }));
+            });
+        }
+        finally
+        {
+            window.Closing -= CancelClose;
+            window.Close();
+        }
+
+        static void CancelClose(object? sender, WindowClosingEventArgs e) => e.Cancel = true;
+    }
+
+    [AvaloniaTest]
+    public void Headless_window_does_not_load_AppKit()
+    {
+        var window = new Window { ExtendClientAreaToDecorationsHint = true };
+
+        try
+        {
+            Assert.That(MacOSTitleBar.TryAttach(window), Is.Null);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    private sealed class RecordingToolbar : MacOSTitleBar.INativeToolbar
+    {
+        public List<bool> FullscreenUpdates { get; } = [];
+
+        public int DisposeCount { get; private set; }
+
+        public void Update(bool fullScreen)
+        {
+            Assert.That(DisposeCount, Is.Zero, "A closed NSWindow must not receive another native update.");
+            FullscreenUpdates.Add(fullScreen);
+        }
+
+        public void Dispose() => DisposeCount++;
+    }
+}

--- a/tests/Beutl.HeadlessUITests/PackageDiscoveryLayoutTests.cs
+++ b/tests/Beutl.HeadlessUITests/PackageDiscoveryLayoutTests.cs
@@ -1,8 +1,8 @@
 ﻿using Avalonia.Controls;
 using Avalonia.Controls.Templates;
 using Avalonia.Headless.NUnit;
+using Beutl.Controls;
 using Beutl.Testing.Headless;
-using PanelExtension;
 
 namespace Beutl.HeadlessUITests;
 
@@ -12,7 +12,7 @@ public class PackageDiscoveryLayoutTests
     [AvaloniaTest]
     public void Package_grid_realizes_and_wraps_items_with_the_current_items_repeater()
     {
-        // The discovery pages use PanelExtension, which is distributed separately from Avalonia.
+        // The discovery pages use the layout included in Beutl.Controls.
         var repeater = new ItemsRepeater
         {
             ItemsSource = new[] { "one", "two", "three", "four" },
@@ -49,4 +49,104 @@ public class PackageDiscoveryLayoutTests
             HeadlessTestHelpers.Settle();
         }
     }
+
+    [AvaloniaTest]
+    public void Resizing_the_window_reflows_items_into_one_column()
+    {
+        var layout = new HorizontalGridLayout { MinItemWidth = 345, ColumnSpacing = 16, RowSpacing = 16 };
+        ItemsRepeater repeater = CreateRepeater(layout);
+        var window = new Window { Content = repeater, Width = 740, Height = 300 };
+        try
+        {
+            window.Show();
+            HeadlessTestHelpers.Render();
+            Assert.That(repeater.TryGetElement(1)!.Bounds.Y, Is.EqualTo(repeater.TryGetElement(0)!.Bounds.Y));
+
+            window.Width = 400;
+            HeadlessTestHelpers.Render();
+            Control first = repeater.TryGetElement(0)!;
+            Control second = repeater.TryGetElement(1)!;
+            Assert.Multiple(() =>
+            {
+                Assert.That(second.Bounds.X, Is.EqualTo(first.Bounds.X));
+                Assert.That(second.Bounds.Y, Is.EqualTo(first.Bounds.Bottom + 16));
+                Assert.That(first.Bounds.Width, Is.EqualTo(repeater.Bounds.Width));
+            });
+        }
+        finally
+        {
+            window.Close();
+            HeadlessTestHelpers.Settle();
+        }
+    }
+
+    [AvaloniaTest]
+    public void Changing_column_limit_and_spacing_updates_existing_items()
+    {
+        var layout = new HorizontalGridLayout { MinItemWidth = 345, ColumnSpacing = 16, RowSpacing = 16 };
+        ItemsRepeater repeater = CreateRepeater(layout);
+        var window = new Window { Content = repeater, Width = 740, Height = 300 };
+        try
+        {
+            window.Show();
+            HeadlessTestHelpers.Render();
+
+            layout.MaxColumns = 1;
+            HeadlessTestHelpers.Render();
+            Assert.That(repeater.TryGetElement(1)!.Bounds.Y, Is.GreaterThan(repeater.TryGetElement(0)!.Bounds.Bottom));
+
+            layout.MaxColumns = 2;
+            layout.ColumnSpacing = 32;
+            layout.RowSpacing = 24;
+            HeadlessTestHelpers.Render();
+            Control first = repeater.TryGetElement(0)!;
+            Control second = repeater.TryGetElement(1)!;
+            Control third = repeater.TryGetElement(2)!;
+            Assert.Multiple(() =>
+            {
+                Assert.That(second.Bounds.X, Is.EqualTo(first.Bounds.Right + 32));
+                Assert.That(second.Bounds.Y, Is.EqualTo(first.Bounds.Y));
+                Assert.That(third.Bounds.Y, Is.EqualTo(first.Bounds.Bottom + 24));
+            });
+        }
+        finally
+        {
+            window.Close();
+            HeadlessTestHelpers.Settle();
+        }
+    }
+
+    [AvaloniaTest]
+    public void Removing_all_items_clears_the_measured_height()
+    {
+        var layout = new HorizontalGridLayout { MinItemWidth = 345, ColumnSpacing = 16, RowSpacing = 16 };
+        ItemsRepeater repeater = CreateRepeater(layout);
+        var window = new Window { Content = repeater, Width = 740, Height = 300 };
+        try
+        {
+            window.Show();
+            HeadlessTestHelpers.Render();
+            Assert.That(repeater.DesiredSize.Height, Is.GreaterThan(0));
+
+            repeater.ItemsSource = Array.Empty<string>();
+            HeadlessTestHelpers.Render();
+            Assert.Multiple(() =>
+            {
+                Assert.That(repeater.TryGetElement(0), Is.Null);
+                Assert.That(repeater.DesiredSize.Height, Is.Zero);
+            });
+        }
+        finally
+        {
+            window.Close();
+            HeadlessTestHelpers.Settle();
+        }
+    }
+
+    private static ItemsRepeater CreateRepeater(HorizontalGridLayout layout) => new()
+    {
+        ItemsSource = new[] { "one", "two", "three", "four" },
+        ItemTemplate = new FuncDataTemplate<string>((text, _) => new TextBlock { Text = text, Height = 40 }),
+        Layout = layout,
+    };
 }

--- a/tests/Beutl.HeadlessUITests/PackageDiscoveryLayoutTests.cs
+++ b/tests/Beutl.HeadlessUITests/PackageDiscoveryLayoutTests.cs
@@ -1,0 +1,52 @@
+﻿using Avalonia.Controls;
+using Avalonia.Controls.Templates;
+using Avalonia.Headless.NUnit;
+using Beutl.Testing.Headless;
+using PanelExtension;
+
+namespace Beutl.HeadlessUITests;
+
+[TestFixture]
+public class PackageDiscoveryLayoutTests
+{
+    [AvaloniaTest]
+    public void Package_grid_realizes_and_wraps_items_with_the_current_items_repeater()
+    {
+        // The discovery pages use PanelExtension, which is distributed separately from Avalonia.
+        var repeater = new ItemsRepeater
+        {
+            ItemsSource = new[] { "one", "two", "three", "four" },
+            ItemTemplate = new FuncDataTemplate<string>((text, _) => new TextBlock { Text = text, Height = 40 }),
+            Layout = new HorizontalGridLayout
+            {
+                MinItemWidth = 345,
+                ColumnSpacing = 16,
+                RowSpacing = 16,
+            },
+        };
+        var window = new Window { Content = repeater, Width = 740, Height = 300 };
+
+        try
+        {
+            window.Show();
+            HeadlessTestHelpers.Render();
+
+            Control first = repeater.TryGetElement(0)!;
+            Control second = repeater.TryGetElement(1)!;
+            Control third = repeater.TryGetElement(2)!;
+            Assert.Multiple(() =>
+            {
+                Assert.That(repeater.TryGetElement(3), Is.Not.Null);
+                Assert.That(first.Bounds.Width, Is.GreaterThanOrEqualTo(345));
+                Assert.That(second.Bounds.X, Is.GreaterThan(first.Bounds.Right));
+                Assert.That(second.Bounds.Y, Is.EqualTo(first.Bounds.Y));
+                Assert.That(third.Bounds.Y, Is.GreaterThan(first.Bounds.Bottom));
+            });
+        }
+        finally
+        {
+            window.Close();
+            HeadlessTestHelpers.Settle();
+        }
+    }
+}

--- a/tests/Beutl.HeadlessUITests/PropertyBindingTests.cs
+++ b/tests/Beutl.HeadlessUITests/PropertyBindingTests.cs
@@ -1,0 +1,45 @@
+﻿using Avalonia.Controls;
+using Avalonia.Data;
+using Avalonia.Headless.NUnit;
+using Beutl.Testing.Headless;
+using Reactive.Bindings;
+
+namespace Beutl.HeadlessUITests;
+
+[TestFixture]
+public class PropertyBindingTests
+{
+    [AvaloniaTest]
+    public void Two_way_binding_updates_both_the_editor_and_reactive_property()
+    {
+        using var value = new ReactiveProperty<string?>("initial");
+        var editor = new TextBox();
+        using var binding = editor.Bind(TextBox.TextProperty, value.ToPropertyBinding(BindingMode.TwoWay));
+
+        Assert.That(editor.Text, Is.EqualTo("initial"));
+
+        value.Value = "model update";
+        HeadlessTestHelpers.Settle();
+        Assert.That(editor.Text, Is.EqualTo("model update"));
+
+        editor.SetCurrentValue(TextBox.TextProperty, "editor update");
+        HeadlessTestHelpers.Settle();
+        Assert.That(value.Value, Is.EqualTo("editor update"));
+    }
+
+    [AvaloniaTest]
+    public void One_way_binding_does_not_write_editor_changes_to_the_reactive_property()
+    {
+        using var value = new ReactiveProperty<string?>("initial");
+        var editor = new TextBox();
+        using var binding = editor.Bind(TextBox.TextProperty, value.ToPropertyBinding(BindingMode.OneWay));
+
+        editor.SetCurrentValue(TextBox.TextProperty, "editor update");
+        HeadlessTestHelpers.Settle();
+        Assert.That(value.Value, Is.EqualTo("initial"));
+
+        value.Value = "model update";
+        HeadlessTestHelpers.Settle();
+        Assert.That(editor.Text, Is.EqualTo("model update"));
+    }
+}

--- a/tests/Beutl.HeadlessUITests/SettingsDialogTests.cs
+++ b/tests/Beutl.HeadlessUITests/SettingsDialogTests.cs
@@ -1,0 +1,109 @@
+﻿using Avalonia.Controls;
+using Avalonia.Headless.NUnit;
+using Avalonia.VisualTree;
+using Beutl.Pages;
+using Beutl.Pages.SettingsPages;
+using Beutl.Testing.Headless;
+using Beutl.ViewModels;
+using FluentAvalonia.UI.Controls;
+
+namespace Beutl.HeadlessUITests;
+
+[TestFixture]
+public class SettingsDialogTests
+{
+    [AvaloniaTest]
+    public void Constructor_initializes_navigation_without_accessing_uninitialized_controls()
+    {
+        SettingsDialog? dialog = null;
+        try
+        {
+            dialog = new SettingsDialog();
+            Assert.Multiple(() =>
+            {
+                Assert.That(dialog.FindControl<FANavigationView>("nav"), Is.Not.Null);
+                Assert.That(dialog.FindControl<FAFrame>("frame"), Is.Not.Null);
+            });
+        }
+        finally
+        {
+            dialog?.Close();
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task Account_requested_before_ShowDialog_is_rendered_on_first_open()
+    {
+        await VerifyInitialPageAsync(requestAccount: true, requestInformation: false);
+    }
+
+    [AvaloniaTest]
+    public async Task Latest_request_before_ShowDialog_wins_without_an_extra_back_entry()
+    {
+        await VerifyInitialPageAsync(requestAccount: true, requestInformation: true);
+    }
+
+    [AvaloniaTest]
+    public async Task Opening_without_a_request_renders_the_default_account_page()
+    {
+        await VerifyInitialPageAsync(requestAccount: false, requestInformation: false);
+    }
+
+    private static async Task VerifyInitialPageAsync(bool requestAccount, bool requestInformation)
+    {
+        await TestReset.ResetShellAsync();
+        using SettingsDialogViewModel viewModel = TestShell.MainViewModel.CreateSettingsDialog();
+        var dialog = new SettingsDialog { DataContext = viewModel, Width = 800, Height = 600 };
+        var owner = new Window();
+        FAFrame frame = dialog.FindControl<FAFrame>("frame")!;
+
+        try
+        {
+            // Match App.OpenSettingsClicked: set the DataContext, request navigation, then show.
+            if (requestAccount)
+                viewModel.GoToAccountSettingsPage();
+            if (requestInformation)
+                viewModel.GoToSettingsPage();
+
+            owner.Show();
+            Task closed = dialog.ShowDialog(owner);
+            HeadlessTestHelpers.Render(3);
+
+            Type expectedPage = requestInformation ? typeof(InformationPage) : typeof(AccountSettingsPage);
+            object expectedContext = requestInformation ? viewModel.Information : viewModel.Account;
+            Assert.Multiple(() =>
+            {
+                Assert.That(frame.Content, Is.TypeOf(expectedPage));
+                Assert.That(((Control)frame.Content!).DataContext, Is.SameAs(expectedContext));
+                Assert.That(dialog.GetVisualDescendants().Any(control => control.GetType() == expectedPage), Is.True);
+                Assert.That(frame.BackStack, Is.Empty);
+            });
+
+            if (requestAccount && !requestInformation)
+            {
+                viewModel.GoToSettingsPage();
+                HeadlessTestHelpers.Render(3);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(frame.Content, Is.TypeOf<InformationPage>());
+                    Assert.That(frame.BackStack, Has.Count.EqualTo(1));
+                });
+            }
+
+            // Closing clears navigation after initialization and completes the modal lifetime.
+            dialog.Close();
+            await closed;
+            Assert.Multiple(() =>
+            {
+                Assert.That(frame.BackStack, Is.Empty);
+                Assert.That(frame.ForwardStack, Is.Empty);
+            });
+        }
+        finally
+        {
+            dialog.Close();
+            owner.Close();
+            HeadlessTestHelpers.Settle();
+        }
+    }
+}

--- a/tests/Beutl.HeadlessUITests/StartupNotificationServiceTests.cs
+++ b/tests/Beutl.HeadlessUITests/StartupNotificationServiceTests.cs
@@ -159,7 +159,7 @@ public sealed class StartupNotificationServiceTests
     {
         string[] packageNames = ["First\nPackage", new('A', 100), "Third", "Fourth", "Fifth"];
 
-        ContentDialog dialog = StartupNotificationService.CreateSideloadDetailsDialog(packageNames);
+        FAContentDialog dialog = StartupNotificationService.CreateSideloadDetailsDialog(packageNames);
         var listBox = (ListBox)dialog.Content!;
 
         Assert.Multiple(() =>
@@ -168,7 +168,7 @@ public sealed class StartupNotificationServiceTests
             Assert.That(listBox.MaxHeight, Is.EqualTo(400));
             Assert.That(listBox.MaxWidth, Is.EqualTo(520));
             Assert.That(dialog.CloseButtonText, Is.EqualTo(Strings.Close));
-            Assert.That(dialog.DefaultButton, Is.EqualTo(ContentDialogButton.Close));
+            Assert.That(dialog.DefaultButton, Is.EqualTo(FAContentDialogButton.Close));
         });
     }
 
@@ -221,7 +221,7 @@ public sealed class StartupNotificationServiceTests
             ],
             IsClosable: false);
         var handler = new NotificationServiceHandler();
-        InfoBar infoBar = handler.BuildInfoBar(notification, dismissed, () => { });
+        FAInfoBar infoBar = handler.BuildInfoBar(notification, dismissed, () => { });
         var actionPanel = (WrapPanel)infoBar.ActionButton!;
         var detailsButton = (Button)actionPanel.Children[0];
         var acceptButton = (Button)actionPanel.Children[1];

--- a/tests/Beutl.HeadlessUITests/StoragePickerWindowTests.cs
+++ b/tests/Beutl.HeadlessUITests/StoragePickerWindowTests.cs
@@ -1,0 +1,198 @@
+﻿using Avalonia.Controls;
+using Avalonia.Headless.NUnit;
+using Avalonia.Interactivity;
+using Avalonia.Platform.Storage;
+using Avalonia.VisualTree;
+using Beutl.Controls;
+using Beutl.Controls.PropertyEditors;
+using Beutl.Pages.SettingsPages;
+using Beutl.Testing.Headless;
+using Beutl.ViewModels.Dialogs;
+using Beutl.ViewModels.SettingsPages;
+using Beutl.Views;
+using Beutl.Views.Dialogs;
+using FluentAvalonia.UI.Controls;
+using FluentIcons.Avalonia.Fluent;
+using FluentIcons.Common;
+using Moq;
+
+namespace Beutl.HeadlessUITests;
+
+[TestFixture]
+public class StoragePickerWindowTests
+{
+    [AvaloniaTest]
+    public void File_input_opens_the_picker_when_the_visual_root_is_not_the_window()
+    {
+        var file = new Mock<IStorageFile>();
+        file.SetupGet(x => x.Name).Returns("example.png");
+        var storage = new Mock<IStorageProvider>(MockBehavior.Strict);
+        storage.Setup(x => x.OpenFilePickerAsync(It.IsAny<FilePickerOpenOptions>()))
+            .ReturnsAsync(new[] { file.Object });
+
+        var input = new FileInputArea();
+        var window = new Window { Content = input, Width = 400, Height = 200 };
+        TestStorageProviderFactory.SetProvider(window, storage.Object);
+        try
+        {
+            window.Show();
+            HeadlessTestHelpers.Render();
+            Assert.That(input.GetVisualAncestors().Last(), Is.Not.InstanceOf<TopLevel>(),
+                "Avalonia 12 places a host visual above the Window.");
+
+            Button button = input.GetVisualDescendants().OfType<Button>().Single(x => x.Name == "PART_Button");
+            button.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+            HeadlessTestHelpers.Settle();
+
+            storage.Verify(x => x.OpenFilePickerAsync(It.IsAny<FilePickerOpenOptions>()), Times.Once);
+            Assert.That(input.SelectedFile, Is.SameAs(file.Object));
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaTest]
+    public void Storage_file_editor_accepts_a_file_from_the_host_window_picker()
+    {
+        string path = Path.Combine(BeutlHomeIsolation.CurrentHome!, "selected-file.bin");
+        var file = new Mock<IStorageFile>();
+        file.SetupGet(x => x.Path).Returns(new Uri(path));
+        var storage = new Mock<IStorageProvider>(MockBehavior.Strict);
+        storage.Setup(x => x.OpenFilePickerAsync(It.IsAny<FilePickerOpenOptions>()))
+            .ReturnsAsync(new[] { file.Object });
+        var editor = new StorageFileEditor { OpenOptions = new FilePickerOpenOptions() };
+        var window = new Window { Content = editor, Width = 500, Height = 200 };
+        TestStorageProviderFactory.SetProvider(window, storage.Object);
+        try
+        {
+            window.Show();
+            HeadlessTestHelpers.Render();
+            Button button = editor.GetVisualDescendants().OfType<Button>().Single(x => x.Name == "PART_Button");
+            button.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+            HeadlessTestHelpers.Settle();
+
+            storage.Verify(x => x.OpenFilePickerAsync(It.IsAny<FilePickerOpenOptions>()), Times.Once);
+            Assert.That(editor.Value.FullName, Is.EqualTo(path));
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaTest]
+    public void Font_settings_uses_the_host_window_folder_picker()
+    {
+        using var viewModel = new FontSettingsPageViewModel();
+        var storage = new Mock<IStorageProvider>(MockBehavior.Strict);
+        storage.Setup(x => x.OpenFolderPickerAsync(It.IsAny<FolderPickerOpenOptions>()))
+            .ReturnsAsync(Array.Empty<IStorageFolder>());
+        var view = new FontSettingsPage { DataContext = viewModel };
+        var window = new Window { Content = view, Width = 500, Height = 400 };
+        TestStorageProviderFactory.SetProvider(window, storage.Object);
+        try
+        {
+            window.Show();
+            HeadlessTestHelpers.Render();
+            view.AddClick(view, new RoutedEventArgs(Button.ClickEvent));
+            HeadlessTestHelpers.Settle();
+
+            storage.Verify(x => x.OpenFolderPickerAsync(It.Is<FolderPickerOpenOptions>(options => options.AllowMultiple)), Times.Once);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task Main_menu_file_project_import_and_export_commands_open_the_host_window_picker()
+    {
+        await TestReset.ResetShellAsync();
+        string projectPath = Path.Combine(BeutlHomeIsolation.CurrentHome!, "picker-project", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(projectPath);
+        await TestShell.Project.CreateProject(640, 480, 30, 44100, "picker-project", projectPath);
+        var storage = new Mock<IStorageProvider>(MockBehavior.Strict);
+        storage.Setup(x => x.OpenFilePickerAsync(It.IsAny<FilePickerOpenOptions>()))
+            .ReturnsAsync(Array.Empty<IStorageFile>());
+        storage.Setup(x => x.SaveFilePickerAsync(It.IsAny<FilePickerSaveOptions>()))
+            .ReturnsAsync((IStorageFile?)null);
+        var window = new Window { Width = 800, Height = 600 };
+        TestStorageProviderFactory.SetProvider(window, storage.Object);
+        // Open the test host before attaching MainView, so it doesn't run the real App startup.
+        window.Show();
+        var view = new MainView { DataContext = TestShell.MainViewModel };
+        try
+        {
+            window.Content = view;
+            HeadlessTestHelpers.Render();
+
+            await TestShell.MainViewModel.MenuBar.OpenFile.ExecuteAsync();
+            await TestShell.MainViewModel.MenuBar.OpenProject.ExecuteAsync();
+            await TestShell.MainViewModel.MenuBar.ImportProject.ExecuteAsync();
+            await TestShell.MainViewModel.MenuBar.ExportProject.ExecuteAsync();
+
+            storage.Verify(x => x.OpenFilePickerAsync(It.IsAny<FilePickerOpenOptions>()), Times.Exactly(3));
+            storage.Verify(x => x.SaveFilePickerAsync(It.IsAny<FilePickerSaveOptions>()), Times.Once);
+        }
+        finally
+        {
+            view.DataContext = null;
+            window.Close();
+            HeadlessTestHelpers.Settle();
+            await TestReset.ResetShellAsync();
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task New_project_dialog_can_select_its_location()
+        => await VerifyCreationLocationPickerAsync(project: true);
+
+    [AvaloniaTest]
+    public async Task New_scene_dialog_can_select_its_location()
+        => await VerifyCreationLocationPickerAsync(project: false);
+
+    private static async Task VerifyCreationLocationPickerAsync(bool project)
+    {
+        await TestReset.ResetShellAsync();
+        string path = Path.Combine(BeutlHomeIsolation.CurrentHome!, "picker-folder", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(path);
+        var folder = new Mock<IStorageFolder>();
+        folder.SetupGet(x => x.Path).Returns(new Uri(path));
+        var storage = new Mock<IStorageProvider>(MockBehavior.Strict);
+        storage.Setup(x => x.OpenFolderPickerAsync(It.IsAny<FolderPickerOpenOptions>()))
+            .ReturnsAsync(new[] { folder.Object });
+        var window = new Window { Width = 800, Height = 600 };
+        TestStorageProviderFactory.SetProvider(window, storage.Object);
+        FAContentDialog dialog = project
+            ? new CreateNewProject { DataContext = new CreateNewProjectViewModel(TestShell.Project) }
+            : new CreateNewScene { DataContext = new CreateNewSceneViewModel(TestShell.Project, TestShell.Editor) };
+        Task? closed = null;
+        try
+        {
+            window.Show();
+            closed = dialog.ShowAsync(window);
+            HeadlessTestHelpers.Render(3);
+            Button button = dialog.GetVisualDescendants().OfType<Button>()
+                .Single(x => x.Content is FluentIcon { Icon: Icon.OpenFolder });
+            button.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+            HeadlessTestHelpers.Settle();
+
+            storage.Verify(x => x.OpenFolderPickerAsync(It.IsAny<FolderPickerOpenOptions>()), Times.Once);
+            string location = dialog.DataContext is CreateNewProjectViewModel projectViewModel
+                ? projectViewModel.Location.Value
+                : ((CreateNewSceneViewModel)dialog.DataContext!).Location.Value;
+            Assert.That(location, Is.EqualTo(path));
+        }
+        finally
+        {
+            dialog.Hide();
+            if (closed is not null)
+                await closed.WaitAsync(TimeSpan.FromSeconds(5));
+            window.Close();
+            HeadlessTestHelpers.Settle();
+        }
+    }
+}

--- a/tests/Beutl.HeadlessUITests/TestAppBuilder.cs
+++ b/tests/Beutl.HeadlessUITests/TestAppBuilder.cs
@@ -1,4 +1,5 @@
 ﻿using Avalonia;
+using Avalonia.Controls.Platform;
 using Avalonia.Headless;
 using Beutl.HeadlessUITests;
 using Beutl.Testing.Headless;
@@ -20,6 +21,7 @@ public static class TestAppBuilder
         OpenALPreload.EnsureLoaded();
         return AppBuilder.Configure<TestApp>()
             .UseSkia()
+            .With<IStorageProviderFactory>(new TestStorageProviderFactory())
             .UseHeadless(new AvaloniaHeadlessPlatformOptions { UseHeadlessDrawing = false });
     }
 }

--- a/tests/Beutl.HeadlessUITests/TestStorageProviderFactory.cs
+++ b/tests/Beutl.HeadlessUITests/TestStorageProviderFactory.cs
@@ -1,0 +1,19 @@
+﻿using System.Runtime.CompilerServices;
+using Avalonia.Controls;
+using Avalonia.Controls.Platform;
+using Avalonia.Platform.Storage;
+
+namespace Beutl.HeadlessUITests;
+
+// Opt individual test windows into mocked native pickers; all other windows use the usual fallback.
+internal sealed class TestStorageProviderFactory : IStorageProviderFactory
+{
+    private static readonly ConditionalWeakTable<TopLevel, IStorageProvider> s_providers = new();
+
+    public static void SetProvider(TopLevel window, IStorageProvider provider)
+        => s_providers.Add(window, provider);
+
+    // TopLevel explicitly falls back to the platform provider when the factory returns null.
+    public IStorageProvider CreateProvider(TopLevel topLevel)
+        => s_providers.TryGetValue(topLevel, out IStorageProvider? provider) ? provider : null!;
+}

--- a/tests/Beutl.HeadlessUITests/ThemeCaptureTests.cs
+++ b/tests/Beutl.HeadlessUITests/ThemeCaptureTests.cs
@@ -178,7 +178,7 @@ public class ThemeCaptureTests
                         Spacing = 10,
                         Children =
                         {
-                            new FluentAvalonia.UI.Controls.NumberBox { Value = 1920, Width = 140 },
+                            new FluentAvalonia.UI.Controls.FANumberBox { Value = 1920, Width = 140 },
                             new AutoCompleteBox { Text = "1920", Width = 160 },
                             new FluentAvalonia.UI.Controls.ColorPickerButton(),
                             new Button
@@ -189,10 +189,10 @@ public class ThemeCaptureTests
                                 {
                                     Items =
                                     {
-                                        new FluentAvalonia.UI.Controls.MenuFlyoutItem { Text = "Cut" },
-                                        new FluentAvalonia.UI.Controls.MenuFlyoutItem { Text = "Copy" },
-                                        new FluentAvalonia.UI.Controls.MenuFlyoutSeparator(),
-                                        new FluentAvalonia.UI.Controls.ToggleMenuFlyoutItem { Text = "Snap to grid", IsChecked = true },
+                                        new FluentAvalonia.UI.Controls.FAMenuFlyoutItem { Text = "Cut" },
+                                        new FluentAvalonia.UI.Controls.FAMenuFlyoutItem { Text = "Copy" },
+                                        new FluentAvalonia.UI.Controls.FAMenuFlyoutSeparator(),
+                                        new FluentAvalonia.UI.Controls.FAToggleMenuFlyoutItem { Text = "Snap to grid", IsChecked = true },
                                     },
                                 },
                             },

--- a/tests/Beutl.HeadlessUITests/ThemeCaptureTests.cs
+++ b/tests/Beutl.HeadlessUITests/ThemeCaptureTests.cs
@@ -61,7 +61,7 @@ public class ThemeCaptureTests
 
         Directory.CreateDirectory(OutputDirectory);
         string path = Path.Combine(OutputDirectory, name);
-        frame!.Save(path);
+        frame!.Save(path, PngBitmapEncoderOptions.Default);
         TestContext.Out.WriteLine($"Saved capture: {path}");
         return path;
     }
@@ -152,7 +152,7 @@ public class ThemeCaptureTests
                         Children =
                         {
                             new TextBox { Width = 200, Text = "1920" },
-                            new TextBox { Width = 200, Watermark = "Search..." },
+                            new TextBox { Width = 200, PlaceholderText = "Search..." },
                             comboBox,
                         },
                     },

--- a/tests/Beutl.HeadlessUITests/VersionControlSaveTests.cs
+++ b/tests/Beutl.HeadlessUITests/VersionControlSaveTests.cs
@@ -1022,10 +1022,10 @@ public class VersionControlSaveTests
                 TestShell.Editor,
                 TestShell.Project);
             bool primaryClosed = await packageHandler.HandleProjectCloseChoice(
-                ContentDialogResult.Primary,
+                FAContentDialogResult.Primary,
                 expected);
             bool secondaryClosed = await packageHandler.HandleProjectCloseChoice(
-                ContentDialogResult.Secondary,
+                FAContentDialogResult.Secondary,
                 expected);
             Assert.Multiple(() =>
             {
@@ -1092,7 +1092,7 @@ public class VersionControlSaveTests
                 TestShell.Project);
 
             bool closed = await packageHandler.HandleProjectCloseChoice(
-                ContentDialogResult.Primary,
+                FAContentDialogResult.Primary,
                 project);
 
             int commitsAfter = await CountCommitsAsync(gitPath, projectRoot);
@@ -1163,7 +1163,7 @@ public class VersionControlSaveTests
                 TestShell.Project);
 
             bool closed = await packageHandler.HandleProjectCloseChoice(
-                ContentDialogResult.Secondary,
+                FAContentDialogResult.Secondary,
                 project);
 
             int commitsAfter = await CountCommitsAsync(gitPath, projectRoot);
@@ -1265,7 +1265,7 @@ public class VersionControlSaveTests
             config.AutoCommitOnClose = false;
             Assert.That(
                 await packageHandler.HandleProjectCloseChoice(
-                    ContentDialogResult.Secondary,
+                    FAContentDialogResult.Secondary,
                     project),
                 Is.False);
             int commitsAfterFailedPackageSave = await CountCommitsAsync(gitPath, projectRoot);

--- a/tests/Beutl.HeadlessUITests/VersionControlTabViewTests.cs
+++ b/tests/Beutl.HeadlessUITests/VersionControlTabViewTests.cs
@@ -145,7 +145,7 @@ public class VersionControlTabViewTests
                 Assert.That(branchButton.Flyout.IsOpen, Is.False);
                 Assert.That(branchPrompt.IsOpen, Is.True);
                 Assert.That(branchPrompt.Target, Is.SameAs(branchButton));
-                Assert.That(branchPrompt.Presenter, Is.TypeOf<PickerFlyoutPresenter>());
+                Assert.That(branchPrompt.Presenter, Is.TypeOf<FAPickerFlyoutPresenter>());
                 Assert.That(branchPrompt.Presenter!.Width, Is.EqualTo(320));
                 Assert.That(branchPrompt.Presenter.Padding, Is.EqualTo(new Thickness(8, 4)));
                 Assert.That(
@@ -476,7 +476,7 @@ public class VersionControlTabViewTests
                     tabPrompt.PrimaryTextBox.Text,
                     Is.EqualTo("https://example.invalid/old.git"));
                 Assert.That(tabPrompt.PrimaryTextBox.IsVisible, Is.True);
-                Assert.That(tabPrompt.Presenter, Is.TypeOf<PickerFlyoutPresenter>());
+                Assert.That(tabPrompt.Presenter, Is.TypeOf<FAPickerFlyoutPresenter>());
                 Assert.That(acceptButton.IsVisible, Is.True);
                 Assert.That(dismissButton.IsVisible, Is.True);
             });
@@ -519,7 +519,7 @@ public class VersionControlTabViewTests
                 Strings.VersionControl_Pull,
                 longWarning);
             HeadlessTestHelpers.Render();
-            PickerFlyoutPresenter presenter = tabPrompt.Presenter!;
+            FAPickerFlyoutPresenter presenter = tabPrompt.Presenter!;
             ScrollViewer presenterScrollViewer = presenter
                 .GetVisualDescendants()
                 .OfType<ScrollViewer>()

--- a/tests/Beutl.HeadlessUITests/VersionControlTabViewTests.cs
+++ b/tests/Beutl.HeadlessUITests/VersionControlTabViewTests.cs
@@ -152,7 +152,7 @@ public class VersionControlTabViewTests
                     branchPrompt.TitleTextBlock.Text,
                     Is.EqualTo(Strings.VersionControl_NewBranch));
                 Assert.That(
-                    branchPrompt.PrimaryTextBox.Watermark,
+                    branchPrompt.PrimaryTextBox.PlaceholderText,
                     Is.EqualTo(Strings.VersionControl_BranchName));
                 Assert.That(branchPrompt.PrimaryTextBox.Text, Is.Null);
                 Assert.That(branchPrompt.MessageTextBlock.IsVisible, Is.False);


### PR DESCRIPTION
## Description

Upgrade the desktop UI to Avalonia 12.1.2 and FluentAvaloniaUI 3.1.0. Update the renamed FluentAvalonia controls, navigation, dialogs, menus, and developer tools; pin the migrated terminal submodule; and bind DispatcherTimers to their owning dispatcher.

Resolve owning windows through `TopLevel.GetTopLevel`, defer window initialization until controls are ready, and handle the macOS title-bar lifecycle. Prevent `DataContextEvents` callbacks from releasing a context twice or reactivating a disposed subscription. Move `HorizontalGridLayout` from PanelExtension into `Beutl.Controls` and record its pinned source and copyright provenance.

## Affected areas

- [ ] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [x] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [x] `Beutl.Extensibility` (plugin abstractions)
- [x] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [ ] Build / CI / docs only

## Breaking changes

- `EditorExtension.GetIcon()` and `ToolWindowExtension.GetIcon()` now return `FluentAvalonia.UI.Controls.FAIconSource?` instead of `IconSource?`. This changes their CLR signatures. Extensions compiled against Avalonia 11 / FluentAvalonia 2 are not binary compatible and can fail during exported-type discovery, causing the package to be rejected. Rebuild extensions and dependent assemblies against the Beutl SDK shipped with the Avalonia 12 host, update the renamed icon types and XAML references, and publish a new package release with the corresponding supported Beutl versions. No legacy icon adapter is provided. See the [extension migration guide](https://github.com/b-editor/beutl/blob/yuto-trd/avalonia12/docs/extension-authoring/avalonia-12-migration.md).
- The `PanelExtension` dependency is removed. Layout consumers must use `Beutl.Controls.HorizontalGridLayout` and update their package references and namespaces.

## Test plan

- Packaging validation: all 3 `ReleaseLicensePackagingTests` passed, including the check that Debian's embedded copyright notice matches `THIRD_PARTY_NOTICES.md`.
- Reproduce reentrant disposal failures before the fix, then verify balanced callbacks and no reattachment after disposal in `DataContextEventsTests`.
- Exercise the migrated editor menus, color-picker component inputs and confirmation/cancellation, navigation history and icons, extension-priority command bars, and file/folder drag lifecycle with Avalonia headless tests.
- Local validation after rebasing onto `faf1de91b`: all 1,064 headless UI tests passed, including file-in-use protection and window shutdown regressions. `dotnet build Beutl.slnx --no-restore` passed for both target frameworks (20 warnings, no errors).
- Formatting: scoped `dotnet format --verify-no-changes` passed for the conflict-resolved file, and `git diff --check origin/main` is clean.
- Coverage: the last completed pre-rebase run passed `codecov/patch` at 61.71% (61.62% target). The new CI run will recompute coverage against the updated base.
- The native macOS title-bar behavior still requires validation on macOS hardware; Linux headless tests cover the managed lifecycle.

## Fixed issues / References

- [Avalonia macOS title-bar issue #21119](https://github.com/AvaloniaUI/Avalonia/issues/21119)
