### PR TITLE
fix: keep plain-key shortcuts from stealing terminal input

### DIFF
--- a/src/Beutl.Editor.Components/TerminalTab/Views/TerminalTabView.axaml
+++ b/src/Beutl.Editor.Components/TerminalTab/Views/TerminalTabView.axaml
@@ -2,6 +2,7 @@
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:ext="using:Beutl.Extensibility"
              xmlns:lang="using:Beutl.Language"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:terminal="using:Iciclecreek.Terminal"
@@ -23,7 +24,12 @@
                 <TextBlock VerticalAlignment="Center" Text="{x:Static lang:Strings.TerminalSessionEnded}" />
             </DockPanel>
         </Border>
+        <!--
+            Plain keys (Space, J/K/L, M, G ...) are scene editor shortcuts. Marking the terminal as a
+            text-entry surface keeps those keystrokes flowing to the shell instead of the editor.
+        -->
         <terminal:TerminalControl Name="Terminal"
+                                  ext:ContextCommandInput.IsTextInput="True"
                                   Background="Transparent"
                                   BufferSize="5000"
                                   FontFamily="Consolas, Menlo, monospace"

--- a/src/Beutl.Extensibility/ContextCommandAttribute.cs
+++ b/src/Beutl.Extensibility/ContextCommandAttribute.cs
@@ -34,6 +34,13 @@ public class ContextCommandExecution
     public string CommandName { get; }
 
     public KeyEventArgs? KeyEventArgs { get; set; }
+
+    /// <summary>
+    /// Whether the triggering key event came from a text-entry control (a <c>TextBox</c>, a terminal, ...).
+    /// Handlers bound to plain keys should not run in that case so the keystroke is typed instead.
+    /// See <see cref="ContextCommandInput"/>.
+    /// </summary>
+    public bool IsFromTextInput => ContextCommandInput.IsFromTextInput(KeyEventArgs);
 }
 
 [AttributeUsage(AttributeTargets.Method)]

--- a/src/Beutl.Extensibility/ContextCommandInput.cs
+++ b/src/Beutl.Extensibility/ContextCommandInput.cs
@@ -1,4 +1,4 @@
-using Avalonia;
+﻿using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.VisualTree;

