### PR TITLE
fix: dispose the targets EffectTargets drops

### DIFF
--- a/src/Beutl.Engine/Graphics/FilterEffects/CustomFilterEffectContext.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/CustomFilterEffectContext.cs
@@ -116,6 +116,11 @@ public class CustomFilterEffectContext
             _drawableBrushMaterializer,
             _renderTargetLeaseSession);
 
+    /// <summary>Visits every target in place.</summary>
+    /// <remarks>
+    /// The callback sees the live target and does not own it: it must neither dispose it nor keep it past the
+    /// call. <see cref="Targets"/> is unchanged afterwards.
+    /// </remarks>
     public void ForEach(Action<int, EffectTarget> action)
     {
         for (int i = 0; i < Targets.Count; i++)
@@ -125,6 +130,14 @@ public class CustomFilterEffectContext
         }
     }
 
+    /// <summary>Replaces each target with the one the callback returns.</summary>
+    /// <remarks>
+    /// The callback receives the live target. Returning that same instance keeps it; returning a different
+    /// instance transfers ownership of the result to <see cref="Targets"/> and disposes the original, so the
+    /// callback must not use the original afterwards and must not dispose the replacement itself. This is the
+    /// disposal a hand-written loop over the <see cref="EffectTargets"/> indexer would have to perform itself,
+    /// which is why this overload is preferable to such a loop.
+    /// </remarks>
     public void ForEach(Func<int, EffectTarget, EffectTarget> action)
     {
         for (int i = 0; i < Targets.Count; i++)
@@ -139,6 +152,22 @@ public class CustomFilterEffectContext
         }
     }
 
+    /// <summary>Replaces each target with zero or more targets the callback returns.</summary>
+    /// <remarks>
+    /// <para>
+    /// This overload's ownership contract differs from the single-target one. The callback receives an
+    /// <see cref="EffectTarget.Clone"/> of the target rather than the live instance, and the original is
+    /// disposed unconditionally once the callback returns, whatever the callback returned. A clone of a
+    /// pooled lease retains that lease and survives the original's disposal; a clone of a bare
+    /// <see cref="Rendering.RenderTarget"/> shares that instance, which the original's disposal releases.
+    /// </para>
+    /// <para>
+    /// Ownership of every target in the returned list transfers to <see cref="Targets"/>; the returned
+    /// <see cref="EffectTargets"/> container itself is not disposed. Changing a callback's return type from
+    /// <see cref="EffectTarget"/> to <see cref="EffectTargets"/> therefore changes both what it is handed and
+    /// what is destroyed.
+    /// </para>
+    /// </remarks>
     public void ForEach(Func<int, EffectTarget, EffectTargets> action)
     {
         for (int i = 0; i < Targets.Count; i++)

--- a/src/Beutl.Engine/Graphics/FilterEffects/CustomFilterEffectContext.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/CustomFilterEffectContext.cs
@@ -161,8 +161,10 @@ public class CustomFilterEffectContext
     /// <para>
     /// Every target in the returned list is moved into <see cref="Targets"/>, which then owns it, and the
     /// returned <see cref="EffectTargets"/> container is left empty, so disposing that container afterwards
-    /// releases nothing. Changing a callback's return type from <see cref="EffectTarget"/> to
-    /// <see cref="EffectTargets"/> therefore changes both what it is handed and what is destroyed.
+    /// releases nothing. The callback must return a list of its own: returning <see cref="Targets"/> itself
+    /// throws <see cref="InvalidOperationException"/> before anything is detached. Changing a callback's
+    /// return type from <see cref="EffectTarget"/> to <see cref="EffectTargets"/> therefore changes both what
+    /// it is handed and what is destroyed.
     /// </para>
     /// </remarks>
     public void ForEach(Func<int, EffectTarget, EffectTargets> action)
@@ -172,6 +174,15 @@ public class CustomFilterEffectContext
             EffectTarget original = Targets[i];
             EffectTarget clone = original.Clone();
             EffectTargets newTargets = action(i, clone);
+            if (ReferenceEquals(newTargets, Targets))
+            {
+                // Moving a list into itself would detach and re-insert the same elements; refuse before
+                // touching the list, releasing the clone the callback was handed unless it stored it.
+                if (!ReferenceEquals(clone, original) && !Targets.Contains(clone))
+                    clone.Dispose();
+                throw new InvalidOperationException(
+                    "The callback must return a list of its own, not the context's Targets.");
+            }
 
             // The callback only ever saw the clone, so RemoveAt can dispose the original. An empty target
             // clones as itself and may now sit in newTargets, so that one is detached instead.

--- a/src/Beutl.Engine/Graphics/FilterEffects/CustomFilterEffectContext.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/CustomFilterEffectContext.cs
@@ -133,23 +133,16 @@ public class CustomFilterEffectContext
 
     /// <summary>Replaces each target with the one the callback returns.</summary>
     /// <remarks>
-    /// The callback receives the live target. Returning that same instance keeps it; returning a different
-    /// instance transfers ownership of the result to <see cref="Targets"/> and disposes the original, so the
-    /// callback must not use the original afterwards and must not dispose the replacement itself. This is the
-    /// disposal a hand-written loop over the <see cref="EffectTargets"/> indexer would have to perform itself,
-    /// which is why this overload is preferable to such a loop.
+    /// The callback receives the live target and must not dispose it, whether it returns it unchanged or
+    /// returns a replacement. Returning that same instance keeps it; returning a different instance transfers
+    /// ownership of the result to <see cref="Targets"/>, whose indexer disposes the original, so the callback
+    /// must not use the original afterwards and must not dispose the replacement itself.
     /// </remarks>
     public void ForEach(Func<int, EffectTarget, EffectTarget> action)
     {
         for (int i = 0; i < Targets.Count; i++)
         {
-            EffectTarget target = Targets[i];
-            EffectTarget newTarget = action(i, target);
-            if (newTarget != target)
-            {
-                target.Dispose();
-                Targets[i] = newTarget;
-            }
+            Targets[i] = action(i, Targets[i]);
         }
     }
 
@@ -158,28 +151,43 @@ public class CustomFilterEffectContext
     /// <para>
     /// This overload's ownership contract differs from the single-target one. The callback receives an
     /// <see cref="EffectTarget.Clone"/> of the target rather than the live instance, and the original is
-    /// disposed unconditionally once the callback returns, whatever the callback returned. The clone holds
-    /// its own retained reference to the original's surface or pooled lease, so it stays valid after the
-    /// original is disposed, and that reference is the callback's to release: return the clone in the list
-    /// or dispose it. A clone that is neither returned nor disposed leaks its reference.
+    /// disposed once the callback returns, whatever the callback returned. The clone holds its own retained
+    /// reference to the original's surface or pooled lease, so it stays valid after the original is disposed,
+    /// and that reference is the callback's to release: return the clone in the list or dispose it. A clone
+    /// that is neither returned nor disposed leaks its reference. An empty target has nothing to clone, so
+    /// <see cref="EffectTarget.Clone"/> hands back the target itself; that instance is detached rather than
+    /// disposed here, so returning it in the list is safe too.
     /// </para>
     /// <para>
-    /// Ownership of every target in the returned list transfers to <see cref="Targets"/>; the returned
-    /// <see cref="EffectTargets"/> container itself is not disposed. Changing a callback's return type from
-    /// <see cref="EffectTarget"/> to <see cref="EffectTargets"/> therefore changes both what it is handed and
-    /// what is destroyed.
+    /// Every target in the returned list is moved into <see cref="Targets"/>, which then owns it, and the
+    /// returned <see cref="EffectTargets"/> container is left empty, so disposing that container afterwards
+    /// releases nothing. Changing a callback's return type from <see cref="EffectTarget"/> to
+    /// <see cref="EffectTargets"/> therefore changes both what it is handed and what is destroyed.
     /// </para>
     /// </remarks>
     public void ForEach(Func<int, EffectTarget, EffectTargets> action)
     {
         for (int i = 0; i < Targets.Count; i++)
         {
-            using EffectTarget target = Targets[i];
-            EffectTargets newTargets = action(i, target.Clone());
+            EffectTarget original = Targets[i];
+            EffectTarget clone = original.Clone();
+            EffectTargets newTargets = action(i, clone);
 
-            Targets.RemoveAt(i);
-            Targets.InsertRange(i, newTargets);
-            i += newTargets.Count - 1;
+            // The callback only ever saw the clone, so RemoveAt can dispose the original. An empty target
+            // clones as itself and may now sit in newTargets, so that one is detached instead.
+            if (ReferenceEquals(clone, original))
+                Targets.DetachAt(i);
+            else
+                Targets.RemoveAt(i);
+
+            int inserted = 0;
+            while (newTargets.Count > 0)
+            {
+                Targets.Insert(i + inserted, newTargets.DetachAt(0));
+                inserted++;
+            }
+
+            i += inserted - 1;
         }
     }
 

--- a/src/Beutl.Engine/Graphics/FilterEffects/CustomFilterEffectContext.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/CustomFilterEffectContext.cs
@@ -119,7 +119,8 @@ public class CustomFilterEffectContext
     /// <summary>Visits every target in place.</summary>
     /// <remarks>
     /// The callback sees the live target and does not own it: it must neither dispose it nor keep it past the
-    /// call. <see cref="Targets"/> is unchanged afterwards.
+    /// call. It may mutate the target it is handed (for example <see cref="EffectTarget.Bounds"/>); what stays
+    /// unchanged is the membership and order of <see cref="Targets"/>.
     /// </remarks>
     public void ForEach(Action<int, EffectTarget> action)
     {
@@ -157,9 +158,10 @@ public class CustomFilterEffectContext
     /// <para>
     /// This overload's ownership contract differs from the single-target one. The callback receives an
     /// <see cref="EffectTarget.Clone"/> of the target rather than the live instance, and the original is
-    /// disposed unconditionally once the callback returns, whatever the callback returned. A clone of a
-    /// pooled lease retains that lease and survives the original's disposal; a clone of a bare
-    /// <see cref="Rendering.RenderTarget"/> shares that instance, which the original's disposal releases.
+    /// disposed unconditionally once the callback returns, whatever the callback returned. The clone holds
+    /// its own retained reference to the original's surface or pooled lease, so it stays valid after the
+    /// original is disposed, and that reference is the callback's to release: return the clone in the list
+    /// or dispose it. A clone that is neither returned nor disposed leaks its reference.
     /// </para>
     /// <para>
     /// Ownership of every target in the returned list transfers to <see cref="Targets"/>; the returned

--- a/src/Beutl.Engine/Graphics/FilterEffects/CustomFilterEffectContext.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/CustomFilterEffectContext.cs
@@ -191,13 +191,9 @@ public class CustomFilterEffectContext
             else
                 Targets.RemoveAt(i);
 
-            int inserted = 0;
-            while (newTargets.Count > 0)
-            {
-                Targets.Insert(i + inserted, newTargets.DetachAt(0));
-                inserted++;
-            }
-
+            // InsertRange moves the targets out of the callback's list in one step and leaves it empty.
+            int inserted = newTargets.Count;
+            Targets.InsertRange(i, newTargets);
             i += inserted - 1;
         }
     }

