### PR TITLE
feat: add cross-platform Nuke dev command

### DIFF
--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -28,6 +28,7 @@
         "BundleApp",
         "Clean",
         "Compile",
+        "Dev",
         "NuGetPack",
         "Publish",
         "Restore",

--- a/README.ja.md
+++ b/README.ja.md
@@ -36,6 +36,18 @@ Beutl アカウントを作成して、拡張機能を取得したり、自身�
 ## 📥 インストール
 [こちら](https://docs.beutl.beditor.net/get-started/install)のドキュメントを参照してください。
 
+## 開発
+
+初回チェックアウト時は、先に `git submodule update --init --recursive` でGitサブモジュールを初期化してください。
+
+リポジトリのルートで次のコマンドを実行します。
+
+```sh
+nuke dev
+```
+
+`src/Beutl` をDebug構成で実行します。TFMはWindowsでは `net10.0-windows`、macOS/Linuxでは `net10.0` を自動選択します。Nukeのグローバルツールをインストールせずに、macOS/Linuxでは `./build.sh dev`、PowerShellでは `./build.ps1 dev` も使用できます。
+
 ## License
 
 このプロジェクトは **MIT License** ([LICENSE](https://github.com/b-editor/beutl/blob/main/LICENSE)) の下でライセンスされています。

--- a/README.ja.md
+++ b/README.ja.md
@@ -40,13 +40,21 @@ Beutl アカウントを作成して、拡張機能を取得したり、自身�
 
 初回チェックアウト時は、先に `git submodule update --init --recursive` でGitサブモジュールを初期化してください。
 
-リポジトリのルートで次のコマンドを実行します。
+リポジトリのルートで、付属のスクリプトを実行します。Nukeのグローバルツールのインストールは不要です。
+
+macOS/Linux:
 
 ```sh
-nuke dev
+./build.sh dev
 ```
 
-`src/Beutl` をDebug構成で実行します。TFMはWindowsでは `net10.0-windows`、macOS/Linuxでは `net10.0` を自動選択します。Nukeのグローバルツールをインストールせずに、macOS/Linuxでは `./build.sh dev`、PowerShellでは `./build.ps1 dev` も使用できます。
+Windows (PowerShell):
+
+```powershell
+.\build.ps1 dev
+```
+
+`src/Beutl` をDebug構成で実行します。TFMはWindowsでは `net10.0-windows`、macOS/Linuxでは `net10.0` を自動選択します。Nukeのグローバルツールをインストール済みの場合は、`nuke dev` も使用できます。
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,18 @@ Track a project's editing history with Git, restore earlier versions, create exp
 ## 📥 Installation
 Refer to the [documentation](https://docs.beutl.beditor.net/get-started/install) here.
 
+## Development
+
+On a fresh checkout, initialize the Git submodules first with `git submodule update --init --recursive`.
+
+Run the application from the repository root:
+
+```sh
+nuke dev
+```
+
+This runs `src/Beutl` in Debug configuration, automatically selecting `net10.0-windows` on Windows and `net10.0` on macOS/Linux. You can also use `./build.sh dev` on macOS/Linux or `./build.ps1 dev` in PowerShell without installing the global Nuke tool.
+
 ## License
 
 This project is licensed under the **MIT License** ([LICENSE](https://github.com/b-editor/beutl/blob/main/LICENSE)).

--- a/README.md
+++ b/README.md
@@ -43,13 +43,21 @@ Refer to the [documentation](https://docs.beutl.beditor.net/get-started/install)
 
 On a fresh checkout, initialize the Git submodules first with `git submodule update --init --recursive`.
 
-Run the application from the repository root:
+Run the application from the repository root using the included scripts, which do not require the global Nuke tool.
+
+macOS/Linux:
 
 ```sh
-nuke dev
+./build.sh dev
 ```
 
-This runs `src/Beutl` in Debug configuration, automatically selecting `net10.0-windows` on Windows and `net10.0` on macOS/Linux. You can also use `./build.sh dev` on macOS/Linux or `./build.ps1 dev` in PowerShell without installing the global Nuke tool.
+Windows (PowerShell):
+
+```powershell
+.\build.ps1 dev
+```
+
+This runs `src/Beutl` in Debug configuration, automatically selecting `net10.0-windows` on Windows and `net10.0` on macOS/Linux. If the global Nuke tool is already installed, you can also use `nuke dev`.
 
 ## License
 

--- a/nukebuild/Build.cs
+++ b/nukebuild/Build.cs
@@ -76,7 +76,7 @@ class Build : NukeBuild
     {
         AbsolutePath mainProj = SourceDirectory / "Beutl" / "Beutl.csproj";
         using IProcess proc = StartProcess(DotNetPath, $"msbuild --getProperty:TargetFrameworks {mainProj}");
-        proc.WaitForExit();
+        proc.AssertZeroExitCode();
         return proc.Output.First().Text.Split(';')[0];
     }
 

--- a/nukebuild/Build.cs
+++ b/nukebuild/Build.cs
@@ -60,6 +60,18 @@ class Build : NukeBuild
                 .EnableNoRestore());
         });
 
+    Target Dev => _ => _
+        .Description("Run Beutl in Debug configuration for the current platform")
+        .Executes(() =>
+        {
+            string tfm = GetTFM();
+
+            DotNetRun(s => s
+                .SetConfiguration(Configuration.Debug)
+                .SetFramework(OperatingSystem.IsWindows() ? $"{tfm}-windows" : tfm)
+                .SetProjectFile(SourceDirectory / "Beutl" / "Beutl.csproj"));
+        });
+
     private string GetTFM()
     {
         AbsolutePath mainProj = SourceDirectory / "Beutl" / "Beutl.csproj";


### PR DESCRIPTION
## Summary
- Add a `Dev` Nuke target to run Beutl in Debug configuration.
- Select the platform-appropriate target framework automatically.
- Document development setup and invocation options in English and Japanese READMEs.

## Description
Provides `nuke dev`, `./build.sh dev`, and `./build.ps1 dev` for launching `src/Beutl` without requiring a globally installed Nuke tool.

## Breaking changes
- None.

## Fixed issues
- None.

## Testing
- Not run (not requested).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a development build target that runs Beutl in Debug mode for the current platform.
  - Added support for selecting the development target in build configuration.

- **Documentation**
  - Added development setup instructions, including submodule initialization, platform-specific targets, and alternative build commands.
  - Updated both English and Japanese README documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->