### PR TITLE
refactor!: centralize reusable tool content disposal

### DIFF
--- a/docs/extension-authoring/tool-tabs.md
+++ b/docs/extension-authoring/tool-tabs.md
@@ -32,6 +32,7 @@ Use localized resources for `DisplayName`, menu `Header`, and the context's tab 
 
 - The `IToolContext` owns subscriptions and state that must survive view unload/reload. Dispose them from `IToolContext.Dispose` when the dockable closes.
 - A reused content control may still leave and re-enter the visual tree; do not use view attachment as the lifetime of editor services.
+- When reused content implements `IDisposable`, the dock host disposes it before its `IToolContext`. Make disposal idempotent and do not share externally owned resources with the view.
 - Save per-tab state in `WriteToJson` and restore it in `ReadFromJson`.
 - Resolve editor services through the supplied `IEditorContext`; forward `GetService` when the context itself is used as a service provider.
 - Push reactive UI state, including a changing tab title, on the UI thread.

--- a/src/Beutl.Editor.Components/TerminalTab/ViewModels/TerminalTabViewModel.cs
+++ b/src/Beutl.Editor.Components/TerminalTab/ViewModels/TerminalTabViewModel.cs
@@ -14,6 +14,7 @@ public sealed class TerminalTabViewModel : IToolContext
     private static int s_lastInstanceNumber;
 
     private readonly ReadOnlyReactivePropertySlim<string> _header;
+    private bool _disposed;
 
     public TerminalTabViewModel(IEditorContext editorContext)
     {
@@ -56,8 +57,6 @@ public sealed class TerminalTabViewModel : IToolContext
     public ReactivePropertySlim<bool> IsProcessExited { get; } = new();
 
     public ReactivePropertySlim<int> ExitCode { get; } = new();
-
-    internal event EventHandler? Disposed;
 
     internal static (string Path, string[] Args) ResolveShell(
         Func<string, string?> getEnvironmentVariable, bool isWindows, bool isMacOS)
@@ -125,8 +124,12 @@ public sealed class TerminalTabViewModel : IToolContext
 
     public void Dispose()
     {
-        Disposed?.Invoke(this, EventArgs.Empty);
-        Disposed = null;
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
         IsSelected.Dispose();
         IsProcessExited.Dispose();
         ExitCode.Dispose();

--- a/src/Beutl.Editor.Components/TerminalTab/Views/TerminalTabView.axaml.cs
+++ b/src/Beutl.Editor.Components/TerminalTab/Views/TerminalTabView.axaml.cs
@@ -7,7 +7,7 @@ using Iciclecreek.Terminal;
 
 namespace Beutl.Editor.Components.TerminalTab.Views;
 
-public partial class TerminalTabView : UserControl
+public partial class TerminalTabView : UserControl, IDisposable
 {
     private TerminalTabViewModel? _viewModel;
     private TerminalTabViewModel? _launchedViewModel;
@@ -34,6 +34,7 @@ public partial class TerminalTabView : UserControl
     protected override void OnDataContextChanged(EventArgs e)
     {
         base.OnDataContextChanged(e);
+        if (_disposed) return;
 
         _viewModel = DataContext as TerminalTabViewModel;
         if (_viewModel != null)
@@ -47,7 +48,6 @@ public partial class TerminalTabView : UserControl
                 // a dock/reparent.
                 _launched = false;
                 _launching = false;
-                _disposed = false;
             }
 
             // Pass the locale per spawn so it never mutates the shared process environment
@@ -92,9 +92,7 @@ public partial class TerminalTabView : UserControl
     {
         TerminalTabViewModel viewModel = _viewModel!;
         _launching = true;
-        // Bind the dispose subscription to the view-model this PTY serves so it survives a same-VM
-        // rebind through null and still tears the PTY down when that view-model is disposed.
-        SetLaunchedViewModel(viewModel);
+        _launchedViewModel = viewModel;
         viewModel.IsProcessExited.Value = false;
         // Clear the previous session title; the new shell may not emit OSC 0/2.
         viewModel.TerminalTitle.Value = null;
@@ -126,7 +124,7 @@ public partial class TerminalTabView : UserControl
             if (_disposed)
             {
                 // Torn down mid-launch: tear down any PTY that did spawn and never touch the disposed
-                // view-model. Shutdown is idempotent with the teardown OnViewModelDisposed already ran.
+                // view-model. Shutdown is idempotent with the view teardown that already ran.
                 Terminal.Shutdown();
                 return;
             }
@@ -166,22 +164,6 @@ public partial class TerminalTabView : UserControl
         }
     }
 
-    private void SetLaunchedViewModel(TerminalTabViewModel viewModel)
-    {
-        if (ReferenceEquals(_launchedViewModel, viewModel))
-        {
-            return;
-        }
-
-        if (_launchedViewModel != null)
-        {
-            _launchedViewModel.Disposed -= OnViewModelDisposed;
-        }
-
-        _launchedViewModel = viewModel;
-        _launchedViewModel.Disposed += OnViewModelDisposed;
-    }
-
     private void OnProcessExited(object? sender, ProcessExitedEventArgs e)
     {
         // Report on the view-model that owns the PTY, not the current DataContext, so a process exit
@@ -193,9 +175,16 @@ public partial class TerminalTabView : UserControl
         }
     }
 
-    private void OnViewModelDisposed(object? sender, EventArgs e)
+    public void Dispose()
     {
+        if (_disposed)
+        {
+            return;
+        }
+
         _disposed = true;
+        Loaded -= OnLoaded;
+        Terminal.RemoveHandler(TerminalView.TitleChangedEvent, OnTerminalTitleChanged);
         // Shutdown (not just Kill) so the connection and read-cancellation source are disposed even
         // when no later detach runs the cleanup — an inactive tab is already detached when closed.
         Terminal.EndReparent();
@@ -207,5 +196,8 @@ public partial class TerminalTabView : UserControl
         {
             // The PTY may already be gone; tearing down the tab must not throw.
         }
+
+        _viewModel = null;
+        _launchedViewModel = null;
     }
 }