--- a/src/Beutl.Engine/Graphics/FilterEffects/EffectTargets.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/EffectTargets.cs
@@ -126,7 +126,8 @@ public sealed class EffectTargets : IList<EffectTarget>, IDisposable
     /// <remarks>
     /// When <paramref name="collection"/> is another <see cref="EffectTargets"/>, its targets are moved and
     /// it is left empty, so one list owns each target and disposing the source afterwards releases nothing.
-    /// Inserting a list into itself throws <see cref="InvalidOperationException"/>.
+    /// Any other sequence is enumerated completely before the list changes, and a target this list already
+    /// owns is refused with <see cref="InvalidOperationException"/>, as is inserting a list into itself.
     /// </remarks>
     public void InsertRange(int index, IEnumerable<EffectTarget> collection)
     {
@@ -141,7 +142,16 @@ public sealed class EffectTargets : IList<EffectTarget>, IDisposable
             return;
         }
 
-        _targets.InsertRange(index, collection);
+        // Materialize first so a deferred query over this list never observes the insertion, then refuse a
+        // target already held here: one element in two slots would be disposed by whichever slot goes first.
+        EffectTarget[] items = collection.ToArray();
+        foreach (EffectTarget item in items)
+        {
+            if (_targets.Contains(item))
+                throw new InvalidOperationException("The list already owns one of the targets being inserted.");
+        }
+
+        _targets.InsertRange(index, items);
     }
 
     /// <summary>Removes <paramref name="item"/> and disposes it.</summary>

--- a/src/Beutl.Engine/Graphics/FilterEffects/EffectTargets.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/EffectTargets.cs
@@ -2,14 +2,37 @@
 
 namespace Beutl.Graphics.Effects;
 
+/// <summary>
+/// The intermediate targets a custom effect reads and writes. The list owns every <see cref="EffectTarget"/>
+/// it holds: <see cref="Dispose"/> releases each element's render target or pooled lease.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Ownership follows the list, not the element. It transfers into the list through <see cref="Add"/>,
+/// <see cref="AddRange"/>, <see cref="Insert"/> and <see cref="InsertRange"/>, and it transfers back to the
+/// caller through every member that drops an element without disposing it: the indexer setter,
+/// <see cref="Clear"/>, <see cref="Remove"/> and <see cref="RemoveAt"/>. An element removed that way keeps its
+/// render target allocated until whoever now holds it disposes it.
+/// </para>
+/// <para>
+/// A hand-written <c>targets[i] = replacement;</c> therefore leaks the previous element unless the caller
+/// disposes it first. <see cref="CustomFilterEffectContext.ForEach(Func{int, EffectTarget, EffectTarget})"/>
+/// does that bookkeeping and is the intended way to replace targets in place.
+/// </para>
+/// </remarks>
 public sealed class EffectTargets : IList<EffectTarget>, IDisposable
 {
     private readonly List<EffectTarget> _targets = [];
 
+    /// <summary>Creates an empty list.</summary>
     public EffectTargets()
     {
     }
 
+    /// <summary>
+    /// Creates a list holding an <see cref="EffectTarget.Clone"/> of every element of <paramref name="obj"/>.
+    /// The clones belong to the new list; <paramref name="obj"/> keeps its own elements.
+    /// </summary>
     public EffectTargets(EffectTargets obj)
     {
         foreach (EffectTarget item in obj)
@@ -18,12 +41,20 @@ public sealed class EffectTargets : IList<EffectTarget>, IDisposable
         }
     }
 
+    /// <summary>Gets or sets the target at <paramref name="index"/>.</summary>
+    /// <remarks>
+    /// Setting takes ownership of the new value and does <b>not</b> dispose the previous element, which stays
+    /// allocated until the caller disposes it. Prefer
+    /// <see cref="CustomFilterEffectContext.ForEach(Func{int, EffectTarget, EffectTarget})"/>, which disposes
+    /// a replaced target for you.
+    /// </remarks>
     public EffectTarget this[int index] { get => ((IList<EffectTarget>)_targets)[index]; set => ((IList<EffectTarget>)_targets)[index] = value; }
 
     public int Count => ((ICollection<EffectTarget>)_targets).Count;
 
     public bool IsReadOnly => ((ICollection<EffectTarget>)_targets).IsReadOnly;
 
