### PR TITLE
docs: correct the render-cache performance record

### DIFF
--- a/docs/specs/004-gpu-pass-fusion/research.md
+++ b/docs/specs/004-gpu-pass-fusion/research.md
@@ -94,9 +94,11 @@ noise floor; recorded in full in issue #2284) found instead:
   is bypassed as `DeviceGridDependentOutput`, and re-running the remaining admission
   gates for each refused candidate found none that would have failed later. Whether
   other workloads admit anything has not been measured.
-- Enabling it nonetheless costs about 1 % of frame time for the boundary sweep and
-  the extra fixed-point pass (`RenderCacheResolver.Resolve` went from 21.5 ms to
-  72.2 ms over 61 requests) while producing zero hits.
+- Enabling it nonetheless adds work for zero hits: the boundary sweep and the extra
+  fixed-point pass took `RenderCacheResolver.Resolve` from 21.5 ms to 72.2 ms over
+  61 requests, about 0.83 ms per frame. That is roughly 1 % of a 1080p frame, which
+  sits inside the run's ±2.7 % noise floor, so the instrumented resolver overhead is
+  the measured quantity; an end-to-end frame-time delta was not resolved.
 - For content forced through admission, the warm replay path measures 1.00–1.025
   times direct rendering, but the admission frame itself measures 3.0–3.1 times.
   A cache that cannot know how long content will persist therefore loses on