--- a/src/Beutl.Extensibility/SceneEditorTabExtension.cs
+++ b/src/Beutl.Extensibility/SceneEditorTabExtension.cs
@@ -30,7 +30,8 @@ public abstract class ToolTabExtension : ViewExtension
     /// <remarks>
     /// Reused controls can still be unloaded from and loaded into the visual tree. State and
     /// resources that must survive those transitions and require deterministic cleanup should be
-    /// owned by the <see cref="IToolContext"/>, which is disposed when its dockable closes.
+    /// owned by the control or the <see cref="IToolContext"/>. When its dockable closes, a reused
+    /// control that implements <see cref="IDisposable"/> is disposed before its context.
     /// </remarks>
     public virtual bool ReuseContentAcrossActivation => false;
 

--- a/src/Beutl/ViewModels/Dock/BeutlToolDockable.cs
+++ b/src/Beutl/ViewModels/Dock/BeutlToolDockable.cs
@@ -68,8 +68,20 @@ public class BeutlToolDockable : Tool, IDisposable
         PropertyChanged -= OnPropertyChanged;
         _headerSubscription.Dispose();
         _isSelectedSubscription.Dispose();
-        ToolContext.Dispose();
+        Control? content = ToolContent;
         ToolContent = null;
+        try
+        {
+            if (content is IDisposable disposableContent
+                && !ReferenceEquals(disposableContent, ToolContext))
+            {
+                disposableContent.Dispose();
+            }
+        }
+        finally
+        {
+            ToolContext.Dispose();
+        }
     }
 
     // Resolve empty per-instance/menu headers to a readable display or extension name.

