### PR TITLE
fix: apply SourceBackdrop opacity to its captured image

### DIFF
--- a/src/Beutl.Engine/Graphics/SourceBackdrop.cs
+++ b/src/Beutl.Engine/Graphics/SourceBackdrop.cs
@@ -40,8 +40,11 @@ public partial class SourceBackdrop : Drawable
             Size size = MeasureCore(availableSize, r);
 
             Matrix transform = GetTransformMatrix(availableSize, size, r);
+            // Same order as Drawable.Render: the opacity fades the captured image after the clear has run,
+            // so Clear keeps its meaning while the drawable's own Opacity applies like any other drawable's.
             using (context.PushBlendMode(r.BlendMode))
             using (context.PushTransform(transform))
+            using (context.PushOpacity(r.Opacity / 100f))
             using (r.FilterEffect == null ? new() : context.PushFilterEffect(r.FilterEffect))
             {
                 context.DrawBackdrop(backdrop);

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Golden/DrawableGroupIsolationTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Golden/DrawableGroupIsolationTests.cs
@@ -645,7 +645,7 @@ public sealed class DrawableGroupIsolationTests
     {
         var frame = new PixelSize(256, 144);
 
-        Drawable.Resource[] CreateScene(bool grouped, bool includeBackdrop = true)
+        Drawable.Resource[] CreateScene(bool grouped, bool includeBackdrop = true, float? backdropOpacity = null)
         {
             var gradient = new LinearGradientBrush();
             gradient.GradientStops.Add(new GradientStop(Colors.Crimson, 0));
@@ -663,17 +663,18 @@ public sealed class DrawableGroupIsolationTests
                 Clear = { CurrentValue = false },
                 FilterEffect = { CurrentValue = new Invert() },
             };
+            float effectOpacity = backdropOpacity ?? opacity;
             Drawable effect = backdrop;
             if (grouped)
             {
                 var group = new DrawableGroup();
                 group.Children.Add(backdrop);
-                group.Opacity.CurrentValue = opacity;
+                group.Opacity.CurrentValue = effectOpacity;
                 effect = group;
             }
             else
             {
-                backdrop.Opacity.CurrentValue = opacity;
+                backdrop.Opacity.CurrentValue = effectOpacity;
             }
 
             return
@@ -687,11 +688,13 @@ public sealed class DrawableGroupIsolationTests
         Drawable.Resource[] expectedResources = CreateScene(grouped: false);
         Drawable.Resource[] actualResources = CreateScene(grouped: true);
         Drawable.Resource[] omittedResources = CreateScene(grouped: false, includeBackdrop: false);
+        Drawable.Resource[] fullResources = CreateScene(grouped: false, backdropOpacity: 100);
         try
         {
             using Bitmap expected = RenderScene(frame, expectedResources);
             using Bitmap actual = RenderScene(frame, actualResources);
             using Bitmap omitted = RenderScene(frame, omittedResources);
+            using Bitmap full = RenderScene(frame, fullResources);
 
             if (opacity == 100)
             {
@@ -699,16 +702,19 @@ public sealed class DrawableGroupIsolationTests
             }
             else
             {
-                // SourceBackdrop overrides Render and does not apply its own Opacity.
-                // Build the control from the full effect and the untouched opaque scene.
-                var full = expected.GetPixelSpan<Half>();
+                // SourceBackdrop applies its own Opacity in its Render override (SourceBackdropOpacityTests), so
+                // the bare and the grouped form must both be the linear blend of the untouched opaque scene and
+                // the full-strength effect. The control is built from those two, not from either form under test.
+                var fullPixels = full.GetPixelSpan<Half>();
                 var background = omitted.GetPixelSpan<Half>();
-                var faded = actual.GetPixelSpan<Half>();
+                var grouped = actual.GetPixelSpan<Half>();
+                var bare = expected.GetPixelSpan<Half>();
                 float factor = opacity / 100f;
-                for (int i = 0; i < full.Length; i++)
+                for (int i = 0; i < fullPixels.Length; i++)
                 {
-                    float reference = (float)background[i] * (1 - factor) + (float)full[i] * factor;
-                    Assert.That((float)faded[i], Is.EqualTo(reference).Within(0.002f), $"component {i}");
+                    float reference = (float)background[i] * (1 - factor) + (float)fullPixels[i] * factor;
+                    Assert.That((float)grouped[i], Is.EqualTo(reference).Within(0.002f), $"grouped component {i}");
+                    Assert.That((float)bare[i], Is.EqualTo(reference).Within(0.002f), $"bare component {i}");
                 }
             }
             Assert.That(
@@ -723,6 +729,8 @@ public sealed class DrawableGroupIsolationTests
             foreach (Drawable.Resource resource in actualResources)
                 resource.Dispose();
             foreach (Drawable.Resource resource in omittedResources)
+                resource.Dispose();
+            foreach (Drawable.Resource resource in fullResources)
                 resource.Dispose();
         }
     }

--- a/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Golden/SourceBackdropOpacityTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/Rendering/Golden/SourceBackdropOpacityTests.cs
@@ -1,0 +1,155 @@
+﻿using Beutl.Composition;
+using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+using Beutl.Graphics.Shapes;
+using Beutl.Media;
+using Beutl.UnitTests.Engine.Graphics.Backend;
+
+namespace Beutl.UnitTests.Engine.Graphics.Rendering.Golden;
+
+/// <summary>
+/// <see cref="SourceBackdrop"/> overrides <see cref="Drawable.Render"/> to capture the scene before it draws,
+/// so the inherited <see cref="Drawable.Opacity"/> has to be applied there explicitly. These tests pin that
+/// the drawable's own opacity fades the captured image the same way an enclosing group does, and that it
+/// leaves the <see cref="SourceBackdrop.Clear"/> step untouched.
+/// </summary>
+[NonParallelizable]
+[TestFixture]
+public sealed class SourceBackdropOpacityTests
+{
+    private static readonly PixelSize s_frame = new(256, 144);
+
+    // One 8-bit code. The group reference and the bare backdrop reach the same blend through different
+    // paint paths, so they may round differently by one storage step.
+    private const double Tolerance = 1.0 / 255.0;
+
+    [TestCase(100f, 1f)]
+    [TestCase(50f, 1f)]
+    [TestCase(0f, 1f)]
+    [TestCase(50f, 2f)]
+    public void OwnOpacity_MatchesTheSameOpacityOnAnEnclosingGroup(float opacity, float scale)
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            using Drawable.Resource expected = CreateScene(new BackdropSetup(100f, Clear: false, GroupOpacity: opacity));
+            using Drawable.Resource actual = CreateScene(new BackdropSetup(opacity, Clear: false, GroupOpacity: null));
+            using Bitmap expectedBitmap = GoldenImageHarness.RenderAtScale(expected, s_frame, scale);
+            using Bitmap actualBitmap = GoldenImageHarness.RenderAtScale(actual, s_frame, scale);
+
+            RgbaMaximumError error = ImageMetrics.MaximumAbsoluteErrorPerChannel(expectedBitmap, actualBitmap);
+            Assert.That(
+                error.Maximum,
+                Is.LessThanOrEqualTo(Tolerance),
+                $"A bare SourceBackdrop at opacity {opacity} must match a group at that opacity around an opaque backdrop at scale {scale}: {error}.");
+        });
+    }
+
+    [Test]
+    public void OwnOpacityZero_LeavesTheSceneUntouched()
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            using Drawable.Resource scene = CreateScene(setup: null);
+            using Drawable.Resource invisible = CreateScene(new BackdropSetup(0f, Clear: false, GroupOpacity: null));
+            using Drawable.Resource visible = CreateScene(new BackdropSetup(100f, Clear: false, GroupOpacity: null));
+            using Bitmap sceneBitmap = GoldenImageHarness.RenderAtScale(scene, s_frame, 1f);
+            using Bitmap invisibleBitmap = GoldenImageHarness.RenderAtScale(invisible, s_frame, 1f);
+            using Bitmap visibleBitmap = GoldenImageHarness.RenderAtScale(visible, s_frame, 1f);
+
+            // The control: the inverting backdrop must visibly change the scene, or "untouched" proves nothing.
+            Assert.That(
+                ImageMetrics.MaximumAbsoluteErrorPerChannel(sceneBitmap, visibleBitmap).Maximum,
+                Is.GreaterThan(0.5),
+                "The fixture's backdrop must visibly invert the scene.");
+            GoldenImageHarness.AssertByteIdentical(sceneBitmap, invisibleBitmap);
+        });
+    }
+
+    [Test]
+    public void OwnOpacity_BlendsAClearedBackdropLinearlyOverTheClearedCanvas()
+    {
+        VulkanTestEnvironment.EnsureAvailable();
+        VulkanTestEnvironment.InvokeOnRenderThread(() =>
+        {
+            using Drawable.Resource none = CreateScene(new BackdropSetup(0f, Clear: true, GroupOpacity: null));
+            using Drawable.Resource half = CreateScene(new BackdropSetup(50f, Clear: true, GroupOpacity: null));
+            using Drawable.Resource full = CreateScene(new BackdropSetup(100f, Clear: true, GroupOpacity: null));
+            using Bitmap noneBitmap = GoldenImageHarness.RenderAtScale(none, s_frame, 1f);
+            using Bitmap halfBitmap = GoldenImageHarness.RenderAtScale(half, s_frame, 1f);
+            using Bitmap fullBitmap = GoldenImageHarness.RenderAtScale(full, s_frame, 1f);
+
+            // Clear runs before the opacity is applied, so opacity 0 shows the cleared canvas and opacity 100
+            // the full effect; 50 must sit exactly between them in premultiplied terms.
+            Assert.That(
+                ImageMetrics.MaximumAbsoluteErrorPerChannel(noneBitmap, fullBitmap).Maximum,
+                Is.GreaterThan(0.5),
+                "The fixture's cleared backdrop must differ from the cleared canvas.");
+            Assert.That(
+                MaximumLerpError(noneBitmap, fullBitmap, halfBitmap, 0.5f),
+                Is.LessThanOrEqualTo(Tolerance),
+                "Opacity 50 on a clearing backdrop must be the midpoint of opacity 0 and opacity 100.");
+        });
+    }
+
+    private static double MaximumLerpError(Bitmap from, Bitmap to, Bitmap actual, float t)
+    {
+        ReadOnlySpan<ushort> fromPixels = from.GetPixelSpan<ushort>();
+        ReadOnlySpan<ushort> toPixels = to.GetPixelSpan<ushort>();
+        ReadOnlySpan<ushort> actualPixels = actual.GetPixelSpan<ushort>();
+        Assert.That(actualPixels.Length, Is.EqualTo(fromPixels.Length).And.EqualTo(toPixels.Length));
+
+        double maximum = 0;
+        for (int i = 0; i < actualPixels.Length; i++)
+        {
+            float expected = float.Lerp(
+                (float)BitConverter.UInt16BitsToHalf(fromPixels[i]),
+                (float)BitConverter.UInt16BitsToHalf(toPixels[i]),
+                t);
+            float observed = (float)BitConverter.UInt16BitsToHalf(actualPixels[i]);
+            maximum = Math.Max(maximum, Math.Abs(observed - expected));
+        }
+
+        return maximum;
+    }
+
+    private readonly record struct BackdropSetup(float Opacity, bool Clear, float? GroupOpacity);
+
+    private static Drawable.Resource CreateScene(BackdropSetup? setup)
+    {
+        var scene = new DrawableGroup();
+        scene.Children.Add(CreateRectangle(s_frame.Width, s_frame.Height, Colors.DimGray));
+        scene.Children.Add(CreateRectangle(130, 95, Colors.Navy));
+
+        if (setup is { } backdropSetup)
+        {
+            var backdrop = new SourceBackdrop();
+            backdrop.FilterEffect.CurrentValue = new Invert();
+            backdrop.Clear.CurrentValue = backdropSetup.Clear;
+            backdrop.Opacity.CurrentValue = backdropSetup.Opacity;
+            if (backdropSetup.GroupOpacity is { } groupOpacity)
+            {
+                var group = new DrawableGroup();
+                group.Opacity.CurrentValue = groupOpacity;
+                group.Children.Add(backdrop);
+                scene.Children.Add(group);
+            }
+            else
+            {
+                scene.Children.Add(backdrop);
+            }
+        }
+
+        return scene.ToResource(CompositionContext.Default);
+    }
+
+    private static RectShape CreateRectangle(float width, float height, Color color)
+    {
+        var shape = new RectShape();
+        shape.Width.CurrentValue = width;
+        shape.Height.CurrentValue = height;
+        shape.Fill.CurrentValue = new SolidColorBrush(color);
+        return shape;
+    }
+}