+    /// <summary>Unions the <see cref="EffectTarget.Bounds"/> of every element.</summary>
     public Rect CalculateBounds()
     {
         Rect bounds = default;
@@ -32,9 +63,17 @@ public sealed class EffectTargets : IList<EffectTarget>, IDisposable
         return bounds;
     }
 
+    /// <summary>
+    /// Creates a list holding an <see cref="EffectTarget.Clone"/> of every element. The clones belong to the
+    /// new list; this list keeps its own elements.
+    /// </summary>
     public EffectTargets Clone() => new(this);
+    /// <summary>Appends <paramref name="item"/> and takes ownership of it.</summary>
     public void Add(EffectTarget item) => ((ICollection<EffectTarget>)_targets).Add(item);
+    /// <summary>Appends every target in <paramref name="collection"/> and takes ownership of them.</summary>
     public void AddRange(IEnumerable<EffectTarget> collection) => _targets.AddRange(collection);
+    /// <summary>Removes every element without disposing any of them.</summary>
+    /// <remarks>Ownership of the removed elements returns to the caller. Use <see cref="Dispose"/> to release them instead.</remarks>
     public void Clear() => ((ICollection<EffectTarget>)_targets).Clear();
     public bool Contains(EffectTarget item) => ((ICollection<EffectTarget>)_targets).Contains(item);
     public void CopyTo(EffectTarget[] array, int arrayIndex) => ((ICollection<EffectTarget>)_targets).CopyTo(array, arrayIndex);
@@ -49,11 +88,18 @@ public sealed class EffectTargets : IList<EffectTarget>, IDisposable
     IEnumerator<EffectTarget> IEnumerable<EffectTarget>.GetEnumerator()
         => ((IEnumerable<EffectTarget>)_targets).GetEnumerator();
     public int IndexOf(EffectTarget item) => ((IList<EffectTarget>)_targets).IndexOf(item);
+    /// <summary>Inserts <paramref name="item"/> at <paramref name="index"/> and takes ownership of it.</summary>
     public void Insert(int index, EffectTarget item) => _targets.Insert(index, item);
+    /// <summary>Inserts every target in <paramref name="collection"/> at <paramref name="index"/> and takes ownership of them.</summary>
     public void InsertRange(int index, IEnumerable<EffectTarget> collection) => _targets.InsertRange(index, collection);
+    /// <summary>Removes <paramref name="item"/> without disposing it.</summary>
+    /// <remarks>Ownership of <paramref name="item"/> returns to the caller, who must dispose it.</remarks>
     public bool Remove(EffectTarget item) => ((ICollection<EffectTarget>)_targets).Remove(item);
+    /// <summary>Removes the element at <paramref name="index"/> without disposing it.</summary>
+    /// <remarks>Ownership of the removed element returns to the caller, who must dispose it.</remarks>
     public void RemoveAt(int index) => ((IList<EffectTarget>)_targets).RemoveAt(index);
     IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable)_targets).GetEnumerator();
+    /// <summary>Disposes every element, last to first, and empties the list.</summary>
     public void Dispose()
     {
         for (int i = _targets.Count - 1; i >= 0; i--)

--- a/src/Beutl.Engine/Graphics/FilterEffects/EffectTargets.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/EffectTargets.cs
@@ -155,6 +155,11 @@ public sealed class EffectTargets : IList<EffectTarget>, IDisposable
 
         if (collection is EffectTargets source)
         {
+            // A target held by both lists would end up in two slots here, so the move is vetted like any
+            // other insertion before anything changes hands.
+            foreach (EffectTarget item in source._targets)
+                ThrowIfOwned(item);
+
             _targets.InsertRange(index, source._targets);
             source._targets.Clear();
             return;

--- a/src/Beutl.Engine/Graphics/FilterEffects/EffectTargets.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/EffectTargets.cs
@@ -9,10 +9,11 @@ namespace Beutl.Graphics.Effects;
 /// <remarks>
 /// <para>
 /// Ownership follows the list, not the element. It transfers into the list through <see cref="Add"/>,
-/// <see cref="AddRange"/>, <see cref="Insert"/> and <see cref="InsertRange"/>, and it transfers back to the
-/// caller through every member that drops an element without disposing it: the indexer setter,
-/// <see cref="Clear"/>, <see cref="Remove"/> and <see cref="RemoveAt"/>. An element removed that way keeps its
-/// render target allocated until whoever now holds it disposes it.
+/// <see cref="AddRange"/>, <see cref="Insert"/> and <see cref="InsertRange"/>. The members that drop an
+/// element, the indexer setter, <see cref="Clear"/>, <see cref="Remove"/> and <see cref="RemoveAt"/>, neither
+/// dispose it nor hand it back: the element keeps its render target allocated, and only a caller that still
+/// holds its own reference can dispose it. Remove an element without such a reference and its render target
+/// is unreachable and leaks.
 /// </para>
 /// <para>
 /// A hand-written <c>targets[i] = replacement;</c> therefore leaks the previous element unless the caller
@@ -73,7 +74,10 @@ public sealed class EffectTargets : IList<EffectTarget>, IDisposable
     /// <summary>Appends every target in <paramref name="collection"/> and takes ownership of them.</summary>
     public void AddRange(IEnumerable<EffectTarget> collection) => _targets.AddRange(collection);
     /// <summary>Removes every element without disposing any of them.</summary>
-    /// <remarks>Ownership of the removed elements returns to the caller. Use <see cref="Dispose"/> to release them instead.</remarks>
+    /// <remarks>
+    /// The removed elements are not handed back, so the caller must already hold references to dispose them.
+    /// Use <see cref="Dispose"/> to release them instead.
+    /// </remarks>
     public void Clear() => ((ICollection<EffectTarget>)_targets).Clear();
     public bool Contains(EffectTarget item) => ((ICollection<EffectTarget>)_targets).Contains(item);
     public void CopyTo(EffectTarget[] array, int arrayIndex) => ((ICollection<EffectTarget>)_targets).CopyTo(array, arrayIndex);
@@ -93,10 +97,12 @@ public sealed class EffectTargets : IList<EffectTarget>, IDisposable
     /// <summary>Inserts every target in <paramref name="collection"/> at <paramref name="index"/> and takes ownership of them.</summary>
     public void InsertRange(int index, IEnumerable<EffectTarget> collection) => _targets.InsertRange(index, collection);
     /// <summary>Removes <paramref name="item"/> without disposing it.</summary>
-    /// <remarks>Ownership of <paramref name="item"/> returns to the caller, who must dispose it.</remarks>
+    /// <remarks>The caller holds <paramref name="item"/> and is responsible for disposing it.</remarks>
     public bool Remove(EffectTarget item) => ((ICollection<EffectTarget>)_targets).Remove(item);
     /// <summary>Removes the element at <paramref name="index"/> without disposing it.</summary>
-    /// <remarks>Ownership of the removed element returns to the caller, who must dispose it.</remarks>
+    /// <remarks>
+    /// The removed element is not handed back; read it with the indexer first and dispose it, or it leaks.
+    /// </remarks>
     public void RemoveAt(int index) => ((IList<EffectTarget>)_targets).RemoveAt(index);
     IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable)_targets).GetEnumerator();
     /// <summary>Disposes every element, last to first, and empties the list.</summary>

--- a/src/Beutl.Engine/Graphics/FilterEffects/EffectTargets.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/EffectTargets.cs
@@ -64,6 +64,7 @@ public sealed class EffectTargets : IList<EffectTarget>, IDisposable
             if (ReferenceEquals(previous, value))
                 return;
 