--- a/src/Beutl.Extensibility/ContextCommandInput.cs
+++ b/src/Beutl.Extensibility/ContextCommandInput.cs
@@ -1,0 +1,54 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.VisualTree;
+
+namespace Beutl.Extensibility;
+
+/// <summary>
+/// Describes which parts of the UI accept typed text so that plain-key context command gestures
+/// (for example <c>Space</c>, <c>J</c>, <c>K</c>, <c>L</c>, <c>M</c>) are not treated as shortcuts while the
+/// user is typing into them.
+/// </summary>
+public static class ContextCommandInput
+{
+    /// <summary>
+    /// Marks a control and its descendants as a text-entry surface. Context command handlers use
+    /// <see cref="IsFromTextInput(KeyEventArgs?)"/> to skip plain-key gestures whose source lies inside it.
+    /// <see cref="TextBox"/> is always treated as text input; use this for custom editors such as a terminal.
+    /// </summary>
+    public static readonly AttachedProperty<bool> IsTextInputProperty =
+        AvaloniaProperty.RegisterAttached<Visual, bool>("IsTextInput", typeof(ContextCommandInput));
+
+    public static bool GetIsTextInput(Visual element)
+    {
+        return element.GetValue(IsTextInputProperty);
+    }
+
+    public static void SetIsTextInput(Visual element, bool value)
+    {
+        element.SetValue(IsTextInputProperty, value);
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> when the key event originates from a control that accepts typed text:
+    /// a <see cref="TextBox"/>, or any control at or below one marked with <see cref="IsTextInputProperty"/>.
+    /// </summary>
+    public static bool IsFromTextInput(KeyEventArgs? args)
+    {
+        if (args?.Source is not Visual source)
+        {
+            return false;
+        }
+
+        foreach (Visual visual in source.GetSelfAndVisualAncestors())
+        {
+            if (visual is TextBox || GetIsTextInput(visual))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Beutl/ViewModels/EditViewModel.CommandHandler.cs
+++ b/src/Beutl/ViewModels/EditViewModel.CommandHandler.cs
@@ -100,11 +100,12 @@ public partial class EditViewModel : IContextCommandHandler, IContextCommandStat
     {
         if (execution.KeyEventArgs != null)
             execution.KeyEventArgs.Handled = true;
-        bool isFromTextBox = execution.KeyEventArgs?.Source is TextBox;
+        // Plain-key gestures must keep typing into text boxes, terminals and other text-entry surfaces.
+        bool isFromTextInput = execution.IsFromTextInput;
         Task operation = Task.CompletedTask;
         switch (execution.CommandName)
         {
-            case "PlayPause" when !isFromTextBox:
+            case "PlayPause" when !isFromTextInput:
                 operation = Player.PlayPause.ExecuteAsync();
                 break;
             case "Next":
@@ -119,43 +120,43 @@ public partial class EditViewModel : IContextCommandHandler, IContextCommandStat
             case "SeekEnd":
                 Player.End.Execute();
                 break;
-            case "ShuttleForward" when !isFromTextBox:
+            case "ShuttleForward" when !isFromTextInput:
                 Player.ShuttleForward();
                 break;
-            case "ShuttleForwardFine" when !isFromTextBox:
+            case "ShuttleForwardFine" when !isFromTextInput:
                 Player.ShuttleForward(fineGrain: true);
                 break;
-            case "ShuttleBackward" when !isFromTextBox:
+            case "ShuttleBackward" when !isFromTextInput:
                 Player.ShuttleBackward();
                 break;
-            case "ShuttleBackwardFine" when !isFromTextBox:
+            case "ShuttleBackwardFine" when !isFromTextInput:
                 Player.ShuttleBackward(fineGrain: true);
                 break;
-            case "ShuttleStop" when !isFromTextBox:
+            case "ShuttleStop" when !isFromTextInput:
                 Player.ShuttleStop();
                 break;
-            case "ToggleLoop" when !isFromTextBox:
+            case "ToggleLoop" when !isFromTextInput:
                 Player.ToggleLoop();
                 break;
-            case "ToggleMarker" when !isFromTextBox:
+            case "ToggleMarker" when !isFromTextInput:
                 ToggleMarkerAtCurrentTime();
                 break;
-            case "NextMarker" when !isFromTextBox:
+            case "NextMarker" when !isFromTextInput:
                 SeekToAdjacentMarker(forward: true);
                 break;
-            case "PreviousMarker" when !isFromTextBox:
+            case "PreviousMarker" when !isFromTextInput:
                 SeekToAdjacentMarker(forward: false);
                 break;
-            case "GotoTimecode" when !isFromTextBox:
+            case "GotoTimecode" when !isFromTextInput:
                 Player.RequestEditTimecode();
                 break;
-            case "NextKeyFrame" when !isFromTextBox:
+            case "NextKeyFrame" when !isFromTextInput:
                 SeekToAdjacentKeyFrame(forward: true);
                 break;
-            case "PreviousKeyFrame" when !isFromTextBox:
+            case "PreviousKeyFrame" when !isFromTextInput:
                 SeekToAdjacentKeyFrame(forward: false);
                 break;
-            case "ToggleOnionSkin" when !isFromTextBox:
+            case "ToggleOnionSkin" when !isFromTextInput:
                 {
                     EditorConfig editorConfig = GlobalConfiguration.Instance.EditorConfig;
                     editorConfig.IsOnionSkinEnabled = !editorConfig.IsOnionSkinEnabled;

--- a/tests/Beutl.HeadlessUITests/ContextCommandInputTests.cs
+++ b/tests/Beutl.HeadlessUITests/ContextCommandInputTests.cs
@@ -1,4 +1,4 @@
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Headless.NUnit;
 using Avalonia.Input;
 using Avalonia.Interactivity;

--- a/tests/Beutl.HeadlessUITests/ContextCommandInputTests.cs
+++ b/tests/Beutl.HeadlessUITests/ContextCommandInputTests.cs
@@ -1,0 +1,138 @@
+using Avalonia.Controls;
+using Avalonia.Headless.NUnit;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.VisualTree;
+
+using Beutl.Editor.Components.TerminalTab.ViewModels;
+using Beutl.Editor.Components.TerminalTab.Views;
+using Beutl.Extensibility;
+using Beutl.ProjectSystem;
+using Beutl.Testing.Headless;
+using Beutl.ViewModels;
+
+using Iciclecreek.Terminal;
+
+namespace Beutl.HeadlessUITests;
+
+[TestFixture]
+public class ContextCommandInputTests
+{
+    [AvaloniaTest]
+    public void Plain_control_is_not_text_input()
+    {
+        var args = KeyDownFrom(new Border());
+
+        Assert.That(ContextCommandInput.IsFromTextInput(args), Is.False);
+    }
+
+    [AvaloniaTest]
+    public void Null_and_sourceless_events_are_not_text_input()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(ContextCommandInput.IsFromTextInput(null), Is.False);
+            Assert.That(ContextCommandInput.IsFromTextInput(new KeyEventArgs { Key = Key.M }), Is.False);
+        });
+    }
+
+    [AvaloniaTest]
+    public void TextBox_is_text_input()
+    {
+        var args = KeyDownFrom(new TextBox());
+
+        Assert.That(ContextCommandInput.IsFromTextInput(args), Is.True);
+    }
+
+    [AvaloniaTest]
+    public void Descendant_of_a_marked_control_is_text_input()
+    {
+        var inner = new Border();
+        var outer = new Border { Child = inner };
+        ContextCommandInput.SetIsTextInput(outer, true);
+        var window = new Window { Content = outer };
+        window.Show();
+        try
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(ContextCommandInput.IsFromTextInput(KeyDownFrom(outer)), Is.True);
+                Assert.That(ContextCommandInput.IsFromTextInput(KeyDownFrom(inner)), Is.True);
+            });
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task Scene_editor_plain_key_commands_ignore_the_terminal_and_leave_the_key_unhandled()
+    {
+        await TestReset.ResetShellAsync();
+        try
+        {
+            string location = Path.Combine(BeutlHomeIsolation.CurrentHome!, "context-command-input-terminal");
+            Directory.CreateDirectory(location);
+            Project project = (await TestShell.Project.CreateProject(
+                640, 480, 30, 44100, "terminal-keys", location))!;
+            Scene scene = project.Items.OfType<Scene>().Single();
+            TestShell.Editor.ActivateTabItem(scene);
+            HeadlessTestHelpers.Settle();
+            var editor = (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
+
+            using var terminalVm = new TerminalTabViewModel(editor);
+            using var terminalTab = new TerminalTabView { DataContext = terminalVm };
+            var window = new Window { Content = terminalTab };
+            window.Show();
+            using var _ = new WindowCloser(window);
+            HeadlessTestHelpers.Render();
+            TerminalControl control = terminalTab.FindControl<TerminalControl>("Terminal")!;
+            // The focused element (and so the KeyDown source) is the inner TerminalView, not the templated control.
+            TerminalView terminalView = control.GetVisualDescendants().OfType<TerminalView>().Single();
+            int markersBefore = scene.Markers.Count;
+
+            Assert.That(ContextCommandInput.GetIsTextInput(control), Is.True);
+
+            // Typing "m" into the terminal must not toggle a marker, and the key must stay unhandled so
+            // Avalonia still delivers the TextInput to the shell.
+            KeyEventArgs fromTerminal = KeyDownFrom(terminalView, Key.M);
+            await editor.ExecuteAsync(new ContextCommandExecution("ToggleMarker") { KeyEventArgs = fromTerminal });
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(scene.Markers.Count, Is.EqualTo(markersBefore));
+                Assert.That(fromTerminal.Handled, Is.False);
+            });
+
+            // Negative control: the same gesture from a non-text control still runs the shortcut.
+            KeyEventArgs fromEditor = KeyDownFrom(new Border(), Key.M);
+            await editor.ExecuteAsync(new ContextCommandExecution("ToggleMarker") { KeyEventArgs = fromEditor });
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(scene.Markers.Count, Is.EqualTo(markersBefore + 1));
+                Assert.That(fromEditor.Handled, Is.True);
+            });
+        }
+        finally
+        {
+            await TestReset.ResetShellAsync();
+        }
+    }
+
+    private sealed class WindowCloser(Window window) : IDisposable
+    {
+        public void Dispose() => window.Close();
+    }
+
+    private static KeyEventArgs KeyDownFrom(Interactive source, Key key = Key.M)
+    {
+        return new KeyEventArgs
+        {
+            RoutedEvent = InputElement.KeyDownEvent,
+            Source = source,
+            Key = key,
+        };
+    }
+}


