### PR TITLE
fix: preserve lexical project paths for Git tree lookup

### DIFF
--- a/src/Beutl.Editor/VersionControl/GitCliVersionControlService.cs
+++ b/src/Beutl.Editor/VersionControl/GitCliVersionControlService.cs
@@ -525,16 +525,43 @@ internal sealed class GitCliVersionControlService :
         return $":(top,literal){prefix}{projectRelativePath}";
     }
 
+    // Callers verify canonical containment first. Git tracks a project-file symbolic link under
+    // its lexical name, so tree queries must use the lexical repository-relative path; the
+    // canonical path only covers a link that lives outside the project root and points into it.
     private static string GetRepositoryRelativeProjectFilePath(
         RepositoryInfo repository,
         string projectFile)
     {
-        string projectRelativePath = NormalizeGitPath(Path.GetRelativePath(
-            RepositoryPathComparer.ResolveCanonicalPath(repository.ProjectRoot),
-            RepositoryPathComparer.ResolveCanonicalPath(projectFile)));
+        string projectRelativePath = NormalizeGitPath(
+            TryGetLexicalProjectRelativePath(repository, projectFile)
+            ?? Path.GetRelativePath(
+                RepositoryPathComparer.ResolveCanonicalPath(repository.ProjectRoot),
+                RepositoryPathComparer.ResolveCanonicalPath(projectFile)));
         return repository.Pathspec == "."
             ? projectRelativePath
             : repository.Pathspec + "/" + projectRelativePath;
+    }
+
+    // Walks the lexical ancestors of the project file up to the first one that is the project
+    // root on disk, so a link above the root still yields the tracked name beneath it. Returns
+    // null when no lexical ancestor is the project root.
+    private static string? TryGetLexicalProjectRelativePath(
+        RepositoryInfo repository,
+        string projectFile)
+    {
+        string lexicalProjectFile = Path.GetFullPath(projectFile);
+        string? lexicalRoot = Path.GetDirectoryName(lexicalProjectFile);
+        while (lexicalRoot is not null)
+        {
+            if (RepositoryPathComparer.AreEquivalent(lexicalRoot, repository.ProjectRoot))
+            {
+                return Path.GetRelativePath(lexicalRoot, lexicalProjectFile);
+            }
+
+            lexicalRoot = Path.GetDirectoryName(lexicalRoot);
+        }
+
+        return null;
     }
 
     private static bool AreSameProjectRelativePath(
@@ -3208,26 +3235,16 @@ internal sealed class GitCliVersionControlService :
         string projectFile,
         string? canonicalRelativePath = null)
     {
-
-        string lexicalProjectFile = Path.GetFullPath(projectFile);
-        string? lexicalRoot = Path.GetDirectoryName(lexicalProjectFile);
-        while (lexicalRoot is not null)
+        string? lexicalRelativePath = TryGetLexicalProjectRelativePath(repository, projectFile);
+        if (lexicalRelativePath is not null)
         {
-            if (RepositoryPathComparer.AreEquivalent(lexicalRoot, repository.ProjectRoot))
-            {
-                string lexicalRelativePath = Path.GetRelativePath(
-                    lexicalRoot,
-                    lexicalProjectFile);
-                ValidateRecoveryProjectFile(lexicalRelativePath);
-                return NormalizeGitPath(lexicalRelativePath);
-            }
-
-            lexicalRoot = Path.GetDirectoryName(lexicalRoot);
+            ValidateRecoveryProjectFile(lexicalRelativePath);
+            return NormalizeGitPath(lexicalRelativePath);
         }
 
         canonicalRelativePath ??= Path.GetRelativePath(
             Path.GetFullPath(repository.ProjectRoot),
-            lexicalProjectFile);
+            Path.GetFullPath(projectFile));
         ValidateRecoveryProjectFile(canonicalRelativePath);
         return NormalizeGitPath(canonicalRelativePath);
     }