--- a/docs/specs/004-gpu-pass-fusion/research.md
+++ b/docs/specs/004-gpu-pass-fusion/research.md
@@ -90,9 +90,10 @@ repository, so they cannot be re-checked. A later measurement on the fused pipel
 (Linux, Intel UHD 630, Vulkan, a 1920×1080 eleven-element animated scene, ±2.7 %
 noise floor; recorded in full in issue #2284) found instead:
 
-- On realistic scenes the cache admits nothing at all. Every candidate is bypassed
-  as `DeviceGridDependentOutput`, and re-running the remaining admission gates for
-  each refused candidate found none that would have failed later.
+- In that scene the cache admits nothing at all, animated or frozen. Every candidate
+  is bypassed as `DeviceGridDependentOutput`, and re-running the remaining admission
+  gates for each refused candidate found none that would have failed later. Whether
+  other workloads admit anything has not been measured.
 - Enabling it nonetheless costs about 1 % of frame time for the boundary sweep and
   the extra fixed-point pass (`RenderCacheResolver.Resolve` went from 21.5 ms to
   72.2 ms over 61 requests) while producing zero hits.

--- a/docs/specs/004-gpu-pass-fusion/research.md
+++ b/docs/specs/004-gpu-pass-fusion/research.md
@@ -103,8 +103,12 @@ figures should be read as unverified rather than as a property of the pipeline:
   the measured quantity; an end-to-end frame-time delta was not resolved.
 - For content forced through admission, the warm replay path measures 1.00–1.025
   times direct rendering, but the admission frame itself measures 3.0–3.1 times.
-  A cache that cannot know how long content will persist therefore loses on
-  animated content, which is a different design from tuning the current one.
+  An admitted candidate that is invalidated before enough replays amortize that
+  admission cost therefore loses. Content that changes every frame never reaches
+  admission, because the warm-up resets on each reported change, so the exposure is
+  limited to candidates that hold still long enough to be admitted and then change;
+  an admission policy that could weigh that risk needs a persistence signal the
+  current one does not have, which is a different design from tuning it.
 
 `RenderCacheOptions.Default` therefore matches `Disabled`;
 `RenderCacheOptions.Enabled` is the deliberate opt-in used by cache-specific

--- a/docs/specs/004-gpu-pass-fusion/research.md
+++ b/docs/specs/004-gpu-pass-fusion/research.md
@@ -80,10 +80,26 @@ The node render cache remains available as an explicit experimental option, but 
 is disabled by default. Authoritative Apple M3/MoltenVK measurements found that
 admitted antialiased geometry changed GPU pixels at admission and replay: an
 ellipse rim differed by up to 0.48 in linear light, and an ordinary SrcOver group
-could lose its outermost antialiasing apron. The same warm-cache path was
-1.7–2.6 times slower than direct rendering for admitted content, including an
-observed 7.1 ms/frame regression at 1080p. Expensive blur content did not become
-eligible yet still paid 1.02–1.2 times the planning cost.
+could lose its outermost antialiasing apron.
+
+The performance figures originally recorded alongside that finding — a warm-cache
+path 1.7–2.6 times slower than direct rendering for admitted content, a 7.1 ms/frame
+regression at 1080p, and a 1.02–1.2 times planning cost for ineligible blur content —
+do not reproduce, and the evidence tree behind them was not carried into the
+repository, so they cannot be re-checked. A later measurement on the fused pipeline
+(Linux, Intel UHD 630, Vulkan, a 1920×1080 eleven-element animated scene, ±2.7 %
+noise floor; recorded in full in issue #2284) found instead:
+
+- On realistic scenes the cache admits nothing at all. Every candidate is bypassed
+  as `DeviceGridDependentOutput`, and re-running the remaining admission gates for
+  each refused candidate found none that would have failed later.
+- Enabling it nonetheless costs about 1 % of frame time for the boundary sweep and
+  the extra fixed-point pass (`RenderCacheResolver.Resolve` went from 21.5 ms to
+  72.2 ms over 61 requests) while producing zero hits.
+- For content forced through admission, the warm replay path measures 1.00–1.025
+  times direct rendering, but the admission frame itself measures 3.0–3.1 times.
+  A cache that cannot know how long content will persist therefore loses on
+  animated content, which is a different design from tuning the current one.
 
 `RenderCacheOptions.Default` therefore matches `Disabled`;
 `RenderCacheOptions.Enabled` is the deliberate opt-in used by cache-specific

--- a/docs/specs/004-gpu-pass-fusion/research.md
+++ b/docs/specs/004-gpu-pass-fusion/research.md
@@ -102,13 +102,14 @@ figures should be read as unverified rather than as a property of the pipeline:
   sits inside the run's ±2.7 % noise floor, so the instrumented resolver overhead is
   the measured quantity; an end-to-end frame-time delta was not resolved.
 - For content forced through admission, the warm replay path measures 1.00–1.025
-  times direct rendering, but the admission frame itself measures 3.0–3.1 times.
-  An admitted candidate that is invalidated before enough replays amortize that
-  admission cost therefore loses. Content that changes every frame never reaches
-  admission, because the warm-up resets on each reported change, so the exposure is
-  limited to candidates that hold still long enough to be admitted and then change;
-  an admission policy that could weigh that risk needs a persistence signal the
-  current one does not have, which is a different design from tuning it.
+  times direct rendering, and the admission frame itself 3.0–3.1 times. A replay
+  that costs at least as much as rendering directly recovers none of that admission
+  overhead, so for the measured content admission is a loss however long the content
+  persists; only content whose replay is cheaper than direct rendering could amortize
+  the admission frame, and none of the measured content was. Content that changes
+  every frame never reaches admission at all, because the warm-up resets on each
+  reported change, so the exposure is limited to candidates that hold still long
+  enough to be admitted.
 
 `RenderCacheOptions.Default` therefore matches `Disabled`;
 `RenderCacheOptions.Enabled` is the deliberate opt-in used by cache-specific

--- a/docs/specs/004-gpu-pass-fusion/research.md
+++ b/docs/specs/004-gpu-pass-fusion/research.md
@@ -85,10 +85,12 @@ could lose its outermost antialiasing apron.
 The performance figures originally recorded alongside that finding — a warm-cache
 path 1.7–2.6 times slower than direct rendering for admitted content, a 7.1 ms/frame
 regression at 1080p, and a 1.02–1.2 times planning cost for ineligible blur content —
-do not reproduce, and the evidence tree behind them was not carried into the
-repository, so they cannot be re-checked. A later measurement on the fused pipeline
-(Linux, Intel UHD 630, Vulkan, a 1920×1080 eleven-element animated scene, ±2.7 %
-noise floor; recorded in full in issue #2284) found instead:
+cannot be re-checked: the evidence tree behind them was not carried into the
+repository, and they have not been rerun on the Apple M3/MoltenVK environment they
+came from. A later measurement on a different platform (Linux, Intel UHD 630,
+Vulkan, a 1920×1080 eleven-element animated scene, ±2.7 % noise floor; recorded in
+full in issue #2284) found different ratios on the fused pipeline, so the original
+figures should be read as unverified rather than as a property of the pipeline:
 
 - In that scene the cache admits nothing at all, animated or frozen. Every candidate
   is bypassed as `DeviceGridDependentOutput`, and re-running the remaining admission


### PR DESCRIPTION
## Description
- The Phase 6 render-cache note in `docs/specs/004-gpu-pass-fusion/research.md` justified the disabled default with warm-path figures (1.7–2.6x slower, a 7.1 ms/frame regression) whose evidence tree was never carried into the repository and which do not reproduce on the fused pipeline.
- Keep the pixel-change finding, mark the original performance figures as unverifiable, and record what the measurement in #2284 found: zero admissions on realistic scenes (every candidate bypassed as `DeviceGridDependentOutput`), about 1% frame-time cost for no hits, a warm replay path at 1.00–1.025x and an admission frame at 3.0–3.1x.

## Affected areas
- [ ] `Beutl.Engine` (rendering / scene / track)
- [ ] `Beutl.ProjectSystem` (project / document persistence)
- [ ] UI (`Beutl.Editor`, `Beutl.Editor.Components`, `Beutl.Controls`)
- [ ] `Beutl.Extensibility` (plugin abstractions)
- [ ] `Beutl.NodeGraph` (node editor)
- [ ] `Beutl.FFmpegIpc` / `Beutl.FFmpegWorker` (media IPC boundary)
- [ ] `Beutl.Api` (server API client)
- [x] Build / CI / docs only

## Breaking changes
None.

## Test plan
- Documentation only.

## Fixed issues / References
- Closes #2284. The latent planner density mismatch it recorded as a related finding is tracked separately in #2385; the plugin-facing sensitivity gaps remain noted there.