+            ThrowIfOwned(value);
             _targets[index] = value;
             previous.Dispose();
         }
@@ -88,7 +89,13 @@ public sealed class EffectTargets : IList<EffectTarget>, IDisposable
     /// </summary>
     public EffectTargets Clone() => new(this);
     /// <summary>Appends <paramref name="item"/> and takes ownership of it.</summary>
-    public void Add(EffectTarget item) => _targets.Add(item);
+    /// <exception cref="InvalidOperationException">The list already holds <paramref name="item"/>.</exception>
+    public void Add(EffectTarget item)
+    {
+        ArgumentNullException.ThrowIfNull(item);
+        ThrowIfOwned(item);
+        _targets.Add(item);
+    }
     /// <summary>Appends every target in <paramref name="collection"/> and takes ownership of them.</summary>
     /// <remarks>
     /// When <paramref name="collection"/> is another <see cref="EffectTargets"/>, its targets are moved and
@@ -121,17 +128,28 @@ public sealed class EffectTargets : IList<EffectTarget>, IDisposable
         => ((IEnumerable<EffectTarget>)_targets).GetEnumerator();
     public int IndexOf(EffectTarget item) => _targets.IndexOf(item);
     /// <summary>Inserts <paramref name="item"/> at <paramref name="index"/> and takes ownership of it.</summary>
-    public void Insert(int index, EffectTarget item) => _targets.Insert(index, item);
+    /// <exception cref="InvalidOperationException">The list already holds <paramref name="item"/>.</exception>
+    public void Insert(int index, EffectTarget item)
+    {
+        ArgumentNullException.ThrowIfNull(item);
+        ArgumentOutOfRangeException.ThrowIfNegative(index);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(index, _targets.Count);
+        ThrowIfOwned(item);
+        _targets.Insert(index, item);
+    }
     /// <summary>Inserts every target in <paramref name="collection"/> at <paramref name="index"/> and takes ownership of them.</summary>
     /// <remarks>
     /// When <paramref name="collection"/> is another <see cref="EffectTargets"/>, its targets are moved and
     /// it is left empty, so one list owns each target and disposing the source afterwards releases nothing.
-    /// Any other sequence is enumerated completely before the list changes, and a target this list already
-    /// owns is refused with <see cref="InvalidOperationException"/>, as is inserting a list into itself.
+    /// Any other sequence is enumerated completely before the list changes, after <paramref name="index"/>
+    /// has been validated, and a target this list already owns or that the sequence yields twice is refused
+    /// with <see cref="InvalidOperationException"/>, as is inserting a list into itself.
     /// </remarks>
     public void InsertRange(int index, IEnumerable<EffectTarget> collection)
     {
         ArgumentNullException.ThrowIfNull(collection);
+        ArgumentOutOfRangeException.ThrowIfNegative(index);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(index, _targets.Count);
         if (ReferenceEquals(collection, this))
             throw new InvalidOperationException("A target list cannot be inserted into itself.");
 
@@ -143,15 +161,24 @@ public sealed class EffectTargets : IList<EffectTarget>, IDisposable
         }
 
         // Materialize first so a deferred query over this list never observes the insertion, then refuse a
-        // target already held here: one element in two slots would be disposed by whichever slot goes first.
+        // target already held here or repeated in the sequence: one element in two slots would be disposed
+        // by whichever slot goes first.
         EffectTarget[] items = collection.ToArray();
+        var owned = new HashSet<EffectTarget>(_targets, ReferenceEqualityComparer.Instance);
         foreach (EffectTarget item in items)
         {
-            if (_targets.Contains(item))
+            ArgumentNullException.ThrowIfNull(item, nameof(collection));
+            if (!owned.Add(item))
                 throw new InvalidOperationException("The list already owns one of the targets being inserted.");
         }
 
         _targets.InsertRange(index, items);
+    }
+
+    private void ThrowIfOwned(EffectTarget item)
+    {
+        if (_targets.Contains(item))
+            throw new InvalidOperationException("The list already owns this target.");
     }
 
     /// <summary>Removes <paramref name="item"/> and disposes it.</summary>

--- a/src/Beutl.Engine/Graphics/FilterEffects/EffectTargets.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/EffectTargets.cs
@@ -4,21 +4,23 @@ namespace Beutl.Graphics.Effects;
 
 /// <summary>
 /// The intermediate targets a custom effect reads and writes. The list owns every <see cref="EffectTarget"/>
-/// it holds: <see cref="Dispose"/> releases each element's render target or pooled lease.
+/// it holds, and every member that drops an element releases that element's render target or pooled lease.
 /// </summary>
 /// <remarks>
 /// <para>
 /// Ownership follows the list, not the element. It transfers into the list through <see cref="Add"/>,
-/// <see cref="AddRange"/>, <see cref="Insert"/> and <see cref="InsertRange"/>. The members that drop an
-/// element, the indexer setter, <see cref="Clear"/>, <see cref="Remove"/> and <see cref="RemoveAt"/>, neither
-/// dispose it nor hand it back: the element keeps its render target allocated, and only a caller that still
-/// holds its own reference can dispose it. Remove an element without such a reference and its render target
-/// is unreachable and leaks.
+/// <see cref="AddRange"/>, <see cref="Insert"/>, <see cref="InsertRange"/> and the indexer setter, and it
+/// leaves the list alive only through <see cref="DetachAt"/>. Every other member that drops an element disposes
+/// it: the indexer setter disposes the element it replaces unless it is the same instance, <see cref="Remove"/>
+/// and <see cref="RemoveAt"/> dispose the element they remove, and <see cref="Clear"/> and <see cref="Dispose"/>
+/// dispose them all.
 /// </para>
 /// <para>
-/// A hand-written <c>targets[i] = replacement;</c> therefore leaks the previous element unless the caller
-/// disposes it first. <see cref="CustomFilterEffectContext.ForEach(Func{int, EffectTarget, EffectTarget})"/>
-/// does that bookkeeping and is the intended way to replace targets in place.
+/// A hand-written <c>targets[i] = replacement;</c> is therefore safe, and an explicit <c>Dispose()</c> of the
+/// previous element around it is redundant but harmless, because <see cref="EffectTarget.Dispose"/> may be
+/// called more than once. Hold a target in one list at a time: adding the same instance twice makes the first
+/// removal dispose the other slot's element as well. The <c>CustomFilterEffectContext.ForEach</c> overloads
+/// build on these rules and are the convenient way to replace or expand targets in place.
 /// </para>
 /// </remarks>
 public sealed class EffectTargets : IList<EffectTarget>, IDisposable
@@ -34,6 +36,11 @@ public sealed class EffectTargets : IList<EffectTarget>, IDisposable
     /// Creates a list holding an <see cref="EffectTarget.Clone"/> of every element of <paramref name="obj"/>.
     /// The clones belong to the new list; <paramref name="obj"/> keeps its own elements.
     /// </summary>