### PR DESCRIPTION
## Description
- Plain-key scene editor gestures (Space, J/K/L, M, G, Shift+L, ...) fired while typing in the terminal tab. The handler marked the key event as handled, which makes Avalonia drop the following `TextInput`, so the keystroke ran the shortcut and never reached the shell.
- The terminal control has to leave printable keys unhandled so layout/Shift/dead-key/IME text arrives via `TextInput`, so the fix lives on the handler side: `EditViewModel` now skips plain-key commands when the event comes from any text-entry surface, not only a `TextBox`.
- Adds `ContextCommandInput.IsTextInput` (attached property) and `ContextCommandInput.IsFromTextInput` / `ContextCommandExecution.IsFromTextInput` so custom editors (the terminal tab, or extension tabs) can opt out of plain-key gestures; `TerminalTabView` opts in.

## Affected areas
- [ ] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [x] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [x] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [ ] Build / CI / docs only

## Breaking changes
None. The new attached property and `IsFromTextInput` members are additive; `TextBox` sources are still recognised without opting in.

## Test plan
- `tests/Beutl.HeadlessUITests/ContextCommandInputTests.cs`
  - `IsFromTextInput` is false for plain controls, null/sourceless events; true for a `TextBox` and for descendants of a control marked `IsTextInput`.
  - Integration: `ToggleMarker` with a key event sourced from the terminal tab's inner `TerminalView` adds no marker and leaves the event unhandled (so `TextInput` still flows); the same gesture from a plain control still toggles the marker (negative control). Removing the AXAML marker makes this test fail.
- Manual: open the Terminal tab, type `space`, `j`, `k`, `l`, `m`, `g`, `Shift+L`; the characters reach the shell and playback/markers are untouched. Ctrl/Cmd chords (undo, save) keep working as before.

## Fixed issues / References
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Terminal and other text-entry controls now receive typed keys without triggering scene editor shortcuts.
  * Keyboard command handling recognizes text-entry context consistently across supported controls.

* **Bug Fixes**
  * Prevented terminal input from executing unrelated editor commands or marking keystrokes as handled.

* **Tests**
  * Added coverage for text-input detection and terminal keyboard behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->