### PR TITLE
feat: Add hover close button and inline add button to dock tabs

### DIFF
--- a/src/Beutl/Views/Dock/DockStyles.axaml
+++ b/src/Beutl/Views/Dock/DockStyles.axaml
@@ -321,11 +321,12 @@
         <Style Selector="^ Button#PART_TabCloseButton:pressed">
             <Setter Property="Background" Value="{DynamicResource DockChromeButtonPressedBackgroundBrush}" />
         </Style>
-        <Style Selector="^:pointerover Button#PART_TabCloseButton">
+        <!--  :focus-visible keeps the keyboard tab stop from being an invisible way to close the tab.  -->
+        <Style Selector="^:pointerover Button#PART_TabCloseButton, ^ Button#PART_TabCloseButton:focus-visible">
             <Setter Property="Opacity" Value="1" />
             <Setter Property="IsHitTestVisible" Value="True" />
         </Style>
-        <Style Selector="^:pointerover Panel.closable Border#PART_TabTitleHost">
+        <Style Selector="^:pointerover Panel.closable Border#PART_TabTitleHost, ^ Panel.closable:focus-within Border#PART_TabTitleHost">
             <Setter Property="OpacityMask">
                 <!--
                     Absolute points are anchored to the left edge, so the brush is mirrored about its centre

--- a/src/Beutl/Views/Dock/DockStyles.axaml
+++ b/src/Beutl/Views/Dock/DockStyles.axaml
@@ -35,11 +35,46 @@
 
             <Setter Property="HeaderTemplate">
                 <DataTemplate DataType="core:IDockable">
-                    <TextBlock MaxWidth="180"
-                               Padding="{DynamicResource DockHeaderContentPadding}"
-                               Text="{Binding Title}"
-                               TextTrimming="CharacterEllipsis"
-                               ToolTip.Tip="{Binding Title}" />
+                    <!--
+                        The close button lives in a zero-width Canvas anchored to the title's right edge, so it
+                        overlays the text without adding to the tab width. Hover styling (button reveal and the
+                        title fade) is in the ToolTabStripItem style block below.
+                    -->
+                    <Panel Classes.closable="{Binding CanClose}">
+                        <!--
+                            Fixed width so every tab is the same size; long titles trim with an ellipsis. The
+                            hover fade mask goes on this Border rather than the TextBlock: a TextBlock's mask
+                            is laid out against the glyph extents, so its fade would move with the title length.
+                        -->
+                        <Border x:Name="PART_TabTitleHost"
+                                Width="120"
+                                Background="Transparent">
+                            <TextBlock x:Name="PART_TabTitle"
+                                       Padding="{DynamicResource DockHeaderContentPadding}"
+                                       Text="{Binding Title}"
+                                       TextTrimming="CharacterEllipsis"
+                                       ToolTip.Tip="{Binding Title}" />
+                        </Border>
+                        <Canvas Width="0"
+                                Height="0"
+                                HorizontalAlignment="Right"
+                                VerticalAlignment="Center"
+                                ClipToBounds="False">
+                            <Button x:Name="PART_TabCloseButton"
+                                    Canvas.Right="0"
+                                    Canvas.Top="-10"
+                                    Width="20"
+                                    Height="20"
+                                    Padding="0"
+                                    AutomationProperties.Name="{x:Static lang:Strings.Close}"
+                                    Command="{Binding Factory.CloseDockable}"
+                                    CommandParameter="{Binding}"
+                                    IsVisible="{Binding CanClose}"
+                                    ToolTip.Tip="{x:Static lang:Strings.Close}">
+                                <icons:FluentIcon FontSize="12" Icon="Dismiss" />
+                            </Button>
+                        </Canvas>
+                    </Panel>
                 </DataTemplate>
             </Setter>
 
@@ -268,6 +303,43 @@
         <Style Selector="^ /template/ Border">
             <!--  Top corners only, so it tracks ControlCornerRadius by hand.  -->
             <Setter Property="CornerRadius" Value="8,8,0,0" />
