### PR TITLE
test: make proxy notification recording thread-safe

### DIFF
--- a/tests/Beutl.UnitTests/Media/Proxy/ProxyJobQueueTests.cs
+++ b/tests/Beutl.UnitTests/Media/Proxy/ProxyJobQueueTests.cs
@@ -15,7 +15,8 @@ public class ProxyJobQueueTests
         var admission = new SequencedAdmission(rejections: int.MaxValue);
         await using var queue = new ProxyJobQueue(new RecordingGenerator(), store: null,
             minUnavailableBackoff: TimeSpan.FromSeconds(30), maxUnavailableBackoff: TimeSpan.FromSeconds(30), admission);
-        var observed = new List<ProxyJobChangeKind>();
+        // Enqueued can be delivered concurrently with admission/cancellation callbacks.
+        var observed = new System.Collections.Concurrent.ConcurrentQueue<ProxyJobChangeKind>();
         var canceled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         queue.JobChanged += (_, change) =>
         {
@@ -24,7 +25,7 @@ public class ProxyJobQueueTests
         };
         queue.JobChanged += (_, change) =>
         {
-            observed.Add(change.Kind);
+            observed.Enqueue(change.Kind);
             if (change.Kind == ProxyJobChangeKind.Canceled) canceled.TrySetResult();
         };
         await queue.EnqueueAsync(CreateFingerprint("wait-cancel-order.mov"), ProxyPreset.Quarter);


### PR DESCRIPTION
## Description

The admission-ordering test records every `JobChanged` callback in a shared `List`. The enqueue caller can publish `Enqueued` concurrently with the worker's admission/cancellation notifications, so simultaneous writes can lose recorded events and produce an empty filtered sequence.

Use `ConcurrentQueue` for the observer, matching the adjacent notification-ordering test. The expected waiting-before-cancellation sequence and all assertions remain unchanged. Production queue behavior is unchanged.

## Affected areas

- [x] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [ ] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [ ] Build / CI / docs only

## Breaking changes

None. Test-only change.

## Test plan

- Repeated the original test on a branch based on `main` and reproduced the same missing-notification failure as CI.
- With the concurrent observer, 100,000 repetitions passed. The temporary repetition attribute is not included in this PR.
- All 59 `ProxyJobQueueTests` passed with an explicit NUnit selection limit.
- Scoped format verification and `git diff --check` passed.

## Fixed issues / References

Observed in [CI run 34592334934](https://github.com/b-editor/beutl/actions/runs/34592334934). The preview-render test addressed by #2370 passed in that run; this is an independent failure.

The synchronization requirements for ordinary generic collections are documented in [Microsoft's thread-safe collections guide](https://learn.microsoft.com/en-us/dotnet/standard/collections/thread-safe/).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved test reliability when tracking changes delivered concurrently during admission and cancellation callbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->