--- a/src/Beutl.Editor/VersionControl/GitCliVersionControlService.cs
+++ b/src/Beutl.Editor/VersionControl/GitCliVersionControlService.cs
@@ -559,12 +559,9 @@ internal sealed class GitCliVersionControlService :
     private static string ResolveTrackedProjectFilePath(string projectFile)
     {
         string fullPath = Path.GetFullPath(projectFile);
-        string? parent = Path.GetDirectoryName(fullPath);
         string name = Path.GetFileName(fullPath);
-        if (parent is null || name.Length == 0)
-            return RepositoryPathComparer.ResolveCanonicalPath(fullPath);
-
-        string canonicalParent = RepositoryPathComparer.ResolveCanonicalPath(parent);
+        string canonicalParent = RepositoryPathComparer.ResolveCanonicalPath(
+            Path.GetDirectoryName(fullPath) ?? fullPath);
         string candidate = Path.Combine(canonicalParent, name);
         if (!Path.Exists(candidate))
         {
@@ -587,28 +584,6 @@ internal sealed class GitCliVersionControlService :
             // A parent that cannot be listed keeps the caller's spelling rather than failing the lookup.
             return candidate;
         }
-    }
-
-    // Walks the lexical ancestors of the project file up to the first one that is the project
-    // root on disk, so a link above the root still yields the tracked name beneath it. Returns
-    // null when no lexical ancestor is the project root.
-    private static string? TryGetLexicalProjectRelativePath(
-        RepositoryInfo repository,
-        string projectFile)
-    {
-        string lexicalProjectFile = Path.GetFullPath(projectFile);
-        string? lexicalRoot = Path.GetDirectoryName(lexicalProjectFile);
-        while (lexicalRoot is not null)
-        {
-            if (RepositoryPathComparer.AreEquivalent(lexicalRoot, repository.ProjectRoot))
-            {
-                return Path.GetRelativePath(lexicalRoot, lexicalProjectFile);
-            }
-
-            lexicalRoot = Path.GetDirectoryName(lexicalRoot);
-        }
-
-        return null;
     }
 
     private static bool AreSameProjectRelativePath(
@@ -3282,16 +3257,26 @@ internal sealed class GitCliVersionControlService :
         string projectFile,
         string? canonicalRelativePath = null)
     {
-        string? lexicalRelativePath = TryGetLexicalProjectRelativePath(repository, projectFile);
-        if (lexicalRelativePath is not null)
+
+        string lexicalProjectFile = Path.GetFullPath(projectFile);
+        string? lexicalRoot = Path.GetDirectoryName(lexicalProjectFile);
+        while (lexicalRoot is not null)
         {
-            ValidateRecoveryProjectFile(lexicalRelativePath);
-            return NormalizeGitPath(lexicalRelativePath);
+            if (RepositoryPathComparer.AreEquivalent(lexicalRoot, repository.ProjectRoot))
+            {
+                string lexicalRelativePath = Path.GetRelativePath(
+                    lexicalRoot,
+                    lexicalProjectFile);
+                ValidateRecoveryProjectFile(lexicalRelativePath);
+                return NormalizeGitPath(lexicalRelativePath);
+            }
+
+            lexicalRoot = Path.GetDirectoryName(lexicalRoot);
         }
 
         canonicalRelativePath ??= Path.GetRelativePath(
             Path.GetFullPath(repository.ProjectRoot),
-            Path.GetFullPath(projectFile));
+            lexicalProjectFile);
         ValidateRecoveryProjectFile(canonicalRelativePath);
         return NormalizeGitPath(canonicalRelativePath);
     }

--- a/src/Beutl.Editor/VersionControl/GitCliVersionControlService.cs
+++ b/src/Beutl.Editor/VersionControl/GitCliVersionControlService.cs
@@ -525,21 +525,61 @@ internal sealed class GitCliVersionControlService :
         return $":(top,literal){prefix}{projectRelativePath}";
     }
 