+        </Style>
+
+        <!--  Close button: hidden until the tab is hovered; the title fades out underneath it.  -->
+        <Style Selector="^ Button#PART_TabCloseButton">
+            <Setter Property="Opacity" Value="0" />
+            <Setter Property="IsHitTestVisible" Value="False" />
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="CornerRadius" Value="4" />
+            <Setter Property="Foreground" Value="{DynamicResource TextFillColorSecondary}" />
+        </Style>
+        <Style Selector="^ Button#PART_TabCloseButton:pointerover">
+            <Setter Property="Background" Value="{DynamicResource DockChromeButtonHoverBackgroundBrush}" />
+            <Setter Property="Foreground" Value="{DynamicResource TextFillColorPrimary}" />
+        </Style>
+        <Style Selector="^ Button#PART_TabCloseButton:pressed">
+            <Setter Property="Background" Value="{DynamicResource DockChromeButtonPressedBackgroundBrush}" />
+        </Style>
+        <Style Selector="^:pointerover Button#PART_TabCloseButton">
+            <Setter Property="Opacity" Value="1" />
+            <Setter Property="IsHitTestVisible" Value="True" />
+        </Style>
+        <Style Selector="^:pointerover Panel.closable Border#PART_TabTitleHost">
+            <Setter Property="OpacityMask">
+                <!--
+                    Absolute points are anchored to the left edge, so the brush is mirrored about its centre
+                    to measure from the right instead: fully transparent 20px from the right edge (the close
+                    button's left edge), fully opaque 46px from it.
+                -->
+                <LinearGradientBrush StartPoint="20,0" EndPoint="46,0" TransformOrigin="50%,50%">
+                    <LinearGradientBrush.Transform>
+                        <ScaleTransform ScaleX="-1" />
+                    </LinearGradientBrush.Transform>
+                    <GradientStop Offset="0" Color="Transparent" />
+                    <GradientStop Offset="1" Color="Black" />
+                </LinearGradientBrush>
+            </Setter>
         </Style>
     </Style>
 

--- a/src/Beutl/Views/Dock/DockStyles.axaml
+++ b/src/Beutl/Views/Dock/DockStyles.axaml
@@ -56,11 +56,11 @@
                     <DockPanel x:Name="PART_DockPanel"
                                DockProperties.IsDockTarget="True"
                                DockProperties.IsDropArea="True">
-                        <Grid x:Name="PART_TabHeader"
-                              MinHeight="28"
-                              Background="Transparent"
-                              ColumnDefinitions="*,Auto"
-                              DockPanel.Dock="Top">
+                        <!--  Children are positional: tab strip, add button, free space (see ToolTabHeaderPanel).  -->
+                        <local:ToolTabHeaderPanel x:Name="PART_TabHeader"
+                                                  MinHeight="28"
+                                                  Background="Transparent"
+                                                  DockPanel.Dock="Top">
                             <ToolTabStrip x:Name="PART_TabStrip"
                                           DockProperties.DockAdornerHost="{Binding #PART_DockPanel}"
                                           DockProperties.IsDropArea="True"
@@ -70,21 +70,25 @@
                                           ModifiedTemplate="{TemplateBinding ModifiedTemplate}"
                                           SelectedItem="{Binding ActiveDockable, Mode=TwoWay}" />
                             <Border x:Name="PART_AddButtonBorder"
-                                    Grid.Column="1"
                                     BorderBrush="{DynamicResource DockBorderSubtleBrush}"
                                     BorderThickness="0,0,0,1">
                                 <local:ToolTabAddButton x:Name="PART_AddButton"
                                                         Width="28"
                                                         Height="28"
+                                                        Margin="4,0"
                                                         Padding="0"
                                                         AutomationProperties.Name="{x:Static lang:Strings.Add}"
+                                                        CornerRadius="{DynamicResource DockDocumentTabCreateButtonCornerRadius}"
                                                         IsTabStop="True"
                                                         Opacity="0"
                                                         ToolTip.Tip="{x:Static lang:Strings.Add}">
                                     <icons:FluentIcon Icon="Add" />
                                 </local:ToolTabAddButton>
                             </Border>
-                        </Grid>
+                            <Border x:Name="PART_FreeSpace"
+                                    BorderBrush="{DynamicResource DockBorderSubtleBrush}"
+                                    BorderThickness="0,0,0,1" />
+                        </local:ToolTabHeaderPanel>
                         <Border x:Name="PART_Border">
                             <DockableControl DataContext="{Binding ActiveDockable}" TrackingMode="Visible">
                                 <ContentControl x:Name="PART_ContentPresenter"
@@ -119,7 +123,7 @@
                 <Setter Property="BorderThickness" Value="0" />
             </Style>
 
-            <Style Selector="^/template/ Grid#PART_TabHeader:pointerover local|ToolTabAddButton#PART_AddButton">
+            <Style Selector="^/template/ local|ToolTabHeaderPanel#PART_TabHeader:pointerover local|ToolTabAddButton#PART_AddButton">
                 <Setter Property="Opacity" Value="1" />
             </Style>
 

--- a/src/Beutl/Views/Dock/DockStyles.axaml
+++ b/src/Beutl/Views/Dock/DockStyles.axaml
@@ -42,12 +42,12 @@
                     -->
                     <Panel Classes.closable="{Binding CanClose}">
                         <!--
-                            Fixed width so every tab is the same size; long titles trim with an ellipsis. The
-                            hover fade mask goes on this Border rather than the TextBlock: a TextBlock's mask
-                            is laid out against the glyph extents, so its fade would move with the title length.
+                            The hover fade mask goes on this Border rather than the TextBlock: a TextBlock's
+                            mask is laid out against the glyph extents, so its fade would drift with the title
+                            length instead of staying anchored to the tab's right edge.
                         -->
                         <Border x:Name="PART_TabTitleHost"
-                                Width="120"
+                                MaxWidth="180"
                                 Background="Transparent">
                             <TextBlock x:Name="PART_TabTitle"
                                        Padding="{DynamicResource DockHeaderContentPadding}"

--- a/src/Beutl/Views/Dock/ToolTabHeaderPanel.cs
+++ b/src/Beutl/Views/Dock/ToolTabHeaderPanel.cs
@@ -43,19 +43,22 @@ public sealed class ToolTabHeaderPanel : Panel
     {
         (Control? strip, Control? addButton, Control? freeSpace) = GetSlots();
 
+        // Reserve the button's width before handing the rest to the strip, so the button survives
+        // an arrange that is narrower than the measure pass (e.g. mid-resize).
+        double buttonWidth = addButton is null ? 0 : Math.Min(addButton.DesiredSize.Width, finalSize.Width);
+
         double x = 0;
         if (strip is not null)
         {
-            double width = Math.Min(strip.DesiredSize.Width, finalSize.Width);
+            double width = Math.Min(strip.DesiredSize.Width, Math.Max(0, finalSize.Width - buttonWidth));
             strip.Arrange(new Rect(x, 0, width, finalSize.Height));
             x += width;
         }
 
         if (addButton is not null)
         {
-            double width = Math.Min(addButton.DesiredSize.Width, Math.Max(0, finalSize.Width - x));
-            addButton.Arrange(new Rect(x, 0, width, finalSize.Height));
-            x += width;
+            addButton.Arrange(new Rect(x, 0, buttonWidth, finalSize.Height));
+            x += buttonWidth;
         }
 
         freeSpace?.Arrange(new Rect(x, 0, Math.Max(0, finalSize.Width - x), finalSize.Height));

--- a/src/Beutl/Views/Dock/ToolTabHeaderPanel.cs
+++ b/src/Beutl/Views/Dock/ToolTabHeaderPanel.cs
@@ -1,0 +1,73 @@
+using Avalonia;
+using Avalonia.Controls;
+
+namespace Beutl.Views.Dock;
+
+/// <summary>
+/// Lays out a tool dock header as [tab strip][add button][free space]. The add button is
+/// measured first so it keeps its width even when the tabs overflow; the strip is then
+/// measured with the remaining width so it clips instead of pushing the button out of view.
+/// </summary>
+public sealed class ToolTabHeaderPanel : Panel
+{
+    protected override Size MeasureOverride(Size availableSize)
+    {
+        (Control? strip, Control? addButton, Control? freeSpace) = GetSlots();
+
+        double buttonWidth = 0;
+        if (addButton is not null)
+        {
+            addButton.Measure(availableSize);
+            buttonWidth = addButton.DesiredSize.Width;
+        }
+
+        double stripWidth = 0;
+        if (strip is not null)
+        {
+            strip.Measure(new Size(Math.Max(0, availableSize.Width - buttonWidth), availableSize.Height));
+            stripWidth = strip.DesiredSize.Width;
+        }
+
+        freeSpace?.Measure(new Size(Math.Max(0, availableSize.Width - stripWidth - buttonWidth), availableSize.Height));
+
+        double height = 0;
+        foreach (Control child in Children)
+        {
+            height = Math.Max(height, child.DesiredSize.Height);
+        }
+
+        return new Size(stripWidth + buttonWidth, height);
+    }
+
+    protected override Size ArrangeOverride(Size finalSize)
+    {
+        (Control? strip, Control? addButton, Control? freeSpace) = GetSlots();
+
+        double x = 0;
+        if (strip is not null)
+        {
+            double width = Math.Min(strip.DesiredSize.Width, finalSize.Width);
+            strip.Arrange(new Rect(x, 0, width, finalSize.Height));
+            x += width;
+        }
+
+        if (addButton is not null)
+        {
+            double width = Math.Min(addButton.DesiredSize.Width, Math.Max(0, finalSize.Width - x));
+            addButton.Arrange(new Rect(x, 0, width, finalSize.Height));
+            x += width;
+        }
+
+        freeSpace?.Arrange(new Rect(x, 0, Math.Max(0, finalSize.Width - x), finalSize.Height));
+
+        return finalSize;
+    }
+
+    private (Control? Strip, Control? AddButton, Control? FreeSpace) GetSlots()
+    {
+        return (
+            Children.Count > 0 ? Children[0] : null,
+            Children.Count > 1 ? Children[1] : null,
+            Children.Count > 2 ? Children[2] : null);
+    }
+}

--- a/src/Beutl/Views/Dock/ToolTabHeaderPanel.cs
+++ b/src/Beutl/Views/Dock/ToolTabHeaderPanel.cs
@@ -1,4 +1,4 @@
-using Avalonia;
+﻿using Avalonia;
 using Avalonia.Controls;
 
 namespace Beutl.Views.Dock;

--- a/tests/Beutl.HeadlessUITests/DockTabAddButtonTests.cs
+++ b/tests/Beutl.HeadlessUITests/DockTabAddButtonTests.cs
@@ -69,12 +69,15 @@ public class DockTabAddButtonTests
             IToolDock playerDock = editor.DockHost.Factory.GetAnchoredDock(DockAnchor.Player)!;
             ToolControl playerControl = controls.Single(control => ReferenceEquals(control.DataContext, playerDock));
             ToolTabAddButton button = FindAddButton(playerControl)!;
-            Grid header = playerControl.GetVisualDescendants()
-                .OfType<Grid>()
-                .Single(control => control.Name == "PART_TabHeader");
+            ToolTabHeaderPanel header = playerControl.GetVisualDescendants()
+                .OfType<ToolTabHeaderPanel>()
+                .Single();
             Border addButtonBorder = playerControl.GetVisualDescendants()
                 .OfType<Border>()
                 .Single(control => control.Name == "PART_AddButtonBorder");
+            ToolTabStrip tabStrip = playerControl.GetVisualDescendants()
+                .OfType<ToolTabStrip>()
+                .Single();
 
             Assert.Multiple(() =>
             {
@@ -82,6 +85,12 @@ public class DockTabAddButtonTests
                     addButtonBorder.BorderBrush,
                     Is.SameAs(addButtonBorder.FindResource("DockBorderSubtleBrush")));
                 Assert.That(addButtonBorder.BorderThickness.Bottom, Is.EqualTo(1));
+                // The button follows the last tab instead of sitting at the far right of the header.
+                Assert.That(addButtonBorder.Bounds.Left, Is.EqualTo(tabStrip.Bounds.Right).Within(0.5));
+                Assert.That(addButtonBorder.Bounds.Right, Is.LessThan(header.Bounds.Width - addButtonBorder.Bounds.Width));
+                Assert.That(
+                    button.CornerRadius,
+                    Is.EqualTo((CornerRadius)button.FindResource("DockDocumentTabCreateButtonCornerRadius")!));
                 Assert.That(button.Opacity, Is.EqualTo(0));
                 Assert.That(button.IsHitTestVisible, Is.True);
                 Assert.That(button.IsTabStop, Is.True);
@@ -119,6 +128,71 @@ public class DockTabAddButtonTests
             {
                 Assert.That(button.Opacity, Is.EqualTo(1));
                 Assert.That(button.IsHitTestVisible, Is.True);
+            });
+        }
+        finally
+        {
+            window.Close();
+            HeadlessTestHelpers.Settle();
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task Add_button_stays_visible_when_tabs_overflow_the_header()
+    {
+        await ResetProjectAsync();
+        EditViewModel editor = await OpenEditorForNewScene("dock-tab-add-overflow");
+
+        var view = new EditView { DataContext = editor };
+        var window = new Window { Content = view, Width = 900, Height = 700 };
+
+        try
+        {
+            window.Show();
+            HeadlessTestHelpers.Render();
+
+            IToolDock target = editor.DockHost.Factory.GetAnchoredDock(DockAnchor.Left)!;
+            ToolControl targetControl = view.GetVisualDescendants()
+                .OfType<ToolControl>()
+                .Single(control => ReferenceEquals(control.DataContext, target));
+            ToolTabAddButton button = FindAddButton(targetControl)!;
+            ToolTabHeaderPanel header = targetControl.GetVisualDescendants()
+                .OfType<ToolTabHeaderPanel>()
+                .Single();
+            Border addButtonBorder = targetControl.GetVisualDescendants()
+                .OfType<Border>()
+                .Single(control => control.Name == "PART_AddButtonBorder");
+            ToolTabStrip tabStrip = targetControl.GetVisualDescendants()
+                .OfType<ToolTabStrip>()
+                .Single();
+
+            var factory = (BeutlDockFactory)editor.DockHost.Factory;
+            foreach (ToolTabExtension extension in factory.EnumerateToolTabExtensions())
+            {
+                if (extension.CanMultiple || !factory.IsToolTabOpen(extension))
+                {
+                    factory.OpenToolTab(extension, target);
+                }
+            }
+
+            HeadlessTestHelpers.Render();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(tabStrip.Bounds.Width, Is.EqualTo(header.Bounds.Width - addButtonBorder.Bounds.Width).Within(0.5));
+                Assert.That(addButtonBorder.Bounds.Left, Is.EqualTo(tabStrip.Bounds.Right).Within(0.5));
+                Assert.That(button.Bounds.Width, Is.EqualTo(28));
+                Assert.That(button.IsEffectivelyVisible, Is.True);
+            });
+
+            Point? buttonLeft = button.TranslatePoint(new Point(0, 0), header);
+            Point? buttonRight = button.TranslatePoint(new Point(button.Bounds.Width, 0), header);
+            Assert.Multiple(() =>
+            {
+                Assert.That(buttonLeft, Is.Not.Null);
+                Assert.That(buttonRight, Is.Not.Null);
+                Assert.That(buttonLeft!.Value.X, Is.GreaterThanOrEqualTo(tabStrip.Bounds.Right - 0.5));
+                Assert.That(buttonRight!.Value.X, Is.LessThanOrEqualTo(header.Bounds.Width + 0.5));
             });
         }
         finally
@@ -183,6 +257,8 @@ public class DockTabAddButtonTests
 
             menu.Close();
             HeadlessTestHelpers.Settle();
+            // The button follows the last tab, so it moved when the new tab was added.
+            buttonCenter = Center(button, window);
             window.MouseDown(buttonCenter, MouseButton.Right);
             window.MouseUp(buttonCenter, MouseButton.Right);
             HeadlessTestHelpers.Settle();

--- a/tests/Beutl.HeadlessUITests/DockTabAddButtonTests.cs
+++ b/tests/Beutl.HeadlessUITests/DockTabAddButtonTests.cs
@@ -203,6 +203,28 @@ public class DockTabAddButtonTests
     }
 
     [AvaloniaTest]