+    /// <remarks>
+    /// An empty element has nothing to clone, so <see cref="EffectTarget.Clone"/> returns that element itself
+    /// and both lists hold the same instance. Disposing it through either list releases nothing and only resets
+    /// its bounds.
+    /// </remarks>
     public EffectTargets(EffectTargets obj)
     {
         foreach (EffectTarget item in obj)
@@ -44,16 +51,27 @@ public sealed class EffectTargets : IList<EffectTarget>, IDisposable
 
     /// <summary>Gets or sets the target at <paramref name="index"/>.</summary>
     /// <remarks>
-    /// Setting takes ownership of the new value and does <b>not</b> dispose the previous element, which stays
-    /// allocated until the caller disposes it. Prefer
-    /// <see cref="CustomFilterEffectContext.ForEach(Func{int, EffectTarget, EffectTarget})"/>, which disposes
-    /// a replaced target for you.
+    /// Setting takes ownership of the new value and disposes the element it replaces, unless that element is
+    /// the new value itself. Call <see cref="DetachAt"/> first to keep the previous element alive.
     /// </remarks>
-    public EffectTarget this[int index] { get => ((IList<EffectTarget>)_targets)[index]; set => ((IList<EffectTarget>)_targets)[index] = value; }
+    public EffectTarget this[int index]
+    {
+        get => _targets[index];
+        set
+        {
+            ArgumentNullException.ThrowIfNull(value);
+            EffectTarget previous = _targets[index];
+            if (ReferenceEquals(previous, value))
+                return;
 
-    public int Count => ((ICollection<EffectTarget>)_targets).Count;
+            _targets[index] = value;
+            previous.Dispose();
+        }
+    }
 
-    public bool IsReadOnly => ((ICollection<EffectTarget>)_targets).IsReadOnly;
+    public int Count => _targets.Count;
+
+    public bool IsReadOnly => false;
 
     /// <summary>Unions the <see cref="EffectTarget.Bounds"/> of every element.</summary>
     public Rect CalculateBounds()
@@ -66,21 +84,27 @@ public sealed class EffectTargets : IList<EffectTarget>, IDisposable
 
     /// <summary>
     /// Creates a list holding an <see cref="EffectTarget.Clone"/> of every element. The clones belong to the
-    /// new list; this list keeps its own elements.
+    /// new list; this list keeps its own elements. See the copy constructor for empty elements.
     /// </summary>
     public EffectTargets Clone() => new(this);
     /// <summary>Appends <paramref name="item"/> and takes ownership of it.</summary>
-    public void Add(EffectTarget item) => ((ICollection<EffectTarget>)_targets).Add(item);
+    public void Add(EffectTarget item) => _targets.Add(item);
     /// <summary>Appends every target in <paramref name="collection"/> and takes ownership of them.</summary>
     public void AddRange(IEnumerable<EffectTarget> collection) => _targets.AddRange(collection);
-    /// <summary>Removes every element without disposing any of them.</summary>
-    /// <remarks>
-    /// The removed elements are not handed back, so the caller must already hold references to dispose them.
-    /// Use <see cref="Dispose"/> to release them instead.
-    /// </remarks>
-    public void Clear() => ((ICollection<EffectTarget>)_targets).Clear();
-    public bool Contains(EffectTarget item) => ((ICollection<EffectTarget>)_targets).Contains(item);
-    public void CopyTo(EffectTarget[] array, int arrayIndex) => ((ICollection<EffectTarget>)_targets).CopyTo(array, arrayIndex);
+
+    /// <summary>Disposes every element, last to first, and empties the list.</summary>
+    public void Clear()
+    {
+        for (int i = _targets.Count - 1; i >= 0; i--)
+        {
+            EffectTarget target = _targets[i];
+            _targets.RemoveAt(i);
+            target.Dispose();
+        }
+    }
+
+    public bool Contains(EffectTarget item) => _targets.Contains(item);
+    public void CopyTo(EffectTarget[] array, int arrayIndex) => _targets.CopyTo(array, arrayIndex);
     /// <summary>Gets a struct enumerator, so a <see langword="foreach"/> over this list allocates nothing.</summary>
     /// <remarks>
     /// The interface form below is what the language would otherwise bind to, and it boxes the list's own
@@ -91,27 +115,48 @@ public sealed class EffectTargets : IList<EffectTarget>, IDisposable
 
     IEnumerator<EffectTarget> IEnumerable<EffectTarget>.GetEnumerator()
         => ((IEnumerable<EffectTarget>)_targets).GetEnumerator();
-    public int IndexOf(EffectTarget item) => ((IList<EffectTarget>)_targets).IndexOf(item);
+    public int IndexOf(EffectTarget item) => _targets.IndexOf(item);
     /// <summary>Inserts <paramref name="item"/> at <paramref name="index"/> and takes ownership of it.</summary>
     public void Insert(int index, EffectTarget item) => _targets.Insert(index, item);
     /// <summary>Inserts every target in <paramref name="collection"/> at <paramref name="index"/> and takes ownership of them.</summary>
     public void InsertRange(int index, IEnumerable<EffectTarget> collection) => _targets.InsertRange(index, collection);
-    /// <summary>Removes <paramref name="item"/> without disposing it.</summary>
-    /// <remarks>The caller holds <paramref name="item"/> and is responsible for disposing it.</remarks>
-    public bool Remove(EffectTarget item) => ((ICollection<EffectTarget>)_targets).Remove(item);
-    /// <summary>Removes the element at <paramref name="index"/> without disposing it.</summary>
+
+    /// <summary>Removes <paramref name="item"/> and disposes it.</summary>
+    /// <returns>
+    /// <see langword="true"/> when the list held <paramref name="item"/>. A target the list does not hold is
+    /// left untouched.
+    /// </returns>
+    public bool Remove(EffectTarget item)
+    {
+        int index = _targets.IndexOf(item);
+        if (index < 0)
+            return false;
+
+        RemoveAt(index);
+        return true;
+    }
+
+    /// <summary>Removes the element at <paramref name="index"/> and disposes it.</summary>
+    /// <remarks>Use <see cref="DetachAt"/> to take the element out alive instead.</remarks>
+    public void RemoveAt(int index)
+    {
+        EffectTarget target = _targets[index];
+        _targets.RemoveAt(index);
+        target.Dispose();
+    }
+
+    /// <summary>Removes the element at <paramref name="index"/> without disposing it and returns it.</summary>
     /// <remarks>
-    /// The removed element is not handed back; read it with the indexer first and dispose it, or it leaks.
+    /// Ownership passes to the caller, who must dispose the returned target or hand it to a list that will.
     /// </remarks>
-    public void RemoveAt(int index) => ((IList<EffectTarget>)_targets).RemoveAt(index);
+    public EffectTarget DetachAt(int index)
+    {
+        EffectTarget target = _targets[index];
+        _targets.RemoveAt(index);
+        return target;
+    }
+
     IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable)_targets).GetEnumerator();
     /// <summary>Disposes every element, last to first, and empties the list.</summary>
-    public void Dispose()
-    {
-        for (int i = _targets.Count - 1; i >= 0; i--)
-        {
-            _targets[i].Dispose();
-            _targets.RemoveAt(i);
-        }
-    }
+    public void Dispose() => Clear();
 }

--- a/src/Beutl.Engine/Graphics/FilterEffects/EffectTargets.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/EffectTargets.cs
@@ -90,7 +90,11 @@ public sealed class EffectTargets : IList<EffectTarget>, IDisposable
     /// <summary>Appends <paramref name="item"/> and takes ownership of it.</summary>
     public void Add(EffectTarget item) => _targets.Add(item);
     /// <summary>Appends every target in <paramref name="collection"/> and takes ownership of them.</summary>
-    public void AddRange(IEnumerable<EffectTarget> collection) => _targets.AddRange(collection);
+    /// <remarks>
+    /// When <paramref name="collection"/> is another <see cref="EffectTargets"/>, its targets are moved and
+    /// it is left empty, so one list owns each target and disposing the source afterwards releases nothing.
+    /// </remarks>
+    public void AddRange(IEnumerable<EffectTarget> collection) => InsertRange(_targets.Count, collection);
 
     /// <summary>Disposes every element, last to first, and empties the list.</summary>
     public void Clear()