-    // Callers verify canonical containment first. Git tracks a project-file symbolic link under
-    // its lexical name, so tree queries must use the lexical repository-relative path; the
-    // canonical path only covers a link that lives outside the project root and points into it.
-    private static string GetRepositoryRelativeProjectFilePath(
+    // Git tracks a symbolic link as the link entry itself, never as the tree or blob it points to, so
+    // the tracked path of a project file is its own entry name inside its canonical parent: a link in
+    // the final component keeps the name Git stores, while an alias directory above it resolves to
+    // the real tree. Callers verify canonical containment before asking.
+    internal static string GetRepositoryRelativeProjectFilePath(
         RepositoryInfo repository,
         string projectFile)
     {
-        string projectRelativePath = NormalizeGitPath(
-            TryGetLexicalProjectRelativePath(repository, projectFile)
-            ?? Path.GetRelativePath(
-                RepositoryPathComparer.ResolveCanonicalPath(repository.ProjectRoot),
-                RepositoryPathComparer.ResolveCanonicalPath(projectFile)));
+        string canonicalProjectRoot = RepositoryPathComparer.ResolveCanonicalPath(repository.ProjectRoot);
+        string projectRelativePath = Path.GetRelativePath(
+            canonicalProjectRoot,
+            ResolveTrackedProjectFilePath(projectFile));
+        if (projectRelativePath == ".."
+            || projectRelativePath.StartsWith(".." + Path.DirectorySeparatorChar, StringComparison.Ordinal)
+            || Path.IsPathRooted(projectRelativePath))
+        {
+            // The entry's own parent sits outside the project root, so only the resolved target
+            // can be the tracked file.
+            projectRelativePath = Path.GetRelativePath(
+                canonicalProjectRoot,
+                RepositoryPathComparer.ResolveCanonicalPath(projectFile));
+        }
+
+        projectRelativePath = NormalizeGitPath(projectRelativePath);
         return repository.Pathspec == "."
             ? projectRelativePath
             : repository.Pathspec + "/" + projectRelativePath;
+    }
+
+    // The canonical parent plus the entry's own on-disk spelling. The entry itself is deliberately
+    // not resolved, because following it would replace a tracked link with its target's name.
+    private static string ResolveTrackedProjectFilePath(string projectFile)
+    {
+        string fullPath = Path.GetFullPath(projectFile);
+        string? parent = Path.GetDirectoryName(fullPath);
+        string name = Path.GetFileName(fullPath);
+        if (parent is null || name.Length == 0)
+            return RepositoryPathComparer.ResolveCanonicalPath(fullPath);
+
+        string canonicalParent = RepositoryPathComparer.ResolveCanonicalPath(parent);
+        string candidate = Path.Combine(canonicalParent, name);
+        try
+        {
+            return VersionControlPathComparison.SelectCanonicalExistingEntry(
+                name,
+                candidate,
+                Directory.EnumerateFileSystemEntries(canonicalParent));
+        }
+        catch (Exception ex) when (ex is IOException
+                                   or UnauthorizedAccessException
+                                   or NotSupportedException)
+        {
+            // A parent that cannot be listed keeps the caller's spelling rather than failing the lookup.
+            return candidate;
+        }
     }
 
     // Walks the lexical ancestors of the project file up to the first one that is the project

--- a/src/Beutl.Editor/VersionControl/GitCliVersionControlService.cs
+++ b/src/Beutl.Editor/VersionControl/GitCliVersionControlService.cs
@@ -566,6 +566,13 @@ internal sealed class GitCliVersionControlService :
 
         string canonicalParent = RepositoryPathComparer.ResolveCanonicalPath(parent);
         string candidate = Path.Combine(canonicalParent, name);
+        if (!Path.Exists(candidate))
+        {
+            // Only an entry that exists under this spelling is renormalized; on a case-sensitive
+            // volume a sole case-insensitive neighbour is a different file, not this one.
+            return candidate;
+        }
+
         try
         {
             return VersionControlPathComparison.SelectCanonicalExistingEntry(

--- a/src/Beutl.Editor/VersionControl/GitCliVersionControlService.cs
+++ b/src/Beutl.Editor/VersionControl/GitCliVersionControlService.cs
@@ -534,21 +534,17 @@ internal sealed class GitCliVersionControlService :
         string projectFile)
     {
         string canonicalProjectRoot = RepositoryPathComparer.ResolveCanonicalPath(repository.ProjectRoot);
-        string projectRelativePath = Path.GetRelativePath(
-            canonicalProjectRoot,
-            ResolveTrackedProjectFilePath(projectFile));
-        if (projectRelativePath == ".."
-            || projectRelativePath.StartsWith(".." + Path.DirectorySeparatorChar, StringComparison.Ordinal)
-            || Path.IsPathRooted(projectRelativePath))
-        {
-            // The entry's own parent sits outside the project root, so only the resolved target
-            // can be the tracked file.
-            projectRelativePath = Path.GetRelativePath(
-                canonicalProjectRoot,
-                RepositoryPathComparer.ResolveCanonicalPath(projectFile));
-        }
-
-        projectRelativePath = NormalizeGitPath(projectRelativePath);
+        string fullPath = Path.GetFullPath(projectFile);
+        string canonicalParent = RepositoryPathComparer.ResolveCanonicalPath(
+            Path.GetDirectoryName(fullPath) ?? fullPath);
+        // Containment is decided on canonical paths compared ordinally, like every other repository
+        // check; a relative path could compare the two parents by platform case rules instead. An
+        // entry whose parent sits outside the project root can only be tracked as its resolved target.
+        string trackedProjectFile = RepositoryPathComparer.IsContainedWithin(canonicalProjectRoot, canonicalParent)
+            ? ResolveTrackedProjectEntry(canonicalParent, Path.GetFileName(fullPath))
+            : RepositoryPathComparer.ResolveCanonicalPath(projectFile);
+        string projectRelativePath = NormalizeGitPath(
+            Path.GetRelativePath(canonicalProjectRoot, trackedProjectFile));
         return repository.Pathspec == "."
             ? projectRelativePath
             : repository.Pathspec + "/" + projectRelativePath;
@@ -556,12 +552,8 @@ internal sealed class GitCliVersionControlService :
 
     // The canonical parent plus the entry's own on-disk spelling. The entry itself is deliberately
     // not resolved, because following it would replace a tracked link with its target's name.
-    private static string ResolveTrackedProjectFilePath(string projectFile)
+    private static string ResolveTrackedProjectEntry(string canonicalParent, string name)
     {
-        string fullPath = Path.GetFullPath(projectFile);
-        string name = Path.GetFileName(fullPath);
-        string canonicalParent = RepositoryPathComparer.ResolveCanonicalPath(
-            Path.GetDirectoryName(fullPath) ?? fullPath);
         string candidate = Path.Combine(canonicalParent, name);
         if (!Path.Exists(candidate))
         {

--- a/tests/Beutl.UnitTests/Editor/VersionControl/TrackedProjectFilePathTests.cs
+++ b/tests/Beutl.UnitTests/Editor/VersionControl/TrackedProjectFilePathTests.cs
@@ -1,0 +1,135 @@
+﻿using Beutl.Editor.VersionControl;
+
+namespace Beutl.UnitTests.Editor.VersionControl;
+
+/// <summary>
+/// Git tracks a symbolic link as the link entry itself, so the tracked path of a project file is its own
+/// entry name inside its canonical parent directory. These tests pin that rule for the path
+/// <see cref="GitCliVersionControlService"/> hands to <c>ls-tree</c> and hook-tree mode lookups.
+/// </summary>
+[TestFixture]
+public sealed class TrackedProjectFilePathTests
+{
+    private string _root = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "beutl-tracked-path-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        try
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+    }
+
+    [Test]
+    public void ProjectFileSymbolicLink_KeepsItsOwnEntryName()
+    {
+        RequireSymbolicLinks();
+        string target = Path.Combine(_root, "project-target.bep");
+        File.WriteAllText(target, "{}");
+        string link = Path.Combine(_root, "project.bep");
+        File.CreateSymbolicLink(link, "project-target.bep");
+
+        string tracked = GitCliVersionControlService.GetRepositoryRelativeProjectFilePath(
+            new RepositoryInfo(_root, _root),
+            link);
+
+        Assert.That(tracked, Is.EqualTo("project.bep"));
+    }
+
+    [Test]
+    public void DirectoryAliasInsideTheRoot_ResolvesToTheTrackedDirectory()
+    {
+        RequireSymbolicLinks();
+        string sub = Path.Combine(_root, "sub");
+        Directory.CreateDirectory(sub);
+        File.WriteAllText(Path.Combine(sub, "project.bep"), "{}");
+        Directory.CreateSymbolicLink(Path.Combine(_root, "alias"), "sub");
+
+        // Git stores "alias" as a symbolic-link blob, not a tree, so the only tracked project entry
+        // is sub/project.bep even when the project was opened through the alias.
+        string tracked = GitCliVersionControlService.GetRepositoryRelativeProjectFilePath(
+            new RepositoryInfo(_root, _root),
+            Path.Combine(_root, "alias", "project.bep"));
+
+        Assert.That(tracked, Is.EqualTo("sub/project.bep"));
+    }
+
+    [Test]
+    public void AliasOfTheProjectRoot_YieldsTheRootRelativeName()
+    {
+        RequireSymbolicLinks();
+        File.WriteAllText(Path.Combine(_root, "project.bep"), "{}");
+        string outside = Path.Combine(Path.GetTempPath(), "beutl-tracked-path-alias-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(outside);
+        try
+        {
+            string aliasRoot = Path.Combine(outside, "link");
+            Directory.CreateSymbolicLink(aliasRoot, _root);
+
+            string tracked = GitCliVersionControlService.GetRepositoryRelativeProjectFilePath(
+                new RepositoryInfo(_root, _root),
+                Path.Combine(aliasRoot, "project.bep"));
+
+            Assert.That(tracked, Is.EqualTo("project.bep"));
+        }
+        finally
+        {
+            Directory.Delete(outside, recursive: true);
+        }
+    }
+
+    [Test]
+    public void CallerSpelling_IsNormalizedToTheOnDiskEntry()
+    {
+        string projectFile = Path.Combine(_root, "project.bep");
+        File.WriteAllText(projectFile, "{}");
+        string variant = Path.Combine(_root, "PROJECT.BEP");
+        if (!File.Exists(variant))
+        {
+            Assert.Ignore("This case needs a case-insensitive volume.");
+        }
+
+        string tracked = GitCliVersionControlService.GetRepositoryRelativeProjectFilePath(
+            new RepositoryInfo(_root, _root),
+            variant);
+
+        Assert.That(tracked, Is.EqualTo("project.bep"));
+    }
+
+    [Test]
+    public void NestedProjectRoot_KeepsThePathspecPrefix()
+    {
+        string projectRoot = Path.Combine(_root, "nested");
+        Directory.CreateDirectory(projectRoot);
+        string projectFile = Path.Combine(projectRoot, "project.bep");
+        File.WriteAllText(projectFile, "{}");
+
+        string tracked = GitCliVersionControlService.GetRepositoryRelativeProjectFilePath(
+            new RepositoryInfo(_root, projectRoot),
+            projectFile);
+
+        Assert.That(tracked, Is.EqualTo("nested/project.bep"));
+    }
+
+    private static void RequireSymbolicLinks()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            Assert.Ignore("This regression requires Unix symbolic-link semantics.");
+        }
+    }
+}

--- a/tests/Beutl.UnitTests/Editor/VersionControl/TrackedProjectFilePathTests.cs
+++ b/tests/Beutl.UnitTests/Editor/VersionControl/TrackedProjectFilePathTests.cs
@@ -160,6 +160,7 @@ public sealed class TrackedProjectFilePathTests
         if (OperatingSystem.IsWindows())
         {
             Assert.Ignore("This case needs Unix directory permissions.");
+            return;
         }
 
         string locked = Path.Combine(_root, "locked");

--- a/tests/Beutl.UnitTests/Editor/VersionControl/TrackedProjectFilePathTests.cs
+++ b/tests/Beutl.UnitTests/Editor/VersionControl/TrackedProjectFilePathTests.cs
@@ -130,6 +130,68 @@ public sealed class TrackedProjectFilePathTests
     }
 
     [Test]
+    public void LinkWhoseParentIsOutsideTheRoot_FallsBackToTheResolvedTarget()
+    {
+        RequireSymbolicLinks();
+        File.WriteAllText(Path.Combine(_root, "project.bep"), "{}");
+        string outside = Path.Combine(Path.GetTempPath(), "beutl-tracked-path-outside-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(outside);
+        try
+        {
+            string link = Path.Combine(outside, "link.bep");
+            File.CreateSymbolicLink(link, Path.Combine(_root, "project.bep"));
+
+            // The entry itself lives outside the root, so Git can only be tracking its target.
+            string tracked = GitCliVersionControlService.GetRepositoryRelativeProjectFilePath(
+                new RepositoryInfo(_root, _root),
+                link);
+
+            Assert.That(tracked, Is.EqualTo("project.bep"));
+        }
+        finally
+        {
+            Directory.Delete(outside, recursive: true);
+        }
+    }
+
+    [Test]
+    public void UnlistableParent_KeepsTheCallerSpelling()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            Assert.Ignore("This case needs Unix directory permissions.");
+        }
+
+        string locked = Path.Combine(_root, "locked");
+        Directory.CreateDirectory(locked);
+        string projectFile = Path.Combine(locked, "project.bep");
+        File.WriteAllText(projectFile, "{}");
+        File.SetUnixFileMode(locked, UnixFileMode.UserExecute | UnixFileMode.GroupExecute | UnixFileMode.OtherExecute);
+        try
+        {
+            try
+            {
+                _ = Directory.EnumerateFileSystemEntries(locked).Any();
+                Assert.Ignore("Directory listing was not denied; the test needs an unprivileged user.");
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
+
+            // A traverse-only parent cannot be listed for spelling, so the caller's name is kept.
+            string tracked = GitCliVersionControlService.GetRepositoryRelativeProjectFilePath(
+                new RepositoryInfo(_root, _root),
+                projectFile);
+
+            Assert.That(tracked, Is.EqualTo("locked/project.bep"));
+        }
+        finally
+        {
+            File.SetUnixFileMode(locked, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        }
+    }
+
+    [Test]
     public void NestedProjectRoot_KeepsThePathspecPrefix()
     {
         string projectRoot = Path.Combine(_root, "nested");

--- a/tests/Beutl.UnitTests/Editor/VersionControl/TrackedProjectFilePathTests.cs
+++ b/tests/Beutl.UnitTests/Editor/VersionControl/TrackedProjectFilePathTests.cs
@@ -111,6 +111,25 @@ public sealed class TrackedProjectFilePathTests
     }
 
     [Test]
+    public void AbsentEntry_KeepsTheCallerSpelling()
+    {
+        // A case-sensitive volume can hold PROJECT.BEP while project.bep is what the index tracks; a
+        // caller asking for project.bep must not be redirected to the neighbour.
+        File.WriteAllText(Path.Combine(_root, "PROJECT.BEP"), "{}");
+        string requested = Path.Combine(_root, "project.bep");
+        if (File.Exists(requested))
+        {
+            Assert.Ignore("This case needs a case-sensitive volume.");
+        }
+
+        string tracked = GitCliVersionControlService.GetRepositoryRelativeProjectFilePath(
+            new RepositoryInfo(_root, _root),
+            requested);
+
+        Assert.That(tracked, Is.EqualTo("project.bep"));
+    }
+
+    [Test]
     public void NestedProjectRoot_KeepsThePathspecPrefix()
     {
         string projectRoot = Path.Combine(_root, "nested");

--- a/tests/Beutl.UnitTests/Editor/VersionControl/VersionControlSnapshotScopeTests.cs
+++ b/tests/Beutl.UnitTests/Editor/VersionControl/VersionControlSnapshotScopeTests.cs
@@ -472,6 +472,130 @@ public class VersionControlSnapshotScopeTests : RealGitTestRepository
     }
 
     [Test]
+    public async Task Snapshot_discovers_historical_temporary_paths_by_the_tracked_name_of_a_project_file_symbolic_link()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            Assert.Ignore("This regression requires Unix symbolic-link semantics.");
+        }
+
+        (string projectFile, string sourceFile) = CreateProjectWithTemporarySidecar();
+        string nextSourceFile = Path.Combine(Root, "assets", "next.tmp");
+        await File.WriteAllTextAsync(sourceFile, "old required state\n");
+        await File.WriteAllTextAsync(nextSourceFile, "new required state\n");
+        await WriteProjectFileAsync(".gitignore", "*.tmp\n");
+        await RunGitAsync("add", "-A", "--", ".");
+        await RunGitAsync("add", "-f", "--", "assets/state.tmp");
+        await RunGitAsync("commit", "-m", "saved project baseline");
+        string baseTip = (await RunGitAsync("rev-parse", "HEAD")).Stdout.Trim();
+        string elementFile = Path.Combine(
+            Root,
+            "elements",
+            "11111111111111111111111111111111.belm");
+        string elementJson = await File.ReadAllTextAsync(elementFile);
+        await File.WriteAllTextAsync(
+            elementFile,
+            elementJson.Replace("state.tmp", "next.tmp", StringComparison.Ordinal));
+        // Git tracks the base entry as project.bep even while the working-tree file is a link
+        // to a sibling, so the historical graph must be looked up by that tracked name.
+        var runner = new ProjectFileLinkingRunner(
+            CreateRunner(TimeSpan.FromSeconds(30)),
+            baseTip,
+            projectFile,
+            linkTarget: Path.Combine(Root, "project-target.bep"),
+            restoreBefore: command => IsHistoricalGraphListing(command, baseTip));
+        using var service = new GitCliVersionControlService(
+            CreateInstalledLocator(),
+            Repository,
+            watcher: null,
+            _ => runner,
+            projectFile: projectFile);
+
+        var revision = (CommitRevision.Known)((CommitResult.Committed)await service.CommitAllAsync(
+            "beutl: snapshot on save",
+            SnapshotKind.Save,
+            CancellationToken.None)).Revision;
+        GitCommandResult treeFiles = await RunGitAsync(
+            "ls-tree",
+            "-r",
+            "--name-only",
+            revision.Sha);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(runner.LinkCount, Is.EqualTo(1));
+            Assert.That(runner.RestoreCount, Is.EqualTo(1));
+            Assert.That(
+                runner.Commands.Count(static command => command.Contains("archive")),
+                Is.EqualTo(1));
+            Assert.That(treeFiles.Stdout, Does.Not.Contain("assets/state.tmp\n"));
+            Assert.That(treeFiles.Stdout, Does.Contain("assets/next.tmp\n"));
+            Assert.That(treeFiles.Stdout, Does.Not.Contain("project-target.bep"));
+        });
+    }
+
+    [Test]
+    public async Task Snapshot_does_not_consult_the_historical_graph_of_a_project_file_symbolic_link_that_escapes_the_project_root()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            Assert.Ignore("This regression requires Unix symbolic-link semantics.");
+        }
+
+        (string projectFile, string sourceFile) = CreateProjectWithTemporarySidecar();
+        string nextSourceFile = Path.Combine(Root, "assets", "next.tmp");
+        await File.WriteAllTextAsync(sourceFile, "old required state\n");
+        await File.WriteAllTextAsync(nextSourceFile, "new required state\n");
+        await WriteProjectFileAsync(".gitignore", "*.tmp\n");
+        await RunGitAsync("add", "-A", "--", ".");
+        await RunGitAsync("add", "-f", "--", "assets/state.tmp");
+        await RunGitAsync("commit", "-m", "saved project baseline");
+        string baseTip = (await RunGitAsync("rev-parse", "HEAD")).Stdout.Trim();
+        string elementFile = Path.Combine(
+            Root,
+            "elements",
+            "11111111111111111111111111111111.belm");
+        string elementJson = await File.ReadAllTextAsync(elementFile);
+        await File.WriteAllTextAsync(
+            elementFile,
+            elementJson.Replace("state.tmp", "next.tmp", StringComparison.Ordinal));
+        // Lexically the link is project.bep inside the root, but its resolved target escapes the
+        // root, so canonical containment must stop the discovery before any historical query.
+        var runner = new ProjectFileLinkingRunner(
+            CreateRunner(TimeSpan.FromSeconds(30)),
+            baseTip,
+            projectFile,
+            linkTarget: Path.Combine(CreateTemporaryDirectory(), "project.bep"),
+            restoreBefore: static _ => true);
+        using var service = new GitCliVersionControlService(
+            CreateInstalledLocator(),
+            Repository,
+            watcher: null,
+            _ => runner,
+            projectFile: projectFile);
+
+        var revision = (CommitRevision.Known)((CommitResult.Committed)await service.CommitAllAsync(
+            "beutl: snapshot on save",
+            SnapshotKind.Save,
+            CancellationToken.None)).Revision;
+        GitCommandResult treeFiles = await RunGitAsync(
+            "ls-tree",
+            "-r",
+            "--name-only",
+            revision.Sha);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(runner.LinkCount, Is.EqualTo(1));
+            Assert.That(runner.RestoreCount, Is.EqualTo(1));
+            Assert.That(runner.Commands, Has.None.Matches<IReadOnlyList<string>>(
+                static command => command.Contains("archive")));
+            Assert.That(treeFiles.Stdout, Does.Contain("assets/state.tmp\n"));
+            Assert.That(treeFiles.Stdout, Does.Contain("assets/next.tmp\n"));
+        });
+    }
+
+    [Test]
     public async Task Required_temporary_sidecar_is_not_reported_as_reserved_or_widened_by_scratch_changes()
     {
         (string projectFile, string sourceFile) = CreateProjectWithTemporarySidecar();
@@ -628,6 +752,48 @@ public class VersionControlSnapshotScopeTests : RealGitTestRepository
             Assert.That(exception!.Message, Does.Contain("reserved state directory"));
             Assert.That((RunGitAsync("rev-parse", "HEAD").GetAwaiter().GetResult()).Stdout.Trim(),
                 Is.EqualTo(baseTip));
+        });
+    }
+
+    [Test]
+    public async Task Snapshot_validates_a_hook_tree_by_the_tracked_name_of_a_project_file_symbolic_link()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            Assert.Ignore("This regression requires Unix symbolic-link semantics.");
+        }
+
+        (string projectFile, string sourceFile) = CreateProjectWithTemporarySidecar();
+        await File.WriteAllTextAsync(sourceFile, "required state\n");
+        await RunGitAsync("add", "-A", "--", ".");
+        await RunGitAsync("add", "-f", "--", "assets/state.tmp");
+        await RunGitAsync("commit", "-m", "baseline");
+        // The layout validation rejects an on-disk project-file link before staging, so the
+        // pre-commit hook is the first point where the working-tree project file can become a
+        // link to a sibling. The snapshot tree keeps tracking that entry as project.bep.
+        await WriteHookAsync(
+            "pre-commit",
+            "mv project.bep project-target.bep\n"
+            + "ln -s project-target.bep project.bep\n"
+            + "printf 'hooked\\n' > hook-added.txt\n"
+            + "git add -- hook-added.txt\n");
+        await File.WriteAllTextAsync(sourceFile, "snapshot state\n");
+        using var service = CreateService(projectFile);
+
+        CommitResult result = await service.CommitAllAsync(
+            "beutl: snapshot on save",
+            SnapshotKind.Save,
+            CancellationToken.None);
+
+        GitCommandResult projectEntry = await RunGitAsync("ls-tree", "HEAD", "--", "project.bep");
+        GitCommandResult treeFiles = await RunGitAsync("ls-tree", "-r", "--name-only", "HEAD");
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.TypeOf<CommitResult.Committed>());
+            Assert.That(new FileInfo(projectFile).LinkTarget, Is.EqualTo("project-target.bep"));
+            Assert.That(projectEntry.Stdout, Does.StartWith("100644 blob "));
+            Assert.That(treeFiles.Stdout, Does.Contain("hook-added.txt\n"));
+            Assert.That(treeFiles.Stdout, Does.Not.Contain("project-target.bep"));
         });
     }
 
