### PR TITLE
chore: update dependencies except SkiaSharp and HarfBuzzSharp

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -40,7 +40,7 @@
     <PackageVersion Include="FFmpeg4Sharp" Version="7.0.1" />
     <PackageVersion Include="FluentAvaloniaUI" Version="3.1.0" />
     <PackageVersion Include="FluentIcons.Avalonia.Fluent" Version="2.1.339.1" />
-    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.9.0" />
+    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.10.0" />
     <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.3.333" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="NAudio.Wasapi" Version="3.1.0" />
@@ -49,18 +49,18 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="5.9.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.9.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="5.9.0" />
-    <PackageVersion Include="Microsoft.Diagnostics.Runtime" Version="4.0.732401" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="10.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.FileSystemGlobbing" Version="10.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Diagnostics.Runtime" Version="4.1.745802" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.12" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="10.0.12" />
+    <PackageVersion Include="Microsoft.Extensions.FileSystemGlobbing" Version="10.0.12" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.12" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.12" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.12" />
+    <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="10.0.12" />
     <PackageVersion Include="ModelContextProtocol" Version="2.2.0" />
     <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="2.2.0" />
     <PackageVersion Include="NAudio.Core" Version="3.1.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.10.0" />
     <PackageVersion Include="Nito.AsyncEx" Version="5.1.2" />
     <PackageVersion Include="NuGet.Packaging" Version="7.9.0" />
     <PackageVersion Include="NuGet.ProjectModel" Version="7.9.0" />
@@ -84,11 +84,11 @@
     <PackageVersion Include="SkiaSharp" Version="3.119.4" />
     <PackageVersion Include="SkiaSharp.HarfBuzz" Version="3.119.4" />
     <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="3.119.4" />
-    <PackageVersion Include="System.CommandLine" Version="2.0.11" />
+    <PackageVersion Include="System.CommandLine" Version="2.0.12" />
     <PackageVersion Include="System.Interactive" Version="7.0.1" />
-    <PackageVersion Include="System.Management" Version="10.0.11" />
-    <PackageVersion Include="System.Reactive" Version="6.1.0" />
-    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.11" />
+    <PackageVersion Include="System.Management" Version="10.0.12" />
+    <PackageVersion Include="System.Reactive" Version="7.0.0" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.12" />
     <PackageVersion Include="Vortice.MediaFoundation" Version="3.8.3" />
     <PackageVersion Include="Vortice.XAudio2" Version="3.8.3" />
   </ItemGroup>

--- a/nukebuild/_build.csproj
+++ b/nukebuild/_build.csproj
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageDownload Include="nbgv" Version="[3.6.133]" />
+    <PackageDownload Include="nbgv" Version="[3.10.94]" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Description
- Bump NuGet packages to their latest stable releases: Microsoft.Extensions.* 10.0.11→10.0.12 (DependencyInjection, DependencyModel, FileSystemGlobbing, Hosting, Logging, Logging.Console, ObjectPool), System.Management and System.Security.Cryptography.Xml 10.0.11→10.0.12, Microsoft.Extensions.TimeProvider.Testing 10.9.0→10.10.0, Microsoft.Diagnostics.Runtime 4.0.732401→4.1.745802, Microsoft.NET.Test.Sdk 18.9.0→18.10.0, System.CommandLine 2.0.11→2.0.12, System.Reactive 6.1.0→7.0.0.
- Bump the `nbgv` PackageDownload in nukebuild 3.6.133→3.10.94.
- Intentionally left as-is: SkiaSharp / HarfBuzzSharp (out of scope), Svg.Controls.Skia.Avalonia (12.0.0.17 pulls SkiaSharp 4.148), ReactiveUI.Avalonia 12.0.3 (existing System.Reactive scheduler pin), FFmpeg.AutoGen.Bindings.DynamicallyLoaded (9.x needs an FFmpeg 9 native distribution: installer asset regex, Homebrew ffmpeg@8, worker search paths), NAudio.Wasapi (22.0.0 is unlisted on NuGet).

## Affected areas
- [ ] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [ ] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [x] Build / CI / docs only

## Breaking changes
None

## Test plan
- Full `Beutl.slnx` Debug build: 0 errors, no NU1xxx warnings; System.Reactive resolves to 7.0.0 while ReactiveUI 23.2.28 / ReactiveProperty 9.9.0 stay unchanged.
- Passing locally (macOS): HeadlessUITests 1074, PublicApiContractTests 235, SourceGeneratorTest 328, FFmpegIpc.Tests 66, Graphics3DTests 61, AVFoundation.Tests 12, FFmpegWorker.Tests 7.
- Beutl.UnitTests: 9282 passed. 41 `ProxiesTabViewModelTests` failures in the full run pass when the class runs in isolation (test-order pollution, unrelated to this change). `RepositoryWatcherStressTests.Rapid_write_burst…` fails identically with System.Reactive 6.1.0 and 7.0.0 (macOS FileSystemWatcher timing, pre-existing).
- Beutl.AgentToolkit.Tests: 647 passed; the 3 `PathBoundaryTests` failures are macOS `/var` → `/private/var` symlink environment issues.

## Fixed issues / References
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated centrally managed package versions.
  * Updated the build tooling package version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->