### PR DESCRIPTION
## Description
- `SourceBackdrop` overrides `Drawable.Render` to snapshot the scene before it draws, and that override never applied the drawable's own `Opacity`: a backdrop at opacity 50 rendered its effect at full strength while a `DrawableGroup` at opacity 50 around it faded correctly.
- Push the opacity in the same position `Drawable.Render` uses (after the transform, before the filter effect), so `Clear` still runs first and blend/filter semantics are unchanged.

## Affected areas
- [x] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [ ] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [ ] Build / CI / docs only

## Breaking changes
None. A `SourceBackdrop` whose `Opacity` is below 100 now renders fainter, which is the documented meaning of the property.

## Test plan
- New `tests/Beutl.UnitTests/Engine/Graphics/Rendering/Golden/SourceBackdropOpacityTests.cs`: a bare backdrop at opacity 100/50/0 (and 50 at 2x) matches an enclosing group at the same opacity; opacity 0 leaves the scene byte-identical (with a control proving the effect is visible at 100); a clearing backdrop at 50 is the exact midpoint of opacity 0 and 100.
- `DrawableGroupIsolationTests.SourceBackdropInsideGroup_MatchesBareBackdrop` built its control on the old behaviour; it now checks both the bare and the grouped form against a full-strength render.
- Negative control: the new fixture failed 5/6 before the fix and passes 6/6 after; 80 neighbouring backdrop/group/preview tests pass.

## Fixed issues / References
- Closes #2362


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed backdrop rendering so its opacity correctly fades the captured image.
  * Ensured opacity behaves consistently whether applied directly to a backdrop or through an enclosing group.
  * Corrected blending behavior for cleared backdrops, including zero-opacity rendering.

* **Tests**
  * Added coverage for backdrop opacity, clearing, scaling, and grouped rendering scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->