@@ -119,7 +123,26 @@ public sealed class EffectTargets : IList<EffectTarget>, IDisposable
     /// <summary>Inserts <paramref name="item"/> at <paramref name="index"/> and takes ownership of it.</summary>
     public void Insert(int index, EffectTarget item) => _targets.Insert(index, item);
     /// <summary>Inserts every target in <paramref name="collection"/> at <paramref name="index"/> and takes ownership of them.</summary>
-    public void InsertRange(int index, IEnumerable<EffectTarget> collection) => _targets.InsertRange(index, collection);
+    /// <remarks>
+    /// When <paramref name="collection"/> is another <see cref="EffectTargets"/>, its targets are moved and
+    /// it is left empty, so one list owns each target and disposing the source afterwards releases nothing.
+    /// Inserting a list into itself throws <see cref="InvalidOperationException"/>.
+    /// </remarks>
+    public void InsertRange(int index, IEnumerable<EffectTarget> collection)
+    {
+        ArgumentNullException.ThrowIfNull(collection);
+        if (ReferenceEquals(collection, this))
+            throw new InvalidOperationException("A target list cannot be inserted into itself.");
+
+        if (collection is EffectTargets source)
+        {
+            _targets.InsertRange(index, source._targets);
+            source._targets.Clear();
+            return;
+        }
+
+        _targets.InsertRange(index, collection);
+    }
 
     /// <summary>Removes <paramref name="item"/> and disposes it.</summary>
     /// <returns>

--- a/src/Beutl.Engine/Graphics/FilterEffects/FilterEffectStageFallbackExecutor.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/FilterEffectStageFallbackExecutor.cs
@@ -803,15 +803,10 @@ internal static class FilterEffectStageFallbackExecutor
                 replacements.Add(replacement);
         }
 
-        foreach (EffectTarget target in targets)
-            target.Dispose();
+        // Clear disposes the originals; DetachAt moves each replacement across alive.
         targets.Clear();
         while (replacements.Count > 0)
-        {
-            EffectTarget replacement = replacements[0];
-            replacements.RemoveAt(0);
-            targets.Add(replacement);
-        }
+            targets.Add(replacements.DetachAt(0));
     }
 
     private static bool IsEmpty(Rect bounds)

--- a/src/Beutl.Engine/Graphics/FilterEffects/PartsSplitEffect.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/PartsSplitEffect.cs
@@ -117,8 +117,9 @@ public partial class PartsSplitEffect : FilterEffect
 
                     target.Dispose();
                     context.Targets.RemoveAt(i);
+                    int inserted = newTargets.Count;
                     context.Targets.InsertRange(i, newTargets);
-                    i += newTargets.Count - 1;
+                    i += inserted - 1;
                 }
                 catch
                 {

--- a/src/Beutl.Engine/Graphics/FilterEffects/SplitEffect.cs
+++ b/src/Beutl.Engine/Graphics/FilterEffects/SplitEffect.cs
@@ -102,8 +102,9 @@ public partial class SplitEffect : FilterEffect
 
                         t.Dispose();
                         effectContext.Targets.RemoveAt(i);
+                        int inserted = newTargets.Count;
                         effectContext.Targets.InsertRange(i, newTargets);
-                        i += newTargets.Count - 1;
+                        i += inserted - 1;
                     }
                 }
             },

--- a/tests/Beutl.UnitTests/Engine/Graphics/FilterEffects/EffectTargetsOwnershipTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/FilterEffects/EffectTargetsOwnershipTests.cs
@@ -129,6 +129,59 @@ public sealed class EffectTargetsOwnershipTests
     }
 
     [Test]
+    public void InsertRange_MovesTheTargetsOutOfAnotherList()
+    {
+        using var destination = new EffectTargets { CreateTarget() };
+        EffectTarget first = CreateTarget();
+        EffectTarget second = CreateTarget();
+        var source = new EffectTargets { first, second };
+
+        destination.InsertRange(0, source);
+        // The source no longer owns anything, so disposing it must not reach the moved targets.
+        source.Dispose();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(destination, Has.Count.EqualTo(3));
+            Assert.That(destination[0], Is.SameAs(first));
+            Assert.That(destination[1], Is.SameAs(second));
+            Assert.That(first.IsEmpty, Is.False, "a moved target must stay alive");
+            Assert.That(second.IsEmpty, Is.False, "a moved target must stay alive");
+        });
+    }
+
+    [Test]
+    public void AddRange_MovesTheTargetsOutOfAnotherList()
+    {
+        using var destination = new EffectTargets();
+        EffectTarget moved = CreateTarget();
+        using var source = new EffectTargets { moved };
+
+        destination.AddRange(source);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(source, Is.Empty, "the source must be left empty");
+            Assert.That(destination[0], Is.SameAs(moved));
+            Assert.That(moved.IsEmpty, Is.False);
+        });
+    }
+
+    [Test]
+    public void InsertRange_RejectsTheListItself()
+    {
+        EffectTarget target = CreateTarget();
+        using var targets = new EffectTargets { target };
+
+        Assert.Throws<InvalidOperationException>(() => targets.InsertRange(0, targets));
+        Assert.Multiple(() =>
+        {
+            Assert.That(targets, Has.Count.EqualTo(1));
+            Assert.That(target.IsEmpty, Is.False);
+        });
+    }
+
+    [Test]
     public void ForEach_ReplacingOverload_DisposesOnlyTheTargetsItReplaces()
     {
         EffectTarget kept = CreateTarget();

--- a/tests/Beutl.UnitTests/Engine/Graphics/FilterEffects/EffectTargetsOwnershipTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/FilterEffects/EffectTargetsOwnershipTests.cs
@@ -182,6 +182,26 @@ public sealed class EffectTargetsOwnershipTests
     }
 
     [Test]