+    public void Header_panel_keeps_the_add_button_when_arranged_narrower_than_measured()
+    {
+        // Explicit widths would win over the arrange rect, so size the slots through their content,
+        // the way ToolTabStrip and the add-button Border are sized in the real template.
+        var strip = new Border { Child = new Border { Width = 200, Height = 28 } };
+        var addButton = new Border { Child = new Border { Width = 36, Height = 28 } };
+        var freeSpace = new Border();
+        var panel = new ToolTabHeaderPanel { Children = { strip, addButton, freeSpace } };
+
+        panel.Measure(new Size(300, 28));
+        panel.Arrange(new Rect(0, 0, 150, 28));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(strip.Bounds.Width, Is.EqualTo(114));
+            Assert.That(addButton.Bounds.Left, Is.EqualTo(114));
+            Assert.That(addButton.Bounds.Width, Is.EqualTo(36));
+            Assert.That(freeSpace.Bounds.Width, Is.EqualTo(0));
+        });
+    }
+
+    [AvaloniaTest]
     public async Task Add_menu_disables_open_singletons_and_opens_the_selected_tool_in_its_dock()
     {
         await ResetProjectAsync();

--- a/tests/Beutl.HeadlessUITests/DockTabCloseButtonTests.cs
+++ b/tests/Beutl.HeadlessUITests/DockTabCloseButtonTests.cs
@@ -1,0 +1,192 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Headless.NUnit;
+using Avalonia.Input;
+using Avalonia.Media;
+using Avalonia.VisualTree;
+using Beutl.ProjectSystem;
+using Beutl.Testing.Headless;
+using Beutl.ViewModels;
+using Beutl.ViewModels.Dock;
+using Beutl.Extensibility;
+using Beutl.Views;
+using Dock.Avalonia.Controls;
+using Dock.Model.Controls;
+using Dock.Model.Core;
+
+namespace Beutl.HeadlessUITests;
+
+[TestFixture]
+public class DockTabCloseButtonTests
+{
+    private static string NewWorkspace(string name)
+    {
+        string location = Path.Combine(BeutlHomeIsolation.CurrentHome!, name);
+        Directory.CreateDirectory(location);
+        return location;
+    }
+
+    private static async Task<EditViewModel> OpenEditorForNewScene(string name)
+    {
+        Project project = (await TestShell.Project.CreateProject(
+            640, 480, 30, 44100, name, NewWorkspace(name)))!;
+        HeadlessTestHelpers.Settle();
+        Scene scene = project.Items.OfType<Scene>().First();
+
+        TestShell.Editor.ActivateTabItem(scene);
+        HeadlessTestHelpers.Settle();
+        return (EditViewModel)TestShell.Editor.SelectedTabItem.Value!.Context.Value;
+    }
+
+    private static ToolTabStripItem TabFor(Visual root, IDockable dockable)
+    {
+        return root.GetVisualDescendants()
+            .OfType<ToolTabStripItem>()
+            .Single(item => ReferenceEquals(item.DataContext, dockable));
+    }
+
+    private static Button CloseButtonOf(ToolTabStripItem tab)
+    {
+        return tab.GetVisualDescendants().OfType<Button>().Single(b => b.Name == "PART_TabCloseButton");
+    }
+
+    private static Border TitleOf(ToolTabStripItem tab)
+    {
+        return tab.GetVisualDescendants().OfType<Border>().Single(b => b.Name == "PART_TabTitleHost");
+    }
+
+    private static Point Center(Control control, Visual relativeTo)
+    {
+        Point? point = control.TranslatePoint(
+            new Point(control.Bounds.Width / 2, control.Bounds.Height / 2),
+            relativeTo);
+        Assert.That(point, Is.Not.Null);
+        return point!.Value;
+    }
+
+    [AvaloniaTest]
+    public async Task Close_button_appears_on_hover_without_changing_the_tab_width_and_fades_the_title()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditorForNewScene("dock-tab-close-hover");
+
+        var view = new EditView { DataContext = editor };
+        var window = new Window { Content = view, Width = 900, Height = 700 };
+
+        try
+        {
+            window.Show();
+            HeadlessTestHelpers.Render();
+
+            IToolDock leftDock = editor.DockHost.Factory.GetAnchoredDock(DockAnchor.Left)!;
+            IDockable first = leftDock.VisibleDockables![0];
+            ToolTabStripItem tab = TabFor(view, first);
+            Button close = CloseButtonOf(tab);
+            Border title = TitleOf(tab);
+            double widthBefore = tab.Bounds.Width;
+
+            double[] tabWidths = leftDock.VisibleDockables
+                .Select(dockable => TabFor(view, dockable).Bounds.Width)
+                .ToArray();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(tabWidths, Has.Length.GreaterThan(1));
+                Assert.That(tabWidths, Is.All.EqualTo(tabWidths[0]).Within(0.5), "Tabs have a fixed width.");
+                Assert.That(first.CanClose, Is.True);
+                Assert.That(close.IsVisible, Is.True);
+                Assert.That(close.Opacity, Is.EqualTo(0));
+                Assert.That(close.IsHitTestVisible, Is.False);
+                Assert.That(title.OpacityMask, Is.Null);
+            });
+
+            window.MouseMove(Center(tab, window));
+            HeadlessTestHelpers.Settle();
+            HeadlessTestHelpers.Render();
+
+            Point? closeRight = close.TranslatePoint(new Point(close.Bounds.Width, 0), tab);
+            Point? titleRight = title.TranslatePoint(new Point(title.Bounds.Width, 0), tab);
+            Assert.Multiple(() =>
+            {
+                Assert.That(close.Opacity, Is.EqualTo(1));
+                Assert.That(close.IsHitTestVisible, Is.True);
+                Assert.That(close.Bounds.Width, Is.EqualTo(20));
+                Assert.That(tab.Bounds.Width, Is.EqualTo(widthBefore));
+                Assert.That(closeRight!.Value.X, Is.EqualTo(titleRight!.Value.X).Within(0.5));
+                Assert.That(title.OpacityMask, Is.InstanceOf<LinearGradientBrush>());
+            });
+
+            window.MouseMove(new Point(1, window.Bounds.Height - 1));
+            HeadlessTestHelpers.Settle();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(close.Opacity, Is.EqualTo(0));
+                Assert.That(close.IsHitTestVisible, Is.False);
+                Assert.That(title.OpacityMask, Is.Null);
+            });
+
+            IToolDock playerDock = editor.DockHost.Factory.GetAnchoredDock(DockAnchor.Player)!;
+            IDockable player = playerDock.VisibleDockables!.Single(d => !d.CanClose);
+            ToolTabStripItem playerTab = TabFor(view, player);
+            window.MouseMove(Center(playerTab, window));
+            HeadlessTestHelpers.Settle();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(CloseButtonOf(playerTab).IsVisible, Is.False);
+                Assert.That(TitleOf(playerTab).OpacityMask, Is.Null);
+            });
+        }
+        finally
+        {
+            window.Close();
+            HeadlessTestHelpers.Settle();
+        }
+    }
+
+    [AvaloniaTest]
+    public async Task Clicking_the_close_button_closes_the_tab()
+    {
+        await TestReset.ResetShellAsync();
+        EditViewModel editor = await OpenEditorForNewScene("dock-tab-close-click");
+
+        var view = new EditView { DataContext = editor };
+        var window = new Window { Content = view, Width = 900, Height = 700 };
+
+        try
+        {
+            window.Show();
+            HeadlessTestHelpers.Render();
+
+            IToolDock leftDock = editor.DockHost.Factory.GetAnchoredDock(DockAnchor.Left)!;
+            int countBefore = leftDock.VisibleDockables!.Count;
+            Assert.That(countBefore, Is.GreaterThan(1));
+            IDockable target = leftDock.VisibleDockables[0];
+            ToolTabStripItem tab = TabFor(view, target);
+            Button close = CloseButtonOf(tab);
+
+            window.MouseMove(Center(tab, window));
+            HeadlessTestHelpers.Settle();
+            Point closeCenter = Center(close, window);
+            window.MouseMove(closeCenter);
+            HeadlessTestHelpers.Settle();
+            window.MouseDown(closeCenter, MouseButton.Left);
+            window.MouseUp(closeCenter, MouseButton.Left);
+            HeadlessTestHelpers.Settle();
+            HeadlessTestHelpers.Render();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(leftDock.VisibleDockables, Has.Count.EqualTo(countBefore - 1));
+                Assert.That(leftDock.VisibleDockables, Does.Not.Contain(target));
+            });
+        }
+        finally
+        {
+            window.Close();
+            HeadlessTestHelpers.Settle();
+        }
+    }
+}

