### PR TITLE
test: avoid racing successful preview recovery

### DIFF
--- a/tests/Beutl.HeadlessUITests/PreviewRenderErrorTests.cs
+++ b/tests/Beutl.HeadlessUITests/PreviewRenderErrorTests.cs
@@ -354,7 +354,8 @@ public class PreviewRenderErrorTests
             new BufferedPlayer.RenderFailure(new InvalidOperationException(PreviewFaultDrawable.ErrorMessage), frame),
             rate,
             static () => true);
-        HeadlessTestHelpers.Settle();
+        // Check the synchronous failure state before pumping queued work: updating the clock
+        // schedules a preview, and a successful recovery render may clear the error again.
 
         Assert.Multiple(() =>
         {


### PR DESCRIPTION
## Description

`ApplyPlaybackRenderFailure` updates the playhead, which queues a preview render. The test then pumped the dispatcher before checking the synchronous failure state. When that healthy preview completed quickly, it correctly cleared the error, causing the assertion to intermittently receive `null`.

Assert the complete synchronous result before pumping queued recovery work. All existing assertions remain, and the fixture's recovery tests continue to verify that successful renders clear errors.

## Affected areas

- [ ] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [x] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [ ] Build / CI / docs only

## Breaking changes

None. Test-only change.

## Test plan

- On `main`, replacing the existing dispatcher pump with the existing render-drain helper reproduced the same expected-error/actual-null failure deterministically.
- `PreviewRenderErrorTests`: all 11 tests passed.
- The affected test passed 20 consecutive runs after the fix.
- Scoped format verification and `git diff --check` passed.

## Fixed issues / References

Observed in [CI run 34587380378](https://github.com/b-editor/beutl/actions/runs/34587380378). The playback code and this test are unchanged by #2369; this fix is isolated on its own branch based on `main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated preview rendering error coverage to verify the error state immediately and confirm playback stops correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->