+    public void InsertRange_RefusesATargetTheListAlreadyOwns()
+    {
+        EffectTarget owned = CreateTarget();
+        using var targets = new EffectTargets { owned };
+        using EffectTarget other = CreateTarget();
+
+        // A deferred query over the list itself is materialized before anything changes, and the target it
+        // yields is already owned, so the call is refused and the list stays as it was.
+        Assert.Throws<InvalidOperationException>(() => targets.InsertRange(0, targets.Where(_ => true)));
+        Assert.Throws<InvalidOperationException>(() => targets.InsertRange(0, new[] { other, owned }));
+        Assert.Multiple(() =>
+        {
+            Assert.That(targets, Has.Count.EqualTo(1));
+            Assert.That(targets[0], Is.SameAs(owned));
+            Assert.That(owned.IsEmpty, Is.False);
+            Assert.That(other.IsEmpty, Is.False, "a refused insertion must not take the other targets");
+        });
+    }
+
+    [Test]
     public void ForEach_ReplacingOverload_DisposesOnlyTheTargetsItReplaces()
     {
         EffectTarget kept = CreateTarget();

--- a/tests/Beutl.UnitTests/Engine/Graphics/FilterEffects/EffectTargetsOwnershipTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/FilterEffects/EffectTargetsOwnershipTests.cs
@@ -1,0 +1,221 @@
+﻿using Beutl.Graphics;
+using Beutl.Graphics.Effects;
+using Beutl.Graphics.Rendering;
+using SkiaSharp;
+
+namespace Beutl.UnitTests.Engine.Graphics.FilterEffects;
+
+/// <summary>
+/// <see cref="EffectTargets"/> owns the render target behind every element, so every member that drops an
+/// element has to release it, and <see cref="EffectTargets.DetachAt"/> is the one way to take an element out
+/// alive. A disposed <see cref="EffectTarget"/> reports <see cref="EffectTarget.IsEmpty"/>.
+/// </summary>
+[TestFixture]
+public sealed class EffectTargetsOwnershipTests
+{
+    private static readonly Rect s_bounds = new(0, 0, 4, 4);
+
+    [Test]
+    public void IndexerSetter_DisposesTheTargetItReplaces()
+    {
+        using var targets = new EffectTargets();
+        EffectTarget original = CreateTarget();
+        EffectTarget replacement = CreateTarget();
+        targets.Add(original);
+
+        targets[0] = replacement;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(original.IsEmpty, Is.True, "the replaced target must be disposed");
+            Assert.That(replacement.IsEmpty, Is.False, "the new target must stay alive");
+            Assert.That(targets[0], Is.SameAs(replacement));
+        });
+    }
+
+    [Test]
+    public void IndexerSetter_LeavesTheSameInstanceAlive()
+    {
+        using var targets = new EffectTargets();
+        EffectTarget target = CreateTarget();
+        targets.Add(target);
+
+        targets[0] = target;
+
+        Assert.That(target.IsEmpty, Is.False, "assigning a target to its own slot must not dispose it");
+    }
+
+    [Test]
+    public void RemoveAt_DisposesTheRemovedTarget()
+    {
+        using var targets = new EffectTargets();
+        EffectTarget first = CreateTarget();
+        EffectTarget second = CreateTarget();
+        targets.Add(first);
+        targets.Add(second);
+
+        targets.RemoveAt(0);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(first.IsEmpty, Is.True);
+            Assert.That(second.IsEmpty, Is.False);
+            Assert.That(targets, Has.Count.EqualTo(1));
+            Assert.That(targets[0], Is.SameAs(second));
+        });
+    }
+
+    [Test]
+    public void Remove_DisposesOnlyTheTargetItRemoves()
+    {
+        using var targets = new EffectTargets();
+        EffectTarget kept = CreateTarget();
+        EffectTarget removed = CreateTarget();
+        using EffectTarget absent = CreateTarget();
+        targets.Add(kept);
+        targets.Add(removed);
+
+        bool removedResult = targets.Remove(removed);
+        bool absentResult = targets.Remove(absent);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(removedResult, Is.True);
+            Assert.That(absentResult, Is.False);
+            Assert.That(removed.IsEmpty, Is.True);
+            Assert.That(kept.IsEmpty, Is.False);
+            Assert.That(absent.IsEmpty, Is.False, "a target the list never held must not be touched");
+            Assert.That(targets, Has.Count.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void Clear_DisposesEveryTarget()
+    {
+        using var targets = new EffectTargets();
+        EffectTarget first = CreateTarget();
+        EffectTarget second = CreateTarget();
+        targets.Add(first);
+        targets.Add(second);
+
+        targets.Clear();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(first.IsEmpty, Is.True);
+            Assert.That(second.IsEmpty, Is.True);
+            Assert.That(targets, Is.Empty);
+        });
+    }
+
+    [Test]
+    public void DetachAt_HandsTheTargetBackAlive()
+    {
+        using var targets = new EffectTargets();
+        EffectTarget first = CreateTarget();
+        EffectTarget second = CreateTarget();
+        targets.Add(first);
+        targets.Add(second);
+
+        using EffectTarget detached = targets.DetachAt(0);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(detached, Is.SameAs(first));
+            Assert.That(detached.IsEmpty, Is.False, "detaching must not dispose");
+            Assert.That(targets, Has.Count.EqualTo(1));
+            Assert.That(targets[0], Is.SameAs(second));
+        });
+    }
+
+    [Test]
+    public void ForEach_ReplacingOverload_DisposesOnlyTheTargetsItReplaces()
+    {
+        EffectTarget kept = CreateTarget();
+        EffectTarget replaced = CreateTarget();
+        EffectTarget replacement = CreateTarget();
+        using var targets = new EffectTargets { kept, replaced };
+        (bool keptAlive, bool replacedDisposed, bool replacementAlive, EffectTarget? slot1)? observed = null;
+
+        RunCustomEffect(targets, execution =>
+        {
+            execution.ForEach((index, target) => index == 1 ? replacement : target);
+            observed = (!kept.IsEmpty, replaced.IsEmpty, !replacement.IsEmpty, execution.Targets[1]);
+        });
+
+        Assert.That(observed, Is.Not.Null, "the custom effect must run");
+        Assert.Multiple(() =>
+        {
+            Assert.That(observed!.Value.keptAlive, Is.True, "a target returned unchanged must stay alive");
+            Assert.That(observed.Value.replacedDisposed, Is.True, "a replaced target must be disposed");
+            Assert.That(observed.Value.replacementAlive, Is.True);
+            Assert.That(observed.Value.slot1, Is.SameAs(replacement));
+        });
+    }
+
+    [Test]
+    public void ForEach_ExpandingOverload_DisposesTheOriginalAndOwnsTheReturnedTargets()
+    {
+        EffectTarget original = CreateTarget();
+        EffectTarget firstPart = CreateTarget();
+        EffectTarget secondPart = CreateTarget();
+        using var targets = new EffectTargets { original };
+        (bool originalDisposed, bool partsAlive, int count)? observed = null;
+
+        RunCustomEffect(targets, execution =>
+        {
+            execution.ForEach((_, clone) =>
+            {
+                clone.Dispose();
+                return new EffectTargets { firstPart, secondPart };
+            });
+            observed = (original.IsEmpty, !firstPart.IsEmpty && !secondPart.IsEmpty, execution.Targets.Count);
+        });
+
+        Assert.That(observed, Is.Not.Null, "the custom effect must run");
+        Assert.Multiple(() =>
+        {
+            Assert.That(observed!.Value.originalDisposed, Is.True, "the expanded original must be disposed");
+            Assert.That(observed.Value.partsAlive, Is.True, "the returned targets now belong to the list");
+            Assert.That(observed.Value.count, Is.EqualTo(2));
+        });
+    }
+
+    private static void RunCustomEffect(EffectTargets targets, Action<CustomFilterEffectContext> effect)
+    {
+        using var builder = new SKImageFilterBuilder();
+        using var activator = new FilterEffectActivator(
+            targets,
+            builder,
+            RenderIntent.Delivery,
+            RenderRequestPurpose.Frame,
+            drawableBrushMaterializer: null);
+        using var context = new FilterEffectContext(s_bounds);
+        context.CustomEffect(
+            0,
+            (_, execution) => effect(execution),
+            static (_, bounds) => bounds);
+
+        activator.Apply(context);
+    }
+
+    private static EffectTarget CreateTarget()
+        => new(new CpuRenderTarget(4, 4), s_bounds, EffectiveScale.At(1));
+
+    private sealed class CpuRenderTarget : RenderTarget
+    {
+        public CpuRenderTarget(int width, int height)
+            : base(CreateSurface(width, height), width, height)
+        {
+        }
+
+        private static SKSurface CreateSurface(int width, int height)
+            => SKSurface.Create(new SKImageInfo(
+                   width,
+                   height,
+                   SKColorType.RgbaF16,
+                   SKAlphaType.Premul,
+                   SKColorSpace.CreateSrgbLinear()))
+               ?? throw new InvalidOperationException("Failed to create a CPU surface.");
+    }
+}

--- a/tests/Beutl.UnitTests/Engine/Graphics/FilterEffects/EffectTargetsOwnershipTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/FilterEffects/EffectTargetsOwnershipTests.cs
@@ -221,6 +221,29 @@ public sealed class EffectTargetsOwnershipTests
     }
 
     [Test]