--- a/tests/Beutl.HeadlessUITests/DockTabCloseButtonTests.cs
+++ b/tests/Beutl.HeadlessUITests/DockTabCloseButtonTests.cs
@@ -1,15 +1,15 @@
-using Avalonia;
+﻿using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Headless;
 using Avalonia.Headless.NUnit;
 using Avalonia.Input;
 using Avalonia.Media;
 using Avalonia.VisualTree;
+using Beutl.Extensibility;
 using Beutl.ProjectSystem;
 using Beutl.Testing.Headless;
 using Beutl.ViewModels;
 using Beutl.ViewModels.Dock;
-using Beutl.Extensibility;
 using Beutl.Views;
 using Dock.Avalonia.Controls;
 using Dock.Model.Controls;
@@ -120,6 +120,21 @@ public class DockTabCloseButtonTests
                 Assert.That(close.IsHitTestVisible, Is.False);
                 Assert.That(title.OpacityMask, Is.Null);
             });
+
+            Assert.That(close.Focus(NavigationMethod.Tab), Is.True);
+            HeadlessTestHelpers.Settle();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(close.Opacity, Is.EqualTo(1), "Keyboard focus reveals the close button.");
+                Assert.That(close.IsHitTestVisible, Is.True);
+                Assert.That(title.OpacityMask, Is.InstanceOf<LinearGradientBrush>());
+            });
+
+            window.MouseMove(new Point(1, window.Bounds.Height - 1));
+            window.MouseDown(new Point(1, window.Bounds.Height - 1), MouseButton.Left);
+            window.MouseUp(new Point(1, window.Bounds.Height - 1), MouseButton.Left);
+            HeadlessTestHelpers.Settle();
 
             IToolDock playerDock = editor.DockHost.Factory.GetAnchoredDock(DockAnchor.Player)!;
             IDockable player = playerDock.VisibleDockables!.Single(d => !d.CanClose);