--- a/tests/Beutl.HeadlessUITests/ToolTabContentLifetimeTests.cs
+++ b/tests/Beutl.HeadlessUITests/ToolTabContentLifetimeTests.cs
@@ -1,0 +1,183 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Nodes;
+using Avalonia.Controls;
+using Avalonia.Headless.NUnit;
+using Beutl.Editor.Components.TerminalTab.ViewModels;
+using Beutl.Editor.Components.TerminalTab.Views;
+using Beutl.Extensibility;
+using Beutl.ViewModels.Dock;
+using Reactive.Bindings;
+
+namespace Beutl.HeadlessUITests;
+
+[TestFixture]
+public class ToolTabContentLifetimeTests
+{
+    [AvaloniaTest]
+    public void DisposedTerminal_DoesNotReconfigureAfterContextRebinding()
+    {
+        using var vm = new TerminalTabViewModel(new TestEditorContext());
+        using var view = new TerminalTabView { DataContext = vm };
+        view.Dispose();
+        var control = view.FindControl<Iciclecreek.Terminal.TerminalControl>("Terminal")!;
+        var marker = new Dictionary<string, string> { ["BEUTL_TEST_MARKER"] = "unchanged" };
+        control.EnvironmentOverrides = marker;
+        view.DataContext = null;
+        view.DataContext = vm;
+        Assert.That(control.EnvironmentOverrides, Is.SameAs(marker));
+    }
+
+    [AvaloniaTest]
+    public void Dockable_DisposesReusableContentBeforeItsContext()
+    {
+        var disposeOrder = new List<string>();
+        var context = new DisposableToolContext(disposeOrder);
+        var content = new DisposableControl(disposeOrder);
+        var dockable = new BeutlToolDockable(context, null!)
+        {
+            ToolContent = content
+        };
+
+        dockable.Dispose();
+
+        Assert.That(disposeOrder, Is.EqualTo(new[] { "content", "context" }));
+    }
+
+    [AvaloniaTest]
+    public void Dockable_DisposesACombinedContentContextOnlyOnce()
+    {
+        var combined = new CombinedToolContentContext();
+        var dockable = new BeutlToolDockable(combined, null!)
+        {
+            ToolContent = combined
+        };
+
+        dockable.Dispose();
+        dockable.Dispose();
+
+        Assert.That(combined.DisposeCount, Is.EqualTo(1));
+    }
+
+    [AvaloniaTest]
+    public void Dockable_DisposesContextWhenContentDisposalThrows()
+    {
+        var disposeOrder = new List<string>();
+        var context = new DisposableToolContext(disposeOrder);
+        var content = new ThrowingDisposableControl(disposeOrder);
+        var dockable = new BeutlToolDockable(context, null!)
+        {
+            ToolContent = content
+        };
+
+        Assert.Throws<InvalidOperationException>(() => dockable.Dispose());
+        Assert.That(disposeOrder, Is.EqualTo(new[] { "content", "context" }));
+    }
+
+    private sealed class DisposableControl(List<string> disposeOrder) : Control, IDisposable
+    {
+        public void Dispose()
+        {
+            disposeOrder.Add("content");
+        }
+    }
+
+    private sealed class ThrowingDisposableControl(List<string> disposeOrder) : Control, IDisposable
+    {
+        public void Dispose()
+        {
+            disposeOrder.Add("content");
+            throw new InvalidOperationException("Content disposal failed.");
+        }
+    }
+
+    private sealed class DisposableToolContext(List<string> disposeOrder) : IToolContext
+    {
+        public ToolTabExtension Extension => DisposableToolExtension.Instance;
+
+        public IReactiveProperty<bool> IsSelected { get; } = new ReactivePropertySlim<bool>();
+
+        public IReadOnlyReactiveProperty<string> Header { get; } = new ReactivePropertySlim<string>("Disposable");
+
+        public void Dispose()
+        {
+            disposeOrder.Add("context");
+            IsSelected.Dispose();
+        }
+
+        public object? GetService(Type serviceType) => null;
+
+        public void ReadFromJson(JsonObject json)
+        {
+        }
+
+        public void WriteToJson(JsonObject json)
+        {
+        }
+    }
+
+    private sealed class DisposableToolExtension : ToolTabExtension
+    {
+        public static readonly DisposableToolExtension Instance = new();
+
+        public override bool CanMultiple => false;
+
+        public override bool ReuseContentAcrossActivation => true;
+
+        public override bool TryCreateContent(
+            IEditorContext editorContext,
+            [NotNullWhen(true)] out Control? control)
+        {
+            control = null;
+            return false;
+        }
+
+        public override bool TryCreateContext(
+            IEditorContext editorContext,
+            [NotNullWhen(true)] out IToolContext? context)
+        {
+            context = null;
+            return false;
+        }
+    }
+
+    private sealed class CombinedToolContentContext : Control, IToolContext
+    {
+        public int DisposeCount { get; private set; }
+
+        public ToolTabExtension Extension => DisposableToolExtension.Instance;
+
+        public IReactiveProperty<bool> IsSelected { get; } = new ReactivePropertySlim<bool>();
+
+        public IReadOnlyReactiveProperty<string> Header { get; } = new ReactivePropertySlim<string>("Combined");
+
+        public void Dispose()
+        {
+            DisposeCount++;
+            IsSelected.Dispose();
+        }
+
+        public object? GetService(Type serviceType) => null;
+
+        public void ReadFromJson(JsonObject json)
+        {
+        }
+
+        public void WriteToJson(JsonObject json)
+        {
+        }
+    }
+
+    private sealed class TestEditorContext : IEditorContext
+    {
+        public CoreObject Object { get; } = new TestCoreObject();
+        public EditorExtension Extension => null!;
+        public IReactiveProperty<bool> IsEnabled { get; } = new ReactivePropertySlim<bool>(true);
+        public IKnownEditorCommands? Commands => null;
+        public T? FindToolTab<T>(Func<T, bool> condition) where T : IToolContext => default;
+        public T? FindToolTab<T>() where T : IToolContext => default;
+        public bool OpenToolTab(IToolContext item) => false;
+        public void CloseToolTab(IToolContext item) { }
+        public object? GetService(Type type) => null;
+    }
+    private sealed class TestCoreObject : CoreObject;
+}