@@ -957,6 +1123,12 @@ public class VersionControlSnapshotScopeTests : RealGitTestRepository
         }
     }
 
+    private static bool IsHistoricalGraphListing(IReadOnlyList<string> command, string commit)
+        => command.Count > 0
+           && command[0] == "ls-tree"
+           && command.Contains("--long")
+           && command.Contains(commit);
+
     private sealed class RecordingGitRunner(IGitCliRunner inner) : IGitCliRunner
     {
         public List<IReadOnlyList<string>> Commands { get; } = [];
@@ -977,6 +1149,66 @@ public class VersionControlSnapshotScopeTests : RealGitTestRepository
                 options,
                 cancellationToken,
                 stderrProgress);
+        }
+
+        public RepositoryLockInfo? GetRecoverableRepositoryLock(RepositoryInfo repository)
+            => inner.GetRecoverableRepositoryLock(repository);
+
+        public bool RemoveRecoverableRepositoryLock(
+            RepositoryInfo repository,
+            RepositoryLockInfo lockInfo)
+            => inner.RemoveRecoverableRepositoryLock(repository, lockInfo);
+    }
+    // Swaps the project file for a symbolic link right after the snapshot index is seeded from
+    // the base commit, and swaps the regular file back before the first command that matches
+    // restoreBefore. The layout validation rejects an on-disk project-file link, so this is the
+    // only window in which the historical graph discovery can observe one.
+    private sealed class ProjectFileLinkingRunner(
+        IGitCliRunner inner,
+        string baseCommit,
+        string projectFile,
+        string linkTarget,
+        Func<IReadOnlyList<string>, bool> restoreBefore) : IGitCliRunner
+    {
+        public List<IReadOnlyList<string>> Commands { get; } = [];
+
+        public int LinkCount { get; private set; }
+
+        public int RestoreCount { get; private set; }
+
+        public bool HasActiveProcess => inner.HasActiveProcess;
+
+        public async Task<GitCommandResult> RunAsync(
+            RepositoryInfo repository,
+            IReadOnlyList<string> arguments,
+            GitCommandOptions options,
+            CancellationToken cancellationToken,
+            IProgress<string>? stderrProgress = null)
+        {
+            Commands.Add([.. arguments]);
+            if (LinkCount == 1 && RestoreCount == 0 && restoreBefore(arguments))
+            {
+                File.Delete(projectFile);
+                File.Move(linkTarget, projectFile);
+                RestoreCount++;
+            }
+
+            GitCommandResult result = await inner.RunAsync(
+                repository,
+                arguments,
+                options,
+                cancellationToken,
+                stderrProgress);
+            if (LinkCount == 0 && arguments is ["read-tree", var commit] && commit == baseCommit)
+            {
+                File.Move(projectFile, linkTarget);
+                File.CreateSymbolicLink(
+                    projectFile,
+                    Path.GetRelativePath(Path.GetDirectoryName(projectFile)!, linkTarget));
+                LinkCount++;
+            }
+
+            return result;
         }
 
         public RepositoryLockInfo? GetRecoverableRepositoryLock(RepositoryInfo repository)


### PR DESCRIPTION
## Description
- Git tree lookups derived the project file's repository-relative path from its resolved canonical target. When the project file is a symbolic link to another file inside the project directory, hook-tree validation and historical temporary-file discovery queried the target's name while Git tracks the link under its lexical name.
- `GetRepositoryRelativeProjectFilePath` now derives the tracked path from the entry's own name inside its **canonical parent directory**: a link in the final component keeps the name Git stores, while an alias directory above it resolves to the real tree (Git stores a directory link as a `120000` blob, so `alias/project.bep` is never a tracked entry). The entry's own spelling is normalized to the on-disk directory entry, so a project opened as `PROJECT.BEP` on a case-insensitive volume still looks up `project.bep`. If the entry's parent sits outside the project root, the lookup falls back to the fully resolved path.
- The canonical `IsContainedWithin` guards at both call sites are unchanged, so a project file whose target escapes the project root is still rejected. The pending-pull recovery path is not touched.

## Affected areas
- [ ] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [x] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [ ] Build / CI / docs only

## Breaking changes
None.

## Test plan
- `tests/Beutl.UnitTests/Editor/VersionControl/VersionControlSnapshotScopeTests.cs`: three end-to-end regression tests. Hook-tree validation and historical `.tmp` discovery use the tracked (link) name of a project-file symlink; a symlink whose target escapes the project root is still not consulted. They `Assert.Ignore` on Windows like the existing symlink tests.
- `tests/Beutl.UnitTests/Editor/VersionControl/TrackedProjectFilePathTests.cs`: eight focused tests on the helper. A project-file link keeps its own name; an alias directory inside the root resolves to `sub/project.bep`; an alias of the root outside it yields the root-relative name; a link whose parent is outside the root falls back to its resolved target; a case-variant caller spelling is normalized to the on-disk entry (skipped on case-sensitive volumes); an absent entry keeps the caller's spelling instead of a case-insensitive neighbour (runs only on case-sensitive volumes, so it is skipped on macOS and exercised on the Linux CI job); a traverse-only parent that cannot be listed keeps the caller's spelling; a nested project root keeps its pathspec prefix.
- Negative controls: with the production change reverted, the two tracked-name end-to-end tests fail and the containment test passes. With the earlier lexical-ancestor walk, the alias-directory and case-variant tests fail (`alias/project.bep`, `PROJECT.BEP`); with the canonical-parent derivation all five pass.
- `GitCliVersionControlServiceTests` (245) and `VersionControlSnapshotScopeTests` (22) pass on macOS against the canonical-parent derivation.

## Fixed issues / References
- Closes #2332


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved version-control handling for project files accessed through symbolic links, directory aliases, case variations, and nested project roots.
  * Preserved tracked file names during snapshot recovery and validation.
  * Avoided historical graph lookups when a symbolic-link target is outside the project root.
  * Improved handling for missing or inaccessible parent directories.

* **Tests**
  * Added regression coverage for symbolic-link paths, aliases, missing entries, inaccessible directories, nested roots, and platform-specific path behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->