--- a/tests/Beutl.HeadlessUITests/DockTabCloseButtonTests.cs
+++ b/tests/Beutl.HeadlessUITests/DockTabCloseButtonTests.cs
@@ -86,14 +86,8 @@ public class DockTabCloseButtonTests
             Border title = TitleOf(tab);
             double widthBefore = tab.Bounds.Width;
 
-            double[] tabWidths = leftDock.VisibleDockables
-                .Select(dockable => TabFor(view, dockable).Bounds.Width)
-                .ToArray();
-
             Assert.Multiple(() =>
             {
-                Assert.That(tabWidths, Has.Length.GreaterThan(1));
-                Assert.That(tabWidths, Is.All.EqualTo(tabWidths[0]).Within(0.5), "Tabs have a fixed width.");
                 Assert.That(first.CanClose, Is.True);
                 Assert.That(close.IsVisible, Is.True);
                 Assert.That(close.Opacity, Is.EqualTo(0));


### PR DESCRIPTION
## Description
- Move the tool dock "add tab" button from the far right of the header to directly after the last tab, and give it rounded corners. A small `ToolTabHeaderPanel` measures the button before the tab strip so it keeps its width when tabs overflow instead of being pushed out of view.
- Show a close button at the right edge of a tool tab only while the tab is hovered. The button is overlaid in a zero-width `Canvas`, so the tab width does not change on hover; tabs whose dockable has `CanClose = false` (the player) never show it.
- Fade the tab title out underneath the close button with an opacity mask. The mask sits on a fixed-position host `Border` (not the `TextBlock`, whose mask would follow the glyph extents) and uses a right-anchored absolute gradient, so the fade lands at the same distance from the tab edge regardless of title length.

## Affected areas
- [ ] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [x] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [ ] Build / CI / docs only

## Breaking changes
None. Only the `ToolControl` template in `src/Beutl/Views/Dock/DockStyles.axaml` changes; `PART_TabHeader` is now a `ToolTabHeaderPanel` instead of a `Grid`.

## Test plan
- `tests/Beutl.HeadlessUITests/DockTabAddButtonTests.cs`: updated for the new header panel; asserts the add button sits flush after the tab strip, has the rounded corner radius, and stays 28px wide when tabs overflow.
- `tests/Beutl.HeadlessUITests/DockTabCloseButtonTests.cs` (new): close button is hidden until hover, tab width is unchanged on hover, the title gets the fade mask, non-closable tabs show no button, and clicking the button closes the dockable.
- Full `Beutl.HeadlessUITests` suite: 1067/1067 passing locally.
- Verified visually with headless Skia captures (`Window.CaptureRenderedFrame`) for idle, hover, overflow, and short/long titles.

## Fixed issues / References
None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added close buttons to dock tabs, shown when hovering over or focusing closable tabs.
  - Added title fading behind close buttons.
  - Added a tab header layout that keeps the add button visible when tabs overflow.
  - Improved add-button spacing, borders, and corner styling.

- **Bug Fixes**
  - Closing a dock tab now removes it from the visible dock area.

- **Tests**
  - Added coverage for tab overflow, close-button behavior, title fading, and tab layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->