--- a/tests/Beutl.UnitTests/Editor/TerminalTabViewModelTests.cs
+++ b/tests/Beutl.UnitTests/Editor/TerminalTabViewModelTests.cs
@@ -212,22 +212,19 @@ public class TerminalTabViewModelTests
     }
 
     [Test]
-    public void Dispose_RaisesDisposedOnce()
+    public void Dispose_IsIdempotent()
     {
         var scene = new Scene(640, 480, string.Empty);
         var editorContext = new TestEditorContext(scene);
         var viewModel = new TerminalTabViewModel(editorContext);
-        int disposedCount = 0;
-        viewModel.Disposed += (_, _) => disposedCount++;
 
-        viewModel.Dispose();
-        viewModel.Dispose();
-
-        Assert.Multiple(() =>
+        Assert.DoesNotThrow(() =>
         {
-            Assert.That(disposedCount, Is.EqualTo(1));
-            Assert.That(viewModel.Extension, Is.SameAs(TerminalTabExtension.Instance));
+            viewModel.Dispose();
+            viewModel.Dispose();
         });
+
+        Assert.That(viewModel.Extension, Is.SameAs(TerminalTabExtension.Instance));
     }
 
     private sealed class TestEditorContext(CoreObject obj) : IEditorContext


### PR DESCRIPTION
## Description

Reusable tool views currently depend on context-specific callbacks to release their native resources. The dock host now disposes cached `IDisposable` content before disposing its `IToolContext`.

TerminalTab adopts this ownership model, removes its context-disposal event, and ignores rebinding after the view has been disposed. The host still disposes the context if content cleanup throws, and disposes combined content/context instances only once.

## Affected areas

- [ ] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [x] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [x] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [ ] Build / CI / docs only

## Breaking changes

The host now owns disposal of reusable controls implementing `IDisposable`, and disposes them before their context. Extension authors should make control disposal idempotent and release only resources owned by that control. Context-owned state remains the responsibility of `IToolContext.Dispose`.

## Test plan

- `ToolTabContentLifetimeTests` and `TerminalTabLifecycleTests`: 7 passed, covering disposal ordering, combined instances, cleanup failures, rebinding after disposal, and terminal tab lifecycle.
- `TerminalTabViewModelTests`: 23 passed.
- `Beutl.PublicApiContractTests`: 235 passed.
- Scoped `dotnet format` and `git diff --check` completed successfully.

## Fixed issues / References

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool-tab cleanup to dispose reusable content before its context.
  * Ensured cleanup remains safe when content and context are the same object or when content disposal fails.
  * Prevented disposed terminal tabs from being reconfigured after rebinding.
  * Made terminal-tab disposal safe to call more than once.

* **Documentation**
  * Clarified lifecycle, ownership, and disposal guidance for extension authors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->