### PR TITLE
feat: open DisplacementMapTransform to out-of-tree transforms

### DIFF
--- a/src/Beutl.Engine/Graphics/FilterEffects/DisplacementMapRotationTransform.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/DisplacementMapRotationTransform.cs
@@ -56,7 +56,7 @@ public partial class DisplacementMapRotationTransform : DisplacementMapTransform
 
     public partial class Resource
     {
-        internal override void ApplyTo(
+        public override void ApplyTo(
             Brush.Resource displacementMap, GradientSpreadMethod spreadMethod,
             DisplacementMapChannel channel, bool signed, FilterEffectContext context)
         {

--- a/src/Beutl.Engine/Graphics/FilterEffects/DisplacementMapScaleTransform.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/DisplacementMapScaleTransform.cs
@@ -58,7 +58,7 @@ public partial class DisplacementMapScaleTransform : DisplacementMapTransform
 
     public partial class Resource
     {
-        internal override void ApplyTo(
+        public override void ApplyTo(
             Brush.Resource displacementMap, GradientSpreadMethod spreadMethod,
             DisplacementMapChannel channel, bool signed, FilterEffectContext context)
         {

--- a/src/Beutl.Engine/Graphics/FilterEffects/DisplacementMapTransform.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/DisplacementMapTransform.cs
@@ -90,7 +90,24 @@ public abstract partial class DisplacementMapTransform : EngineObject
 
     public partial class Resource
     {
-        internal abstract void ApplyTo(
+        /// <summary>
+        /// Lowers this transform into <paramref name="context"/> for the displacement map the owning
+        /// <see cref="DisplacementMapEffect"/> resolved.
+        /// </summary>
+        /// <param name="displacementMap">The brush whose pixels supply the displacement.</param>
+        /// <param name="spreadMethod">How the input is sampled outside its bounds.</param>
+        /// <param name="channel">The channel of <paramref name="displacementMap"/> that carries the displacement.</param>
+        /// <param name="signed">Whether the channel is centred on zero rather than starting from it.</param>
+        /// <param name="context">The effect context that receives the recorded stages.</param>
+        /// <remarks>
+        /// <see cref="DisplacementMapEffect"/> calls this once per application in place of its own lowering
+        /// whenever <see cref="DisplacementMapEffect.Transform"/> is set and the map is not being shown. An
+        /// out-of-tree transform records its stages through the public <see cref="FilterEffectContext"/>
+        /// surface, for example a <see cref="ShaderDefinition{TState}"/> that binds
+        /// <paramref name="displacementMap"/> as a resource; the binding helpers the built-in transforms
+        /// share are not part of the public contract.
+        /// </remarks>
+        public abstract void ApplyTo(
             Brush.Resource displacementMap, GradientSpreadMethod spreadMethod,
             DisplacementMapChannel channel, bool signed, FilterEffectContext context);
     }

--- a/src/Beutl.Engine/Graphics/FilterEffects/DisplacementMapTransform.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/DisplacementMapTransform.cs
@@ -103,9 +103,10 @@ public abstract partial class DisplacementMapTransform : EngineObject
         /// <see cref="DisplacementMapEffect"/> calls this once per application in place of its own lowering
         /// whenever <see cref="DisplacementMapEffect.Transform"/> is set and the map is not being shown. An
         /// out-of-tree transform records its stages through the public <see cref="FilterEffectContext"/>
-        /// surface, for example a <see cref="ShaderDefinition{TState}"/> that binds
-        /// <paramref name="displacementMap"/> as a resource; the binding helpers the built-in transforms
-        /// share are not part of the public contract.
+        /// surface, typically <see cref="FilterEffectContext.Shader(Shaders.ShaderDescription)"/> with a
+        /// <see cref="Shaders.ShaderDescription"/> whose <see cref="Shaders.ShaderBindingBuilder"/> callback
+        /// binds <paramref name="displacementMap"/> as a resource. The sampling helpers the built-in
+        /// transforms share are not part of the public contract.
         /// </remarks>
         public abstract void ApplyTo(
             Brush.Resource displacementMap, GradientSpreadMethod spreadMethod,

--- a/src/Beutl.Engine/Graphics/FilterEffects/DisplacementMapTranslateTransform.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/DisplacementMapTranslateTransform.cs
@@ -48,7 +48,7 @@ public partial class DisplacementMapTranslateTransform : DisplacementMapTransfor
 
     public partial class Resource
     {
-        internal override void ApplyTo(
+        public override void ApplyTo(
             Brush.Resource displacementMap, GradientSpreadMethod spreadMethod,
             DisplacementMapChannel channel, bool signed, FilterEffectContext context)
         {

--- a/tests/Beutl.PublicApiContractTests/DisplacementTransformAuthoringContractTests.cs
+++ b/tests/Beutl.PublicApiContractTests/DisplacementTransformAuthoringContractTests.cs
@@ -1,0 +1,94 @@
+﻿using Beutl.Composition;
+using Beutl.Engine;
+using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+using Beutl.Media;
+
+namespace Beutl.PublicApiContractTests;
+
+/// <summary>
+/// <see cref="DisplacementMapTransform"/> is the extension point <see cref="DisplacementMapEffect.Transform"/>
+/// advertises. This project is not a friend of the engine assembly, so a derivation that compiles here and is
+/// dispatched to by the effect is what proves the point is usable from a plugin.
+/// </summary>
+[TestFixture]
+public sealed class DisplacementTransformAuthoringContractTests
+{
+    [Test]
+    public void PluginTransform_IsLoweredByDisplacementMapEffect()
+    {
+        var transform = new PluginDisplacementTransform();
+        transform.Strength.CurrentValue = 0.25f;
+        var effect = new DisplacementMapEffect();
+        effect.DisplacementMap.CurrentValue = new SolidColorBrush(Colors.White);
+        effect.Transform.CurrentValue = transform;
+        effect.SpreadMethod.CurrentValue = GradientSpreadMethod.Repeat;
+        effect.Channel.CurrentValue = DisplacementMapChannel.Green;
+        effect.Signed.CurrentValue = true;
+
+        using DisplacementMapEffect.Resource resource = effect.ToResource(CompositionContext.Default);
+        var pluginResource = resource.Transform as PluginDisplacementTransform.Resource;
+        Assert.That(pluginResource, Is.Not.Null, "The effect resource must snapshot the plugin transform.");
+
+        using var context = new FilterEffectContext(new Rect(0, 0, 8, 8));
+        int itemsBefore = context.CountItems();
+
+        effect.ApplyTo(context, resource);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(pluginResource!.Invocations, Is.EqualTo(1));
+            Assert.That(pluginResource.LastDisplacementMap, Is.SameAs(resource.DisplacementMap));
+            Assert.That(pluginResource.LastSpreadMethod, Is.EqualTo(GradientSpreadMethod.Repeat));
+            Assert.That(pluginResource.LastChannel, Is.EqualTo(DisplacementMapChannel.Green));
+            Assert.That(pluginResource.LastSigned, Is.True);
+            Assert.That(pluginResource.LastStrength, Is.EqualTo(0.25f));
+            Assert.That(
+                context.CountItems(),
+                Is.GreaterThan(itemsBefore),
+                "The stage the plugin recorded must reach the effect context.");
+        });
+    }
+}
+
+/// <summary>A displacement transform authored outside the engine assembly.</summary>
+public sealed partial class PluginDisplacementTransform : DisplacementMapTransform
+{
+    public PluginDisplacementTransform()
+    {
+        ScanProperties<PluginDisplacementTransform>();
+    }
+
+    public IProperty<float> Strength { get; } = Property.CreateAnimatable<float>();
+
+    public partial class Resource
+    {
+        public int Invocations { get; private set; }
+
+        public Brush.Resource? LastDisplacementMap { get; private set; }
+
+        public GradientSpreadMethod LastSpreadMethod { get; private set; }
+
+        public DisplacementMapChannel LastChannel { get; private set; }
+
+        public bool LastSigned { get; private set; }
+
+        public float LastStrength { get; private set; }
+
+        public override void ApplyTo(
+            Brush.Resource displacementMap, GradientSpreadMethod spreadMethod,
+            DisplacementMapChannel channel, bool signed, FilterEffectContext context)
+        {
+            Invocations++;
+            LastDisplacementMap = displacementMap;
+            LastSpreadMethod = spreadMethod;
+            LastChannel = channel;
+            LastSigned = signed;
+            LastStrength = Strength;
+
+            // A public stage stands in for a real displacement shader. The contract under test is that the
+            // effect hands its resolved arguments to an out-of-tree transform and records what it lowers.
+            context.Brightness(Strength);
+        }
+    }
+}


### PR DESCRIPTION
## Description
- `DisplacementMapTransform` is `public abstract` and `DisplacementMapEffect.Transform` is typed on it, but the execution hook `Resource.ApplyTo` was `internal abstract`, so a plugin derivation could not compile (CS0534 on a member it cannot see).
- Make the hook `public abstract`, the three built-in overrides `public`, and document the contract. An out-of-tree transform records through the public `FilterEffectContext.Shader(ShaderDescription)` surface, binding the map through `ShaderBindingBuilder` (both already public). The sampling helpers the built-ins share stay `private protected` for now; opening them as `protected` is a possible follow-up rather than part of this change. (The commit message's remark that `ShaderBindingBuilder` is internal is wrong; the review-fix commit corrects the doc comment.)
- This is the "open the hierarchy" option from the issue in its cheaper form; "close it honestly" (a `private protected` constructor) is a two-line alternative if preferred.

## Affected areas
- [x] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [ ] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [ ] Build / CI / docs only

## Breaking changes
None. No external subclass could exist before, and the in-tree overrides only widen accessibility.

## Test plan
- New `tests/Beutl.PublicApiContractTests/DisplacementTransformAuthoringContractTests.cs` derives `PluginDisplacementTransform` in the non-friend contract project, assigns it to `DisplacementMapEffect.Transform`, and asserts the effect dispatches its resolved map, spread method, channel and signedness to it and records the stage it lowers.
- Existing displacement tests in `Beutl.UnitTests` (45) pass.

## Fixed issues / References
- Closes #2288


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded displacement map transform support for externally authored effects.
  * Displacement transforms can now be applied through the public effect interface.
* **Documentation**
  * Added developer-facing API documentation for applying displacement transforms.
* **Tests**
  * Added coverage verifying that custom displacement transforms preserve configuration and generate the expected effect stages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