+    public void InsertRange_RefusesMovingATargetTheDestinationAlreadyHolds()
+    {
+        EffectTarget shared = CreateTarget();
+        EffectTarget other = CreateTarget();
+        using var destination = new EffectTargets { shared };
+        using var source = new EffectTargets { other, shared };
+
+        // Two lists that were handed the same instance is already a contract violation; the move must not
+        // turn it into two slots of one list, and it must not move anything before refusing.
+        Assert.Throws<InvalidOperationException>(() => destination.InsertRange(0, source));
+        Assert.Multiple(() =>
+        {
+            Assert.That(destination, Has.Count.EqualTo(1));
+            Assert.That(source, Has.Count.EqualTo(2));
+            Assert.That(shared.IsEmpty, Is.False);
+            Assert.That(other.IsEmpty, Is.False);
+        });
+
+        // Detach the shared instance from one list so the two disposals below do not overlap.
+        source.DetachAt(1);
+    }
+
+    [Test]
     public void InsertRange_RefusesASequenceThatRepeatsATarget()
     {
         using var targets = new EffectTargets();

--- a/tests/Beutl.UnitTests/Engine/Graphics/FilterEffects/EffectTargetsOwnershipTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/FilterEffects/EffectTargetsOwnershipTests.cs
@@ -181,6 +181,30 @@ public sealed class EffectTargetsOwnershipTests
         });
     }
 
+    [Test]
+    public void ForEach_ExpandingOverload_RejectsTheContextsOwnList()
+    {
+        EffectTarget first = CreateTarget();
+        EffectTarget second = CreateTarget();
+        using var targets = new EffectTargets { first, second };
+        (int count, bool alive)? observed = null;
+
+        RunCustomEffect(targets, execution =>
+        {
+            // Returning the live list would alias source and destination of the move; it must be refused
+            // before anything is detached.
+            Assert.Throws<InvalidOperationException>(() => execution.ForEach((_, _) => execution.Targets));
+            observed = (execution.Targets.Count, !first.IsEmpty && !second.IsEmpty);
+        });
+
+        Assert.That(observed, Is.Not.Null, "the custom effect must run");
+        Assert.Multiple(() =>
+        {
+            Assert.That(observed!.Value.count, Is.EqualTo(2), "the list must be left as it was");
+            Assert.That(observed.Value.alive, Is.True, "no target may be disposed by the refused call");
+        });
+    }
+
     private static void RunCustomEffect(EffectTargets targets, Action<CustomFilterEffectContext> effect)
     {
         using var builder = new SKImageFilterBuilder();

--- a/tests/Beutl.UnitTests/Engine/Graphics/FilterEffects/EffectTargetsOwnershipTests.cs
+++ b/tests/Beutl.UnitTests/Engine/Graphics/FilterEffects/EffectTargetsOwnershipTests.cs
@@ -202,6 +202,54 @@ public sealed class EffectTargetsOwnershipTests
     }
 
     [Test]
+    public void Add_Insert_AndTheIndexer_RefuseATargetHeldInAnotherSlot()
+    {
+        EffectTarget first = CreateTarget();
+        EffectTarget second = CreateTarget();
+        using var targets = new EffectTargets { first, second };
+
+        Assert.Multiple(() =>
+        {
+            Assert.Throws<InvalidOperationException>(() => targets.Add(first));
+            Assert.Throws<InvalidOperationException>(() => targets.Insert(0, second));
+            Assert.Throws<InvalidOperationException>(() => targets[0] = second);
+            Assert.That(targets, Has.Count.EqualTo(2));
+            Assert.That(targets[0], Is.SameAs(first));
+            Assert.That(first.IsEmpty, Is.False);
+            Assert.That(second.IsEmpty, Is.False);
+        });
+    }
+
+    [Test]
+    public void InsertRange_RefusesASequenceThatRepeatsATarget()
+    {
+        using var targets = new EffectTargets();
+        using EffectTarget repeated = CreateTarget();
+
+        Assert.Throws<InvalidOperationException>(() => targets.InsertRange(0, new[] { repeated, repeated }));
+        Assert.Multiple(() =>
+        {
+            Assert.That(targets, Is.Empty);
+            Assert.That(repeated.IsEmpty, Is.False);
+        });
+    }
+
+    [Test]
+    public void InsertRange_ValidatesTheIndexBeforeEnumerating()
+    {
+        using var targets = new EffectTargets();
+        bool enumerated = false;
+        IEnumerable<EffectTarget> Deferred()
+        {
+            enumerated = true;
+            yield return CreateTarget();
+        }
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => targets.InsertRange(1, Deferred()));
+        Assert.That(enumerated, Is.False, "an invalid index must be rejected before the sequence runs");
+    }
+
+    [Test]
     public void ForEach_ReplacingOverload_DisposesOnlyTheTargetsItReplaces()
     {
         EffectTarget kept = CreateTarget();


### PR DESCRIPTION
## Description
- `EffectTargets` owns the render target behind every element, but its `IList<T>` members released nothing: the indexer setter, `Clear`, `Remove` and `RemoveAt` dropped an element without disposing it, so a hand-written replacement loop leaked a render target per iteration, and the type carried no documentation saying so.
- Keep the `IList<EffectTarget>` surface and make it own what it holds: the indexer setter disposes the element it replaces (unless it is the same instance), `Remove`/`RemoveAt` dispose the element they remove, and `Clear`/`Dispose` dispose everything. The one way to take an element out alive is the new additive `DetachAt(int)`. Each target records its owning list (an internal `EffectTarget.Owner`), so every insertion refuses a target any list already holds in O(1), `AddRange`/`InsertRange` move targets out of another `EffectTargets`, and a failing or refused sequence releases what it had taken. An empty target now clones as a fresh empty target rather than itself.
- Every in-tree mutation site was audited: all of them already disposed the dropped element explicitly before or after the call, so none relied on detach semantics. Those explicit disposes become idempotent no-ops (`EffectTarget.Dispose` is re-entrant) and are left in place to keep the diff small. The two `CustomFilterEffectContext.ForEach` overloads now lean on the list for the disposal they used to do by hand.
- Document the ownership rule on the type and on each member, and what each `ForEach` overload hands the callback and what it destroys.

## Affected areas
- [x] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [ ] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [ ] Build / CI / docs only

## Breaking changes
Behavioural, not signature-level: `EffectTargets` still implements `IList<EffectTarget>`, but its indexer setter, `Clear`, `Remove` and `RemoveAt` now dispose the element they drop. An out-of-tree effect that removed a target to keep using it must call `DetachAt(int)` instead; one that disposed the dropped target itself keeps working, since the second `Dispose` is a no-op.

## Test plan
- New `tests/Beutl.UnitTests/Engine/Graphics/FilterEffects/EffectTargetsOwnershipTests.cs` (20 tests, ownership tracked on the target): indexer setter disposes the replaced target but not the same instance; `RemoveAt`, `Remove` and `Clear` dispose what they drop and leave the rest alive; `Remove` of an absent target touches nothing; `DetachAt` hands the target back alive; both `ForEach` overloads dispose what they replace and own what they receive; the expanding `ForEach` refuses a callback that returns the context's own `Targets`, and a context target cannot even be placed in the callback's own list, so the context is left intact; `InsertRange`/`AddRange` move targets out of another `EffectTargets` (leaving it empty, and refusing the move when the destination already holds one of them), validate the index before staging any other sequence, leave the list unchanged when a sequence fails or is refused, refuse self-insertion and a view over another owning list, and `Add`, `Insert` and the indexer refuse a target any list holds until it is detached.
- Negative controls: with only `DetachAt` added and the disposal semantics absent, the four disposal tests fail and the rest pass; without the alias guard the aliasing test fails with `ArgumentOutOfRangeException`; with copy semantics the three range-move tests fail; with the implementation all 20 pass.
- Existing fixtures pass against the new semantics on macOS: the FilterEffects, effect, GLSL shader, golden, fusion and rendering namespaces (2358 passed, 1 skipped) and `Beutl.PublicApiContractTests` (235).

## Fixed issues / References
- Closes #2292
